### PR TITLE
starlark: fix bugs in str.{title,capitalize}

### DIFF
--- a/cmd/starlark/starlark.go
+++ b/cmd/starlark/starlark.go
@@ -56,7 +56,7 @@ func main() {
 
 	switch len(flag.Args()) {
 	case 0:
-		fmt.Println("Welcome to Starlark (go.starlark.net/starlark)")
+		fmt.Println("Welcome to Starlark (go.starlark.net)")
 		repl.REPL(thread, globals)
 	case 1:
 		// Execute specified file.

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3505,11 +3505,15 @@ See also: `string·elems`.
 <a id='string·capitalize'></a>
 ### string·capitalize
 
-`S.capitalize()` returns a copy of string S with all Unicode letters
-that begin words changed to their title case.
+`S.capitalize()` returns a copy of string S with its first code point
+changes to its title case and all subsequent letters changed to their
+lower case.
 
 ```python
-"hello, world!".capitalize()		# "Hello, World!"
+"hello, world!".capitalize()		# "Hello, world!"
+"hElLo, wOrLd!".capitalize()		# "Hello, world!"
+"¿Por qué?".capitalize()		# "¿por qué?"
+
 ```
 
 <a id='string·codepoint_ords'></a>

--- a/starlark/testdata/string.star
+++ b/starlark/testdata/string.star
@@ -360,4 +360,24 @@ assert.fails(lambda: any("abc"), "got string, want iterable") # any
 assert.fails(lambda: reversed("abc"), "got string, want iterable") # reversed
 assert.fails(lambda: zip("ab", "cd"), "not iterable: string") # zip
 
-# TODO(adonovan): tests for: {,r}index join {capitalize,lower,title,upper}
+# TODO(adonovan): tests for: {,r}index join
+
+# str.capitalize
+assert.eq("hElLo, WoRlD!".capitalize(), "Hello, world!")
+assert.eq("por qué".capitalize(), "Por qué")
+assert.eq("¿Por qué?".capitalize(), "¿por qué?")
+
+# str.lower
+assert.eq("hElLo, WoRlD!".lower(), "hello, world!")
+assert.eq("por qué".lower(), "por qué")
+assert.eq("¿Por qué?".lower(), "¿por qué?")
+
+# str.upper
+assert.eq("hElLo, WoRlD!".upper(), "HELLO, WORLD!")
+assert.eq("por qué".upper(), "POR QUÉ")
+assert.eq("¿Por qué?".upper(), "¿POR QUÉ?")
+
+# str.title
+assert.eq("hElLo, WoRlD!".title(), "Hello, World!")
+assert.eq("por qué".title(), "Por Qué")
+assert.eq("¿Por qué?".title(), "¿Por Qué?")


### PR DESCRIPTION
Behavior now matches the spec (and Python3).
+ Tests.

Fixes google/skylark#140
