### PR TITLE
starlark: allow parenthesized expressions on LHS of augmented assignments

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -980,7 +980,7 @@ func (fcomp *fcomp) stmt(stmt syntax.Stmt) {
 			var set func()
 
 			// Evaluate "address" of x exactly once to avoid duplicate side-effects.
-			switch lhs := stmt.LHS.(type) {
+			switch lhs := unparen(stmt.LHS).(type) {
 			case *syntax.Ident:
 				// x = ...
 				fcomp.lookup(lhs)

--- a/starlark/testdata/assign.star
+++ b/starlark/testdata/assign.star
@@ -243,6 +243,10 @@ assert.eq(type(z), "tuple")
 assert.eq(len(z), 1)
 assert.eq(z[0], 1)
 
+# assign value to parenthesized variable
+(a) = 1
+assert.eq(a, 1)
+
 ---
 # assignment to/from fields.
 load("assert.star", "assert", "freeze")
@@ -278,3 +282,16 @@ def g():
     pass
   return a
 assert.eq(g(), {"one": 1, "two": 2})
+
+---
+# parenthesized LHS in augmented assignment (success)
+load("assert.star", "assert")
+
+a = 5
+(a) += 3
+assert.eq(a, 8)
+
+---
+# parenthesized LHS in augmented assignment (error)
+
+(a) += 5 ### "global variable a referenced before assignment"


### PR DESCRIPTION
This change fixes the Go implementation of starlark vis-a-vis parens on the LHS of augmented assignments. Fixing the spec is tracked at https://github.com/bazelbuild/bazel/issues/6756.

cc @laurentlb

Fixes #25