### PR TITLE
[parser] Unify handling of * and **.

### DIFF
--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -703,27 +703,14 @@ func (p *parser) parseArgs() []Expr {
 			break
 		}
 
-		// *args
-		if p.tok == STAR {
+		// *args or **kwargs
+		if p.tok == STAR || p.tok == STARSTAR {
 			stars = true
 			pos := p.nextToken()
 			x := p.parseTest()
 			args = append(args, &UnaryExpr{
 				OpPos: pos,
-				Op:    STAR,
-				X:     x,
-			})
-			continue
-		}
-
-		// **kwargs
-		if p.tok == STARSTAR {
-			stars = true
-			pos := p.nextToken()
-			x := p.parseTest()
-			args = append(args, &UnaryExpr{
-				OpPos: pos,
-				Op:    STARSTAR,
+				Op:    p.tok,
 				X:     x,
 			})
 			continue


### PR DESCRIPTION
This is similar to a recent [change](https://github.com/google/starlark-go/pull/57/files) to `parseParams` method.