### PR TITLE
starlark: if a built-in Callable defines Position method, use it

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -130,8 +130,14 @@ func (fr *Frame) Position() syntax.Position {
 	if fr.posn.IsValid() {
 		return fr.posn // leaf frame only (the error)
 	}
-	if fn, ok := fr.callable.(*Function); ok {
-		return fn.funcode.Position(fr.callpc) // position of active call
+	switch c := fr.callable.(type) {
+	case *Function:
+		// Starlark function
+		return c.funcode.Position(fr.callpc) // position of active call
+	case interface{ Position() syntax.Position }:
+		// If a built-in Callable defines
+		// a Position method, use it.
+		return c.Position()
 	}
 	return syntax.MakePosition(&builtinFilename, 1, 0)
 }


### PR DESCRIPTION
...when printing a frame or backtrace.

This is more of a low-risk usability hack than a specified feature at
this point. I don't think it warrants a (breaking) change to the
Callable interface.
