### PR TITLE
README: link Travis CI badge to build status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ languages and compilers.
 
 * Issue tracker: [https://go.starlark.net/starlark/issues](https://go.starlark.net/starlark/issues)
 
-* Travis CI: ![Travis CI](https://travis-ci.org/google/starlark-go.svg) [https://travis-ci.org/google/starlark-go](https://travis-ci.org/google/starlark-go)
+* Travis CI: [![Travis CI](https://travis-ci.org/google/starlark-go.svg) https://travis-ci.org/google/starlark-go](https://travis-ci.org/google/starlark-go)
 
 ### Getting started
 


### PR DESCRIPTION
It's more helpful (and expected) to link the badge to the build status page,
rather than it just being a link to the [badge SVG itself](https://travis-ci.org/google/starlark-go.svg).