### PR TITLE
Support keyword-only function parameters

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2321,6 +2321,7 @@ LambdaExpr = 'lambda' [Parameters] ':' Test .
 Parameters = Parameter {',' Parameter} .
 Parameter  = identifier
            | identifier '=' Test
+           | '*'
            | '*' identifier
            | '**' identifier
            .
@@ -2508,7 +2509,7 @@ the parameter list (which is enclosed in parentheses), a colon, and
 then an indented block of statements which form the body of the function.
 
 The parameter list is a comma-separated list whose elements are of
-four kinds.  First come zero or more required parameters, which are
+several kinds.  First come zero or more required parameters, which are
 simple identifiers; all calls must provide an argument value for these parameters.
 
 The required parameters are followed by zero or more optional
@@ -2519,11 +2520,24 @@ provide an argument value for it.
 The required parameters are optionally followed by a single parameter
 name preceded by a `*`.  This is the called the _varargs_ parameter,
 and it accumulates surplus positional arguments specified by a call.
+It is conventionally named `*args`.
+
+The varargs parameter may be followed by zero or more optional
+parameters, again of the form `name=expression`, but these optional parameters
+differ from earlier ones in that they are "keyword-only":
+a call must provide their values as keyword arguments,
+not positional ones.
+
+A non-variadic function may also declare keyword-only parameters,
+by using a bare `*` in place of the `*args` parameter.
+This form does not declare a parameter but marks the boundary
+between the earlier parameters and the keyword-only parameters.
+This form must be followed by at least one optional parameter.
 
 Finally, there may be an optional parameter name preceded by `**`.
 This is called the _keyword arguments_ parameter, and accumulates in a
 dictionary any surplus `name=value` arguments that do not match a
-prior parameter.
+prior parameter. It is conventionally named `**kwargs`.
 
 Here are some example parameter lists:
 
@@ -2534,6 +2548,7 @@ def f(a, b, c=1): pass
 def f(a, b, c=1, *args): pass
 def f(a, b, c=1, *args, **kwargs): pass
 def f(**kwargs): pass
