### PR TITLE
starlark: fix a crash in UnpackArgs

### DIFF
--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -549,3 +549,34 @@ g(z=7)
 		t.Errorf("got <<%s>>, want <<%s>>", got, want)
 	}
 }
+
+type badType string
+
+func (b *badType) String() string        { return "badType" }
+func (b *badType) Type() string          { return "badType:" + string(*b) } // panics if b==nil
+func (b *badType) Truth() starlark.Bool  { return true }
+func (b *badType) Hash() (uint32, error) { return 0, nil }
+func (b *badType) Freeze()               {}
+
+var _ starlark.Value = new(badType)
+
+// TestUnpackErrorBadType verifies that the Unpack functions fail
+// gracefully when a parameter's default value's Type method panics.
+func TestUnpackErrorBadType(t *testing.T) {
+	for _, test := range []struct {
+		x    *badType
+		want string
+	}{
+		{new(badType), "got NoneType, want badType"},       // Starlark type name
+		{nil, "got NoneType, want *starlark_test.badType"}, // Go type name
+	} {
+		err := starlark.UnpackArgs("f", starlark.Tuple{starlark.None}, nil, "x", &test.x)
+		if err == nil {
+			t.Errorf("UnpackArgs succeeded unexpectedly")
+			continue
+		}
+		if !strings.Contains(err.Error(), test.want) {
+			t.Errorf("UnpackArgs error %q does not contain %q", err, test.want)
+		}
+	}
+}


### PR DESCRIPTION
When computing the error message, the parameter's Type method is
called. Mostly this works, but it may panic for a user-defined
type whose Type method doesn't work on the zero value.
Recover from the panic and show the Go type instead.

+ Test