### PR TITLE
internal/compile: prefer panic to log.Fatal

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1602,7 +1602,7 @@ func (fcomp *fcomp) args(call *syntax.CallExpr) (op Opcode, arg uint32) {
 
 	// TODO(adonovan): avoid this with a more flexible encoding.
 	if p >= 256 || n >= 256 {
-		log.Fatalf("%s: compiler error: too many arguments in call", call.Lparen)
+		panic(fmt.Sprintf("%s: compiler error: too many arguments in call", call.Lparen))
 	}
 
 	return CALL + Opcode(callmode), uint32(p<<8 | n)


### PR DESCRIPTION
One use case for starlark is execute user code.

It'd be better for there not to be an easy way for executing code
to take down the entire process, as log.Fatalf does.
panics can at least be locally recovered.

It'd obviously be better to fix the TODO,
but in the meantime, it's easy and safe to panic instead of exiting.