### PR TITLE
README: simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ languages and compilers.
 Build the code:
 
 ```shell
-$ go get -u go.starlark.net/cmd/starlark  # check out the code and dependencies, then install interpreter in $GOPATH/bin
+# check out the code and dependencies,
+# and install interpreter in $GOPATH/bin
+$ go get -u go.starlark.net/cmd/starlark
 ```
 
 Run the interpreter:

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ languages and compilers.
 Build the code:
 
 ```shell
-
-$ go get     go.starlark.net/cmd/starlark  # check out the code
-$ go install go.starlark.net/cmd/starlark  # install interpreter in $GOPATH/bin
+$ go get go.starlark.net/cmd/starlark  # check out the code and install interpreter in $GOPATH/bin
 ```
 
 Run the interpreter:


### PR DESCRIPTION
`go get` already does the work done by `go install` ¹, so doing a `go install`
afterwards is redundant. Use this property to make the installation
process simpler.

¹ https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies

This assumes a GOPATH workspace mode, but the current directions seem to imply that (i.e., `$GOPATH/bin` is mentioned in the comment).

You may want to include `-u` flag by default, if you'd rather have the `go get` command produce more predictable results. Without `-u`, if the user happens to have really old versions of some dependencies (rather not have them at all), `go get` will not update them and your program may not build. If the user doesn't have those dependencies, `go get` will fetch the latest version. Using the `-u` flag makes `go get -u` always get the latest version, which is more consistent and predictable.