### PR TITLE
starlark: disallow list element update during iteration over list

### DIFF
--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -175,7 +175,7 @@ loop:
 			var z Value
 			if xlist, ok := x.(*List); ok {
 				if yiter, ok := y.(Iterable); ok {
-					if err = xlist.checkMutable("apply += to", true); err != nil {
+					if err = xlist.checkMutable("apply += to"); err != nil {
 						break loop
 					}
 					listExtend(xlist, yiter)

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1313,7 +1313,7 @@ func list_append(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value,
 	if err := UnpackPositionalArgs(fnname, args, kwargs, 1, &object); err != nil {
 		return nil, err
 	}
-	if err := recv.checkMutable("append to", true); err != nil {
+	if err := recv.checkMutable("append to"); err != nil {
 		return nil, err
 	}
 	recv.elems = append(recv.elems, object)
@@ -1335,7 +1335,7 @@ func list_extend(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value,
 	if err := UnpackPositionalArgs(fnname, args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
-	if err := recv.checkMutable("extend", true); err != nil {
+	if err := recv.checkMutable("extend"); err != nil {
 		return nil, err
 	}
 	listExtend(recv, iterable)
@@ -1373,7 +1373,7 @@ func list_insert(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value,
 	if err := UnpackPositionalArgs(fnname, args, kwargs, 2, &index, &object); err != nil {
 		return nil, err
 	}
-	if err := recv.checkMutable("insert into", true); err != nil {
+	if err := recv.checkMutable("insert into"); err != nil {
 		return nil, err
 	}
 
@@ -1402,7 +1402,7 @@ func list_remove(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value,
 	if err := UnpackPositionalArgs(fnname, args, kwargs, 1, &value); err != nil {
 		return nil, err
 	}
-	if err := recv.checkMutable("remove from", true); err != nil {
+	if err := recv.checkMutable("remove from"); err != nil {
 		return nil, err
 	}
 	for i, elem := range recv.elems {
@@ -1426,7 +1426,7 @@ func list_pop(fnname string, recv Value, args Tuple, kwargs []Tuple) (Value, err
 	if index < 0 || index >= list.Len() {
 		return nil, fmt.Errorf("pop: index %d is out of range [0:%d]", index, list.Len())
 	}
-	if err := list.checkMutable("pop from", true); err != nil {
+	if err := list.checkMutable("pop from"); err != nil {
 		return nil, err
 	}
 	res := list.elems[index]

--- a/starlark/testdata/list.star
+++ b/starlark/testdata/list.star
@@ -215,7 +215,7 @@ def iterator1():
   for x in list:
     list[x] = 2 * x
   return list
-assert.eq(iterator1(), [0, 2, 4]) # element updates are allowed
+assert.fails(iterator1, "assign to element.* during iteration")
 
 def iterator2():
   list = [0, 1, 2]

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -686,12 +686,11 @@ func (l *List) Freeze() {
 
 // checkMutable reports an error if the list should not be mutated.
 // verb+" list" should describe the operation.
-// Structural mutations are not permitted during iteration.
-func (l *List) checkMutable(verb string, structural bool) error {
+func (l *List) checkMutable(verb string) error {
 	if l.frozen {
 		return fmt.Errorf("cannot %s frozen list", verb)
 	}
-	if structural && l.itercount > 0 {
+	if l.itercount > 0 {
 		return fmt.Errorf("cannot %s list during iteration", verb)
 	}
 	return nil
@@ -781,7 +780,7 @@ func (it *listIterator) Done() {
 }
 
 func (l *List) SetIndex(i int, v Value) error {
-	if err := l.checkMutable("assign to element of", false); err != nil {
+	if err := l.checkMutable("assign to element of"); err != nil {
 		return err
 	}
 	l.elems[i] = v
@@ -789,7 +788,7 @@ func (l *List) SetIndex(i int, v Value) error {
 }
 
 func (l *List) Append(v Value) error {
-	if err := l.checkMutable("append to", true); err != nil {
+	if err := l.checkMutable("append to"); err != nil {
 		return err
 	}
 	l.elems = append(l.elems, v)
@@ -797,7 +796,7 @@ func (l *List) Append(v Value) error {
 }
 
 func (l *List) Clear() error {
-	if err := l.checkMutable("clear", true); err != nil {
+	if err := l.checkMutable("clear"); err != nil {
 		return err
 	}
 	for i := range l.elems {


### PR DESCRIPTION
The notion of "structural" vs "nonstructural" updates was apparently
never more than a vague idea and was never implemented in Bazel.

Fixes google/skylark#141