### PR TITLE
all: use explicit URLs to refer to old Starlark issues

### DIFF
--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -9,7 +9,8 @@ x = 1
 _ = x
 
 ---
-# premature use of global is not a static error; see issue 116.
+# premature use of global is not a static error;
+# see github.com/google/skylark/issues/116.
 _ = x
 x = 1
 
@@ -20,7 +21,7 @@ _ = x ### "undefined: x"
 ---
 # redeclaration of global
 x = 1
-x = 2 ### "cannot reassign global x declared at .*resolve.star:22:1"
+x = 2 ### "cannot reassign global x declared at .*resolve.star:23:1"
 
 ---
 # Redeclaration of predeclared names is allowed.
@@ -37,7 +38,8 @@ U = 1 # ok
 U = 1 ### "cannot reassign global U declared at .*/resolve.star"
 
 ---
-# A global declaration shadows all references to a predeclared; see issue 116.
+# A global declaration shadows all references to a predeclared;
+# see github.com/google/skylark/issues/116.
 
 a = U # ok: U is a reference to the global defined on the next line.
 U = 1

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"go.starlark.net/starlark"
 	"go.starlark.net/internal/chunkedfile"
 	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
 	"go.starlark.net/starlarktest"
 	"go.starlark.net/syntax"
 )
@@ -145,11 +145,11 @@ func TestExecFile(t *testing.T) {
 // A fib is an iterable value representing the infinite Fibonacci sequence.
 type fib struct{}
 
-func (t fib) Freeze()                   {}
-func (t fib) String() string            { return "fib" }
-func (t fib) Type() string              { return "fib" }
+func (t fib) Freeze()                    {}
+func (t fib) String() string             { return "fib" }
+func (t fib) Type() string               { return "fib" }
 func (t fib) Truth() starlark.Bool       { return true }
-func (t fib) Hash() (uint32, error)     { return 0, fmt.Errorf("fib is unhashable") }
+func (t fib) Hash() (uint32, error)      { return 0, fmt.Errorf("fib is unhashable") }
 func (t fib) Iterate() starlark.Iterator { return &fibIterator{0, 1} }
 
 type fibIterator struct{ x, y int }
@@ -192,7 +192,7 @@ var (
 
 func (hf *hasfields) String() string        { return "hasfields" }
 func (hf *hasfields) Type() string          { return "hasfields" }
-func (hf *hasfields) Truth() starlark.Bool   { return true }
+func (hf *hasfields) Truth() starlark.Bool  { return true }
 func (hf *hasfields) Hash() (uint32, error) { return 42, nil }
 
 func (hf *hasfields) Freeze() {
@@ -298,7 +298,7 @@ def f(a, b=42, *args, **kwargs):
 		{`f(0, b=1)`, `(0, 1, (), {})`},
 		{`f(0, a=1)`, `function f got multiple values for keyword argument "a"`},
 		{`f(0, b=1, c=2)`, `(0, 1, (), {"c": 2})`},
-		{`f(0, 1, x=2, *[3, 4], y=5, **dict(z=6))`, // go.starlark.net/starlark/issues/135
+		{`f(0, 1, x=2, *[3, 4], y=5, **dict(z=6))`, // github.com/google/skylark/issues/135
 			`(0, 1, (3, 4), {"x": 2, "y": 5, "z": 6})`},
 	} {
 		var got string

--- a/starlark/testdata/assign.star
+++ b/starlark/testdata/assign.star
@@ -199,7 +199,7 @@ assert.eq(type(list), "list")
 
 # ...but then all uses refer to the global,
 # even if they occur before the binding use.
-# See go.starlark.net/starlark/issues/116.
+# See github.com/google/skylark/issues/116.
 assert.fails(lambda: tuple, "global variable tuple referenced before assignment")
 tuple = ()
 

--- a/starlark/testdata/function.star
+++ b/starlark/testdata/function.star
@@ -186,7 +186,7 @@ def f(a, b, x, y):
 assert.eq(f(*("a", "b"), **dict(y="y", x="x")) + ".", 'abxy.')
 ---
 # Order of evaluation of function arguments.
-# Regression test for go.starlark.net/starlark/issues/135.
+# Regression test for github.com/google/skylark/issues/135.
 load("assert.star", "assert")
 
 r = []

--- a/starlark/testdata/misc.star
+++ b/starlark/testdata/misc.star
@@ -105,7 +105,7 @@ assert.eq(str(freeze), '<built-in function freeze>')
 
 ---
 # Load does not expose pre-declared globals from other modules.
-# See go.starlark.net/starlark/issues/75.
+# See github.com/google/skylark/issues/75.
 load('assert.star', 'assert', 'matches') ### "matches not found in module"
 
 ---

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -105,7 +105,7 @@ func TestExprParseTrees(t *testing.T) {
 		{`a and not b`,
 			`(BinaryExpr X=a Op=and Y=(UnaryExpr Op=not X=b))`},
 		{`[e for x in y if cond1 if cond2]`,
-			`(Comprehension Body=e Clauses=((ForClause Vars=x X=y) (IfClause Cond=cond1) (IfClause Cond=cond2)))`}, // go.starlark.net/starlark issue 53
+			`(Comprehension Body=e Clauses=((ForClause Vars=x X=y) (IfClause Cond=cond1) (IfClause Cond=cond2)))`}, // github.com/google/skylark/issues/53
 	} {
 		e, err := syntax.ParseExpr("foo.star", test.input, 0)
 		if err != nil {

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -192,7 +192,7 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		// octal escapes in string literals
 		{`"\037"`, `"\x1f" EOF`},
 		{`"\377"`, `"\xff" EOF`},
-		{`"\378"`, `"\x1f8" EOF`},                               // = '\37' + '8'
+		{`"\378"`, `"\x1f8" EOF`},                                // = '\37' + '8'
 		{`"\400"`, `foo.star:1:1: invalid escape sequence \400`}, // unlike Python 2 and 3
 		// Backslashes that are not part of escapes are treated literally,
 		// but this behavior will change; see b/34519173.
@@ -204,7 +204,7 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		{"012934e1", `1.293400e+05 EOF`},
 		{"0123.", `1.230000e+02 EOF`},
 		{"0123.1", `1.231000e+02 EOF`},
-		// issue #16
+		// github.com/google/skylark/issues/16
 		{"x ! 0", "foo.star:1:3: unexpected input character '!'"},
 	} {
 		got, err := scan(test.input)


### PR DESCRIPTION
GitHub allows individual issues to be transferred but provides no bulk
mechanism---also, we've started reusing issue numbers---so I
transferred the few open issues and left the closed ones.
