### PR TITLE
make break and continue work with while

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1086,7 +1086,9 @@ func (fcomp *fcomp) stmt(stmt syntax.Stmt) {
 		fcomp.ifelse(stmt.Cond, body, done)
 
 		fcomp.block = body
+		fcomp.loops = append(fcomp.loops, loop{break_: done, continue_: head})
 		fcomp.stmts(stmt.Body)
+		fcomp.loops = fcomp.loops[:len(fcomp.loops)-1]
 		fcomp.jump(head)
 
 		fcomp.block = done

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.starlark.net/internal/chunkedfile"
@@ -109,6 +110,7 @@ func TestExecFile(t *testing.T) {
 		"testdata/set.star",
 		"testdata/string.star",
 		"testdata/tuple.star",
+		"testdata/recursion.star",
 	} {
 		filename := filepath.Join(testdata, file)
 		for _, chunk := range chunkedfile.Read(filename, t) {
@@ -116,6 +118,9 @@ func TestExecFile(t *testing.T) {
 				"hasfields": starlark.NewBuiltin("hasfields", newHasFields),
 				"fibonacci": fib{},
 			}
+
+			resolve.AllowRecursion = option(chunk.Source, "recursion")
+
 			_, err := starlark.ExecFile(thread, filename, chunk.Source, predeclared)
 			switch err := err.(type) {
 			case *starlark.EvalError:
@@ -136,9 +141,14 @@ func TestExecFile(t *testing.T) {
 			default:
 				t.Error(err)
 			}
+			resolve.AllowRecursion = false
 			chunk.Done()
 		}
 	}
+}
+
+func option(chunk, name string) bool {
+	return strings.Contains(chunk, "option:"+name)
 }
 
 // A fib is an iterable value representing the infinite Fibonacci sequence.
@@ -471,74 +481,5 @@ def somefunc():
 
 	if globals["somefunc"].(*starlark.Function).Doc() != "somefunc doc" {
 		t.Fatal("docstring not found")
-	}
-}
-
-func TestRecursion(t *testing.T) {
-	resolve.AllowRecursion = true
-	defer func() { resolve.AllowRecursion = false }()
-
-	globals, err := starlark.ExecFile(&starlark.Thread{}, "rec.star", `
-def sum(n):
-	r = 0
-	while n > 0:
-		r += n
-		n -= 1
-	return r
-
-def fib(n):
-	if n <= 1:
-		return 1
-	return fib(n-1) + fib(n-2)
-
-fib5 = fib(5)
-sum5 = sum(5)
-`, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, _ := globals["fib5"].(starlark.Int).Int64(); got != 8 {
-		t.Fatalf("wrong value for fib5, got %d expected 8", got)
-	}
-	if got, _ := globals["sum5"].(starlark.Int).Int64(); got != 5+4+3+2+1 {
-		t.Fatalf("wrong value for sum5, got %d expected %d", got, 5+4+3+2+1)
-	}
-}
-
-func TestWhileBreakContinue(t *testing.T) {
-	resolve.AllowRecursion = true
-	defer func() { resolve.AllowRecursion = false }()
-
-	globals, err := starlark.ExecFile(&starlark.Thread{}, "while-break-continue.star", `
-def while_break(n):
-	r = 0
-	while n > 0:
-		if n == 5:
-			break
-		r += n
-		n -= 1
-	return r
-
-def while_continue(n):
-	r = 0
-	while n > 0:
-		if n % 2 == 0:
-			n -= 1
-			continue
-		r += n
-		n -= 1
-	return r
-	
-wb = while_break(10)
-wc = while_continue(10)
-`, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, _ := globals["wb"].(starlark.Int).Int64(); got != 40 {
-		t.Fatalf("wrong value for wb, got %d expected 40", got)
-	}
-	if got, _ := globals["wc"].(starlark.Int).Int64(); got != 25 {
-		t.Fatalf("wrong value for wc, got %d expected 25", got)
 	}
 }

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -497,10 +497,48 @@ sum5 = sum(5)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, _ := globals["fib5"].(starlark.Int).Int64(); int(got) != 8 {
-		t.Fatalf("wrong value for fib5, got %d expected 8\n", got)
+	if got, _ := globals["fib5"].(starlark.Int).Int64(); got != 8 {
+		t.Fatalf("wrong value for fib5, got %d expected 8", got)
 	}
-	if got, _ := globals["sum5"].(starlark.Int).Int64(); int(got) != 5+4+3+2+1 {
-		t.Fatalf("wrong value for sum5, got %d expected %d\n", got, 5+4+3+2+1)
+	if got, _ := globals["sum5"].(starlark.Int).Int64(); got != 5+4+3+2+1 {
+		t.Fatalf("wrong value for sum5, got %d expected %d", got, 5+4+3+2+1)
+	}
+}
+
+func TestWhileBreakContinue(t *testing.T) {
+	resolve.AllowRecursion = true
+	defer func() { resolve.AllowRecursion = false }()
+
+	globals, err := starlark.ExecFile(&starlark.Thread{}, "while-break-continue.star", `
+def while_break(n):
+	r = 0
+	while n > 0:
+		if n == 5:
+			break
+		r += n
+		n -= 1
+	return r
+
+def while_continue(n):
+	r = 0
+	while n > 0:
+		if n % 2 == 0:
+			n -= 1
+			continue
+		r += n
+		n -= 1
+	return r
+	
+wb = while_break(10)
+wc = while_continue(10)
+`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := globals["wb"].(starlark.Int).Int64(); got != 40 {
+		t.Fatalf("wrong value for wb, got %d expected 40", got)
+	}
+	if got, _ := globals["wc"].(starlark.Int).Int64(); got != 25 {
+		t.Fatalf("wrong value for wc, got %d expected 25", got)
 	}
 }

--- a/starlark/testdata/recursion.star
+++ b/starlark/testdata/recursion.star
@@ -1,0 +1,43 @@
+# Tests of Starlark recursion and while statement.
+
+# This is a "chunked" file: each "---" effectively starts a new file.
+
+# option:recursion
+
+load("assert.star", "assert")
+
+def sum(n):
+	r = 0
+	while n > 0:
+		r += n
+		n -= 1
+	return r
+
+def fib(n):
+	if n <= 1:
+		return 1
+	return fib(n-1) + fib(n-2)
+
+def while_break(n):
+	r = 0
+	while n > 0:
+		if n == 5:
+			break
+		r += n
+		n -= 1
+	return r
+
+def while_continue(n):
+	r = 0
+	while n > 0:
+		if n % 2 == 0:
+			n -= 1
+			continue
+		r += n
+		n -= 1
+	return r
+
+assert.eq(fib(5), 8)
+assert.eq(sum(5), 5+4+3+2+1)
+assert.eq(while_break(10), 40)
+assert.eq(while_continue(10), 25)


### PR DESCRIPTION
```
make break and continue work with while

break and continue should work inside a while loop instead of causing a
compiler panic.

```
