### PR TITLE
starlark: HasUnary: allow extension types to define +x, -x, ~x

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -266,8 +266,10 @@ var stackEffect = [...]int8{
 	SLICE:       -3,
 	STAR:        -1,
 	TRUE:        +1,
+	UMINUS:      0,
 	UNIVERSAL:   +1,
 	UNPACK:      variableStackEffect,
+	UPLUS:       0,
 }
 
 func (op Opcode) String() string {

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -478,26 +478,20 @@ func setIndex(fr *Frame, x, y, z Value) error {
 
 // Unary applies a unary operator (+, -, ~, not) to its operand.
 func Unary(op syntax.Token, x Value) (Value, error) {
-	switch op {
-	case syntax.MINUS:
-		switch x := x.(type) {
-		case Int:
-			return zero.Sub(x), nil
-		case Float:
-			return -x, nil
-		}
-	case syntax.PLUS:
-		switch x.(type) {
-		case Int, Float:
-			return x, nil
-		}
-	case syntax.TILDE:
-		if xint, ok := x.(Int); ok {
-			return xint.Not(), nil
-		}
-	case syntax.NOT:
+	// The NOT operator is not customizable.
+	if op == syntax.NOT {
 		return !x.Truth(), nil
 	}
+
+	// Int, Float, and user-defined types
+	if x, ok := x.(HasUnary); ok {
+		// (nil, nil) => unhandled
+		y, err := x.Unary(op)
+		if y != nil || err != nil {
+			return y, err
+		}
+	}
+
 	return nil, fmt.Errorf("unknown unary op: %s %s", op, x.Type())
 }
 
@@ -832,6 +826,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 	}
 
 	// user-defined types
+	// (nil, nil) => unhandled
 	if x, ok := x.(HasBinary); ok {
 		z, err := x.Binary(op, y, Left)
 		if z != nil || err != nil {

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -62,6 +62,8 @@ var (
 	smallint   [256]big.Int
 	smallintok bool
 	zero, one  Int
+
+	_ HasUnary = Int{}
 )
 
 func init() {
@@ -72,6 +74,19 @@ func init() {
 
 	zero = MakeInt64(0)
 	one = MakeInt64(1)
+}
+
+// Unary implements the operations +int, -int, and ~int.
+func (i Int) Unary(op syntax.Token) (Value, error) {
+	switch op {
+	case syntax.MINUS:
+		return zero.Sub(i), nil
+	case syntax.PLUS:
+		return i, nil
+	case syntax.TILDE:
+		return i.Not(), nil
+	}
+	return nil, nil
 }
 
 // Int64 returns the value as an int64.


### PR DESCRIPTION
This mirrors the treatment of HasBinary.