+def f(a, b, c=1, *, d=1): pass
 ```
 
 Execution of a `def` statement creates a new function object.  The

--- a/internal/compile/serial.go
+++ b/internal/compile/serial.go
@@ -39,6 +39,7 @@ package compile
 //	freevar		[]Ident
 //	maxstack	varint
 //	numparams	varint
+//	numkwonlyparams	varint
 //	hasvarargs	varint (0 or 1)
 //	haskwargs	varint (0 or 1)
 //
@@ -185,6 +186,7 @@ func (e *encoder) function(fn *Funcode) {
 	e.idents(fn.Freevars)
 	e.int(fn.MaxStack)
 	e.int(fn.NumParams)
+	e.int(fn.NumKwonlyParams)
 	e.int(b2i(fn.HasVarargs))
 	e.int(b2i(fn.HasKwargs))
 }
@@ -350,20 +352,22 @@ func (d *decoder) function() *Funcode {
 	freevars := d.idents()
 	maxStack := d.int()
 	numParams := d.int()
+	numKwonlyParams := d.int()
 	hasVarargs := d.int() != 0
 	hasKwargs := d.int() != 0
 	return &Funcode{
 		// Prog is filled in later.
-		Pos:        id.Pos,
-		Name:       id.Name,
-		Doc:        doc,
-		Code:       code,
-		pclinetab:  pclinetab,
-		Locals:     locals,
-		Freevars:   freevars,
-		MaxStack:   maxStack,
-		NumParams:  numParams,
-		HasVarargs: hasVarargs,
-		HasKwargs:  hasKwargs,
+		Pos:             id.Pos,
+		Name:            id.Name,
+		Doc:             doc,
+		Code:            code,
+		pclinetab:       pclinetab,
+		Locals:          locals,
+		Freevars:        freevars,
+		MaxStack:        maxStack,
+		NumParams:       numParams,
+		NumKwonlyParams: numKwonlyParams,
+		HasVarargs:      hasVarargs,
+		HasKwargs:       hasKwargs,
 	}
 }

--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -184,31 +184,51 @@ M(x=1, 2) ### `positional argument may not follow named`
 
 def f(x=1, y): pass ### `required parameter may not follow optional`
 ---
-# No parameters may follow **kwargs
+# No parameters may follow **kwargs in a declaration.
 
 def f(**kwargs, x): ### `parameter may not follow \*\*kwargs`
   pass
 
-def g(**kwargs, *args): ### `\*args may not follow \*\*kwargs`
+def g(**kwargs, *args): ### `\* parameter may not follow \*\*kwargs`
   pass
 
-def h(**kwargs1, **kwargs2): ### `multiple \*\*kwargs not allowed`
-  pass
-
----
-# Only **kwargs may follow *args
-
-def f(*args, x): ### `parameter may not follow \*args`
-  pass
-
-def g(*args1, *args2): ### `multiple \*args not allowed`
-  pass
-
-def h(*args, **kwargs): # ok
+def h(**kwargs1, **kwargs2): ### `multiple \*\* parameters not allowed`
   pass
 
 ---
-# No arguments may follow **kwargs
+# Only keyword-only params and **kwargs may follow *args in a declaration.
+
+def f(*args, x): ### `required parameter may not follow \* parameter`
+  pass
+
+def g(*args1, *args2): ### `multiple \* parameters not allowed`
+  pass
+
+def h(*, ### `bare \* must be followed by optional parameters`
+      *): ### `multiple \* parameters not allowed`
+  pass
+
+def i(*args, *): ### `multiple \* parameters not allowed`
+  pass
+
+def j(*,      ### `bare \* must be followed by optional parameters`
+      *args): ### `multiple \* parameters not allowed`
+  pass
+
+def k(*, **kwargs): ### `bare \* must be followed by optional parameters`
+  pass
+
+def l(*): ### `bare \* must be followed by optional parameters`
+  pass
+
+def m(*args, a=1, **kwargs): # ok
+  pass
+
+def n(*, a=1, **kwargs): # ok
+  pass
+
+---
+# No arguments may follow **kwargs in a call.
 def f(*args, **kwargs):
   pass
 
@@ -218,7 +238,7 @@ f(**{}, *[]) ### `\*args may not follow \*\*kwargs`
 f(**{}, **{}) ### `multiple \*\*kwargs not allowed`
 
 ---
-# Only keyword arguments may follow *args
+# Only keyword arguments may follow *args in a call.
 def f(*args, **kwargs):
   pass
 

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1011,6 +1011,16 @@ func asIndex(v Value, len int, result *int) error {
 // setArgs sets the values of the formal parameters of function fn in
 // based on the actual parameter values in args and kwargs.
 func setArgs(locals []Value, fn *Function, args Tuple, kwargs []Tuple) error {
+	// This is adapted from the algorithm from PyEval_EvalCodeEx.
+
+	// Nullary function?
+	if fn.NumParams() == 0 {
+		if nactual := len(args) + len(kwargs); nactual > 0 {
+			return fmt.Errorf("function %s takes no arguments (%d given)", fn.Name(), nactual)
+		}
+		return nil
+	}
+
 	cond := func(x bool, y, z interface{}) interface{} {
 		if x {
 			return y
@@ -1020,101 +1030,95 @@ func setArgs(locals []Value, fn *Function, args Tuple, kwargs []Tuple) error {
 
 	// nparams is the number of ordinary parameters (sans * or **).
 	nparams := fn.NumParams()
+	var kwdict *Dict
+	if fn.HasKwargs() {
+		nparams--
+		kwdict = new(Dict)
+		locals[nparams] = kwdict
+	}
 	if fn.HasVarargs() {
 		nparams--
 	}
-	if fn.HasKwargs() {
-		nparams--
+
+	// Too many positional args?
+	n := len(args)
+	maxpos := nparams - fn.NumKwonlyParams()
+	if len(args) > maxpos {
+		if !fn.HasVarargs() {
+			return fmt.Errorf("function %s takes %s %d positional argument%s (%d given)",
+				fn.Name(),
+				cond(len(fn.defaults) > 0, "at most", "exactly"),
+				maxpos,
+				cond(nparams == 1, "", "s"),
+				len(args)+len(kwargs))
+		}
+		n = maxpos
 	}
 
-	// This is the algorithm from PyEval_EvalCodeEx.
-	var kwdict *Dict
-	n := len(args)
-	if nparams > 0 || fn.HasVarargs() || fn.HasKwargs() {
-		if fn.HasKwargs() {
-			kwdict = new(Dict)
-			locals[fn.NumParams()-1] = kwdict
+	// set of defined (regular) parameters
+	var defined intset
+	defined.init(nparams)
+
+	// ordinary parameters
+	for i := 0; i < n; i++ {
+		locals[i] = args[i]
+		defined.set(i)
+	}
+
+	// variadic arguments
+	if fn.HasVarargs() {
+		tuple := make(Tuple, len(args)-n)
+		for i := n; i < len(args); i++ {
+			tuple[i-n] = args[i]
 		}
+		locals[nparams] = tuple
+	}
 
-		// too many args?
-		if len(args) > nparams {
-			if !fn.HasVarargs() {
-				return fmt.Errorf("function %s takes %s %d argument%s (%d given)",
-					fn.Name(),
-					cond(len(fn.defaults) > 0, "at most", "exactly"),
-					nparams,
-					cond(nparams == 1, "", "s"),
-					len(args)+len(kwargs))
-			}
-			n = nparams
-		}
-
-		// set of defined (regular) parameters
-		var defined intset
-		defined.init(nparams)
-
-		// ordinary parameters
-		for i := 0; i < n; i++ {
-			locals[i] = args[i]
-			defined.set(i)
-		}
-
-		// variadic arguments
-		if fn.HasVarargs() {
-			tuple := make(Tuple, len(args)-n)
-			for i := n; i < len(args); i++ {
-				tuple[i-n] = args[i]
-			}
-			locals[nparams] = tuple
-		}
-
-		// keyword arguments
-		paramIdents := fn.funcode.Locals[:nparams]
-		for _, pair := range kwargs {
-			k, v := pair[0].(String), pair[1]
-			if i := findParam(paramIdents, string(k)); i >= 0 {
-				if defined.set(i) {
-					return fmt.Errorf("function %s got multiple values for keyword argument %s", fn.Name(), k)
-				}
-				locals[i] = v
-				continue
-			}
-			if kwdict == nil {
-				return fmt.Errorf("function %s got an unexpected keyword argument %s", fn.Name(), k)
-			}
-			n := kwdict.Len()
-			kwdict.SetKey(k, v)
-			if kwdict.Len() == n {
+	// keyword arguments
+	paramIdents := fn.funcode.Locals[:nparams]
+	for _, pair := range kwargs {
+		k, v := pair[0].(String), pair[1]
+		if i := findParam(paramIdents, string(k)); i >= 0 {
+			if defined.set(i) {
 				return fmt.Errorf("function %s got multiple values for keyword argument %s", fn.Name(), k)
 			}
+			locals[i] = v
+			continue
+		}
+		if kwdict == nil {
+			return fmt.Errorf("function %s got an unexpected keyword argument %s", fn.Name(), k)
+		}
+		n := kwdict.Len()
+		kwdict.SetKey(k, v)
+		if kwdict.Len() == n {
+			return fmt.Errorf("function %s got multiple values for keyword argument %s", fn.Name(), k)
+		}
+	}
+
+	// default values
+	if n < nparams || fn.NumKwonlyParams() > 0 {
+
+		m := nparams - len(fn.defaults) // first default
+
+		// report errors for missing non-optional arguments
+		i := n
+		for ; i < m; i++ {
+			if !defined.get(i) {
+				return fmt.Errorf("function %s takes %s %d positional argument%s (%d given)",
+					fn.Name(),
+					cond(fn.HasVarargs() || len(fn.defaults) > 0, "at least", "exactly"),
+					m,
+					cond(m == 1, "", "s"),
+					defined.len())
+			}
 		}
 
-		// default values
-		if len(args) < nparams {
-			m := nparams - len(fn.defaults) // first default
-
-			// report errors for missing non-optional arguments
-			i := len(args)
-			for ; i < m; i++ {
-				if !defined.get(i) {
-					return fmt.Errorf("function %s takes %s %d argument%s (%d given)",
-						fn.Name(),
-						cond(fn.HasVarargs() || len(fn.defaults) > 0, "at least", "exactly"),
-						m,
-						cond(m == 1, "", "s"),
-						defined.len())
-				}
-			}
-
-			// set default values
-			for ; i < nparams; i++ {
-				if !defined.get(i) {
-					locals[i] = fn.defaults[i-m]
-				}
+		// set default values
+		for ; i < nparams; i++ {
+			if !defined.get(i) {
+				locals[i] = fn.defaults[i-m]
 			}
 		}
-	} else if nactual := len(args) + len(kwargs); nactual > 0 {
-		return fmt.Errorf("function %s takes no arguments (%d given)", fn.Name(), nactual)
 	}
 	return nil
 }

--- a/starlark/testdata/function.star
+++ b/starlark/testdata/function.star
@@ -161,7 +161,7 @@ assert.fails(lambda: f(
     33, 34, 35, 36, 37, 38, 39, 40,
     41, 42, 43, 44, 45, 46, 47, 48,
     49, 50, 51, 52, 53, 54, 55, 56,
-    57, 58, 59, 60, 61, 62, 63, 64), "takes exactly 65 arguments .64 given.")
+    57, 58, 59, 60, 61, 62, 63, 64), "takes exactly 65 positional arguments .64 given.")
 
 assert.fails(lambda: f(
     1, 2, 3, 4, 5, 6, 7, 8,

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -548,9 +548,12 @@ func (fn *Function) Globals() StringDict {
 
 func (fn *Function) Position() syntax.Position { return fn.funcode.Pos }
 func (fn *Function) NumParams() int            { return fn.funcode.NumParams }
+func (fn *Function) NumKwonlyParams() int      { return fn.funcode.NumKwonlyParams }
 
 // Param returns the name and position of the ith parameter,
 // where 0 <= i < NumParams().
+// The *args and **kwargs parameters are at the end
+// even if there were optional parameters after *args.
 func (fn *Function) Param(i int) (string, syntax.Position) {
 	id := fn.funcode.Locals[i]
 	return id.Name, id.Pos

--- a/syntax/grammar.txt
+++ b/syntax/grammar.txt
@@ -10,7 +10,7 @@ DefStmt = 'def' identifier '(' [Parameters [',']] ')' ':' Suite .
 
 Parameters = Parameter {',' Parameter}.
 
-Parameter = identifier | identifier '=' Test | '*' identifier | '**' identifier .
+Parameter = identifier | identifier '=' Test | '*' | '*' identifier | '**' identifier .
 
 IfStmt = 'if' Test ':' Suite {'elif' Test ':' Suite} ['else' ':' Suite] .
 

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -11,7 +11,7 @@ package syntax
 // package.  Verify that error positions are correct using the
 // chunkedfile mechanism.
 
-import log "log"
+import "log"
 
 // Enable this flag to print the token stream and log.Fatal on the first error.
 const debug = false
@@ -382,15 +382,17 @@ func (p *parser) consume(t Token) Position {
 //
 // param = IDENT
 //       | IDENT EQ test
+//       | STAR
 //       | STAR IDENT
 //       | STARSTAR IDENT
 //
 // parseParams parses a parameter list.  The resulting expressions are of the form:
 //
-//      *Ident
-//      *Binary{Op: EQ, X: *Ident, Y: Expr}
-//      *Unary{Op: STAR, X: *Ident}
-//      *Unary{Op: STARSTAR, X: *Ident}
+//      *Ident                                          x
+//      *Binary{Op: EQ, X: *Ident, Y: Expr}             x=y
+//      *Unary{Op: STAR}                                *
+//      *Unary{Op: STAR, X: *Ident}                     *args
+//      *Unary{Op: STARSTAR, X: *Ident}                 **kwargs
 func (p *parser) parseParams() []Expr {
 	var params []Expr
 	stars := false
@@ -406,16 +408,19 @@ func (p *parser) parseParams() []Expr {
 			break
 		}
 
-		// *args or **kwargs
+		// * or *args or **kwargs
 		if p.tok == STAR || p.tok == STARSTAR {
 			stars = true
 			op := p.tok
 			pos := p.nextToken()
-			id := p.parseIdent()
+			var x Expr
+			if op == STARSTAR || p.tok == IDENT {
+				x = p.parseIdent()
+			}
 			params = append(params, &UnaryExpr{
 				OpPos: pos,
 				Op:    op,
-				X:     id,
+				X:     x,
 			})
 			continue
 		}

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -100,6 +100,10 @@ func TestExprParseTrees(t *testing.T) {
 			`(CallExpr Fn=f Args=(1 (BinaryExpr X=x Op== Y=y)))`},
 		{`f(*args, **kwargs)`,
 			`(CallExpr Fn=f Args=((UnaryExpr Op=* X=args) (UnaryExpr Op=** X=kwargs)))`},
+		{`lambda *args, *, x=1, **kwargs: 0`,
+			`(LambdaExpr Function=(Function Params=((UnaryExpr Op=* X=args) (UnaryExpr Op=*) (BinaryExpr X=x Op== Y=1) (UnaryExpr Op=** X=kwargs)) Body=((ReturnStmt Result=0))))`},
+		{`lambda *, a, *b: 0`,
+			`(LambdaExpr Function=(Function Params=((UnaryExpr Op=*) a (UnaryExpr Op=* X=b)) Body=((ReturnStmt Result=0))))`},
 		{`a if b else c`,
 			`(CondExpr Cond=b True=a False=c)`},
 		{`a and not b`,
@@ -316,6 +320,11 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 				if f.IsNil() {
 					continue
 				}
+			case reflect.Int:
+				if f.Int() != 0 {
+					fmt.Fprintf(out, " %s=%d", name, f.Int())
+				}
+				continue
 			case reflect.Bool:
 				if f.Bool() {
 					fmt.Fprintf(out, " %s", name)

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -122,14 +122,15 @@ func (x *AssignStmt) Span() (start, end Position) {
 type Function struct {
 	commentsRef
 	StartPos Position // position of DEF or LAMBDA token
-	Params   []Expr   // param = ident | ident=expr | *ident | **ident
+	Params   []Expr   // param = ident | ident=expr | * | *ident | **ident
 	Body     []Stmt
 
 	// set by resolver:
-	HasVarargs bool     // whether params includes *args (convenience)
-	HasKwargs  bool     // whether params includes **kwargs (convenience)
-	Locals     []*Ident // this function's local variables, parameters first
-	FreeVars   []*Ident // enclosing local variables to capture in closure
+	HasVarargs      bool     // whether params includes *args (convenience)
+	HasKwargs       bool     // whether params includes **kwargs (convenience)
+	NumKwonlyParams int      // number of keyword-only optional parameters
+	Locals          []*Ident // this function's local variables, parameters first
+	FreeVars        []*Ident // enclosing local variables to capture in closure
 }
 
 func (x *Function) Span() (start, end Position) {

--- a/syntax/testdata/errors.star
+++ b/syntax/testdata/errors.star
@@ -27,6 +27,17 @@ def f(**kwargs, ): ### `got '\)', want parameter`
 
 ---
 
+# Parameters are validated later.
+def f(**kwargs, *args, *, b=1, a, **kwargs, *args, *, b=1, a):
+  pass
+
+---
+
+def f(a, *-b, c): # ### `got '-', want ','`
+  pass
+
+---
+
 def pass(): ### "not an identifier"
   pass
 
@@ -45,6 +56,10 @@ f(*args, ) ### `got '\)', want argument`
 ---
 
 f(**kwargs, ) ### `got '\)', want argument`
+
+---
+
+f(a=1, *, b=2) ### `got ',', want primary`
 
 ---
 
@@ -109,7 +124,7 @@ _ = 0 == 1 == 2 ### "== does not associate with =="
 ---
 
 _ = (0 <= i) < n   # ok
-_ = 0 <= (i < n) # ok 
+_ = 0 <= (i < n) # ok
 _ = 0 <= i < n ### "<= does not associate with <"
 
 ---
@@ -152,14 +167,14 @@ load("a", x2="x", "y") # => positional-before-named arg check happens later (!)
 # 'load' is not an identifier
 load = 1 ### `got '=', want '\('`
 ---
-# 'load' is not an identifier   
+# 'load' is not an identifier
 f(load()) ### `got load, want primary`
 ---
-# 'load' is not an identifier   
+# 'load' is not an identifier
 def load(): ### `not an identifier`
   pass
 ---
-# 'load' is not an identifier   
+# 'load' is not an identifier
 def f(load): ### `not an identifier`
   pass
 ---


### PR DESCRIPTION
Following an undocumented feature of Skylark-in-Java,
which in turn follows Python3,
a function declaration may now include optional parameters
after the *args parameter:

	def f(a, b, c=1, *args, d=2, **kwargs)

The parameter d is a "keyword-only" parameter as it can
never by assigned from a positional parameter; all positional
arguments surplus to a, b, and c are put in a tuple and
assigned to args.

To declare a non-variadic function with keyword-only arguments,
the *args parameter is replaced by just *:

        def f(a, b, c=1, *, d=2, **kwargs)

The * parameter is not a real parameter; it just serves as a
separator between the parameter that may be specified positionally
and the keyword-only ones.

Fixes #61