### PR TITLE
starlark: reject dup keyword args in call to func with **kwargs param

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1053,7 +1053,11 @@ func setArgs(locals []Value, fn *Function, args Tuple, kwargs []Tuple) error {
 			if kwdict == nil {
 				return fmt.Errorf("function %s got an unexpected keyword argument %s", fn.Name(), k)
 			}
+			n := kwdict.Len()
 			kwdict.SetKey(k, v)
+			if kwdict.Len() == n {
+				return fmt.Errorf("function %s got multiple values for keyword argument %s", fn.Name(), k)
+			}
 		}
 
 		// default values

--- a/starlark/testdata/function.star
+++ b/starlark/testdata/function.star
@@ -174,6 +174,23 @@ assert.fails(lambda: f(
     57, 58, 59, 60, 61, 62, 63, 64, 65,
     mm = 100), 'multiple values for keyword argument "mm"')
 
+---
+# Regression test for github.com/google/starlark-go/issues/21.
+
+load("assert.star", "assert")
+
+def f(*args, **kwargs):
+  return args, kwargs
+
+assert.eq(f(x=1, y=2), ((), {"x": 1, "y": 2}))
+assert.fails(lambda: f(x=1, x=2), 'multiple values for keyword argument "x"')
+assert.fails(lambda: f(x=1, **dict(x=2)), 'multiple values for keyword argument "x"')
+
+def g(x, y):
+  return x, y
+
+assert.eq(g(1, y=2), (1, 2))
+assert.fails(lambda: g(1, y=2, y=3), 'multiple values for keyword argument "y"')
 
 ---
 # Regression test for a bug in CALL_VAR_KW.


### PR DESCRIPTION
Fixes #21
