### PR TITLE
starlark: API additions for improved debugging

### DIFF
--- a/cmd/starlark/starlark.go
+++ b/cmd/starlark/starlark.go
@@ -71,6 +71,7 @@ func main() {
 			// Execute specified file.
 			filename = flag.Arg(0)
 		}
+		thread.Name = "exec " + filename
 		globals, err = starlark.ExecFile(thread, filename, src, nil)
 		if err != nil {
 			repl.PrintError(err)
@@ -78,6 +79,7 @@ func main() {
 		}
 	case flag.NArg() == 0:
 		fmt.Println("Welcome to Starlark (go.starlark.net)")
+		thread.Name = "REPL"
 		repl.REPL(thread, globals)
 	default:
 		log.Fatal("want at most one Starlark file name")

--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -64,7 +64,7 @@ func TestPlusFolding(t *testing.T) {
 			t.Errorf("#%d: %v", i, err)
 			continue
 		}
-		got := disassemble(Expr(expr, locals))
+		got := disassemble(Expr(expr, "<expr>", locals))
 		if test.want != got {
 			t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
 				test.src, got, test.want)

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -406,13 +406,14 @@ func idents(ids []*syntax.Ident) []Ident {
 }
 
 // Expr compiles an expression to a program consisting of a single toplevel function.
-func Expr(expr syntax.Expr, locals []*syntax.Ident) *Funcode {
+func Expr(expr syntax.Expr, name string, locals []*syntax.Ident) *Funcode {
+	pos := syntax.Start(expr)
 	stmts := []syntax.Stmt{&syntax.ReturnStmt{Result: expr}}
-	return File(stmts, locals, nil).Toplevel
+	return File(stmts, pos, name, locals, nil).Toplevel
 }
 
 // File compiles the statements of a file into a program.
-func File(stmts []syntax.Stmt, locals, globals []*syntax.Ident) *Program {
+func File(stmts []syntax.Stmt, pos syntax.Position, name string, locals, globals []*syntax.Ident) *Program {
 	pcomp := &pcomp{
 		prog: &Program{
 			Globals: idents(globals),
@@ -421,13 +422,7 @@ func File(stmts []syntax.Stmt, locals, globals []*syntax.Ident) *Program {
 		constants: make(map[interface{}]uint32),
 		functions: make(map[*Funcode]uint32),
 	}
-
-	var pos syntax.Position
-	if len(stmts) > 0 {
-		pos = syntax.Start(stmts[0])
-	}
-
-	pcomp.prog.Toplevel = pcomp.function("<toplevel>", pos, stmts, locals, nil)
+	pcomp.prog.Toplevel = pcomp.function(name, pos, stmts, locals, nil)
 
 	return pcomp.prog
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -215,7 +215,7 @@ func MakeLoad() func(thread *starlark.Thread, module string) (starlark.StringDic
 			cache[module] = nil
 
 			// Load it.
-			thread := &starlark.Thread{Load: thread.Load}
+			thread := &starlark.Thread{Name: "exec " + module, Load: thread.Load}
 			globals, err := starlark.ExecFile(thread, module, nil, nil)
 			e = &entry{globals, err}
 

--- a/starlark/debug.go
+++ b/starlark/debug.go
@@ -1,0 +1,18 @@
+package starlark
+
+// This file defines an experimental API for the debugging tools.
+// Some of these declarations expose details of internal packages.
+// (The debugger makes liberal use of exported fields of unexported types.)
+// Breaking changes may occur without notice.
+
+// Local returns the value of the i'th local variable.
+// It may be nil if not yet assigned.
+//
+// Local may be called only for frames whose Callable is a *Function (a
+// function defined by Starlark source code), and only while the frame
+// is active; it will panic otherwise.
+//
+// This function is provided only for debugging tools.
+//
+// THIS API IS EXPERIMENTAL AND MAY CHANGE WITHOUT NOTICE.
+func (fr *Frame) Local(i int) Value { return fr.locals[i] }

--- a/starlark/example_test.go
+++ b/starlark/example_test.go
@@ -28,6 +28,7 @@ squares = [x*x for x in range(10)]
 `
 
 	thread := &starlark.Thread{
+		Name:  "example",
 		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
 	}
 	predeclared := starlark.StringDict{
@@ -90,7 +91,7 @@ func ExampleThread_Load_sequential() {
 
 			// Load and initialize the module in a new thread.
 			data := fakeFilesystem[module]
-			thread := &starlark.Thread{Load: load}
+			thread := &starlark.Thread{Name: "exec " + module, Load: load}
 			globals, err := starlark.ExecFile(thread, module, data, nil)
 			e = &entry{globals, err}
 
@@ -100,7 +101,7 @@ func ExampleThread_Load_sequential() {
 		return e.globals, e.err
 	}
 
-	thread := &starlark.Thread{Load: load}
+	thread := &starlark.Thread{Name: "exec c.star", Load: load}
 	globals, err := load(thread, "c.star")
 	if err != nil {
 		log.Fatal(err)
@@ -250,6 +251,7 @@ func (c *cache) get(cc *cycleChecker, module string) (starlark.StringDict, error
 
 func (c *cache) doLoad(cc *cycleChecker, module string) (starlark.StringDict, error) {
 	thread := &starlark.Thread{
+		Name:  "exec " + module,
 		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
 		Load: func(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 			// Tunnel the cycle-checker state for this "thread of loading".

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -53,6 +53,8 @@ func call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
 		return nil, fr.errorf(fr.Position(), "%v", err)
 	}
 
+	fr.locals = locals // for debugger
+
 	if vmdebug {
 		fmt.Printf("Entering %s @ %s\n", f.Name, f.Position(0))
 		fmt.Printf("%d stack, %d locals\n", len(stack), len(locals))
@@ -561,5 +563,8 @@ loop:
 			err = fr.errorf(f.Position(savedpc), "%s", err.Error())
 		}
 	}
+
+	fr.locals = nil
+
 	return result, err
 }


### PR DESCRIPTION
This change adds a number of small features to improve debugging.
The actual debugger API will come in a later change.

- Thread.Name : an optional string field that describes the purpose of
  the thread, for use in debugging.
- (*Program).Filename: a method that reports the file of the program.
  Also, a String method that returns the same thing.
  Also, a test that it reports the correct location even for
  an empty file (a special case of the previous implementation).
- (*Frame).Local(i int): a method to return the value of a local
  variable of an active frame, such as one might use in debugger's
  stack trace.
- ExprFunc: creates a starlark.Function from a given expression,
  such as one might use in a debugger REPL.