### PR TITLE
resolve: allow use of predeclared name prior to a global def (if AllowGlobalReassign)

### DIFF
--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -243,3 +243,28 @@ c = 3.141          ### `dialect does not support floating point`
 a = float("3.141")
 b = 1 / 2
 c = 3.141
+
+---
+# option:global_reassign
+# Legacy Bazel (and Python) semantics: def must precede use even for globals.
+
+_ = x ### `undefined: x`
+x = 1
+
+---
+# option:global_reassign
+# Legacy Bazel (and Python) semantics: reassignment of globals is allowed.
+x = 1
+x = 2 # ok
+
+---
+# option:global_reassign
+# Redeclaration of predeclared names is allowed.
+
+# module-specific predeclared name
+M = 1 # ok
+M = 2 # ok (legacy)
+
+# universal predeclared name
+U = 1 # ok
+U = 1 # ok (legacy)


### PR DESCRIPTION
This change causes the AllowGlobalReassign flag (used for legacy Bazel
semantics) to also allow use of predeclared names prior to a global
binding of the same name, as in:

   print(len); len=1; print(len)

This effectively reverses github.com/google/skylark/pull/123 behind an option.

See github.com/google/skylark/issues/116 for discussion.