### PR TITLE
starlark: fix overflow in repeat operator

### DIFF
--- a/starlark/testdata/string.star
+++ b/starlark/testdata/string.star
@@ -23,6 +23,8 @@ assert.eq(-1 * "abc", "")
 assert.eq(1 * "abc", "abc")
 assert.eq(5 * "abc", "abcabcabcabcabc")
 assert.fails(lambda: 1.0 * "abc", "unknown.*float \\* str")
+assert.fails(lambda : "abc" * (1000000 * 1000000), "repeat count 1000000000000 too large")
+assert.fails(lambda : "abc" * 1000000 * 1000000, "excessive repeat .3000000000000 elements")
 
 # len
 assert.eq(len("Hello, 世界!"), 14)

--- a/starlark/testdata/tuple.star
+++ b/starlark/testdata/tuple.star
@@ -36,7 +36,7 @@ assert.eq(tuple(), ())
 assert.eq(tuple("abc".elems()), ("a", "b", "c"))
 assert.eq(tuple(["a", "b", "c"]), ("a", "b", "c"))
 assert.eq(tuple([1]), (1,))
-assert.fails(lambda: tuple(1), "got int, want iterable")
+assert.fails(lambda : tuple(1), "got int, want iterable")
 
 # tuple * int,  int * tuple
 abc = tuple("abc".elems())
@@ -48,6 +48,8 @@ assert.eq(0 * abc, ())
 assert.eq(-1 * abc, ())
 assert.eq(1 * abc, abc)
 assert.eq(3 * abc, ("a", "b", "c", "a", "b", "c", "a", "b", "c"))
+assert.fails(lambda : abc * (1000000 * 1000000), "repeat count 1000000000000 too large")
+assert.fails(lambda : abc * 1000000 * 1000000, "excessive repeat .3000000000000 elements")
 
 # TODO(adonovan): test use of tuple as sequence
 # (for loop, comprehension, library functions).


### PR DESCRIPTION
We limit repeats arbitrarily to 10,000,000 elements
to avoid accidental OOM. It's still possible to
OOM piecewise but we can't fix that.

Also, handle integer overflow in multiplication
and excessive repeats counts.
