### PR TITLE
compile: add missing opcodeName[EXCH]

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -152,6 +152,7 @@ var opcodeNames = [...]string{
 	DUP2:        "dup2",
 	DUP:         "dup",
 	EQL:         "eql",
+	EXCH:        "exch",
 	FALSE:       "false",
 	FREE:        "free",
 	GE:          "ge",
@@ -271,7 +272,9 @@ var stackEffect = [...]int8{
 
 func (op Opcode) String() string {
 	if op < OpcodeMax {
-		return opcodeNames[op]
+		if name := opcodeNames[op]; name != "" {
+			return name
+		}
 	}
 	return fmt.Sprintf("illegal op (%d)", op)
 }

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -549,6 +549,9 @@ func (fn *Function) Globals() StringDict {
 
 func (fn *Function) Position() syntax.Position { return fn.funcode.Pos }
 func (fn *Function) NumParams() int            { return fn.funcode.NumParams }
+
+// Param returns the name and position of the ith parameter,
+// where 0 <= i < NumParams().
 func (fn *Function) Param(i int) (string, syntax.Position) {
 	id := fn.funcode.Locals[i]
 	return id.Name, id.Pos


### PR DESCRIPTION
Also,
- make Opcode.String catch future missing entries.
- document (*Function).Param.
