### PR TITLE
syntax: improve REPL parsing

### DIFF
--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -208,6 +208,7 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		{"x ! 0", "foo.star:1:3: unexpected input character '!'"},
 		// github.com/google/starlark-go/issues/80
 		{"([{<>}])", "( [ { < > } ] ) EOF"},
+		{"f();", "f ( ) ; EOF"},
 	} {
 		got, err := scan(test.input)
 		if err != nil {

--- a/syntax/testdata/errors.star
+++ b/syntax/testdata/errors.star
@@ -138,7 +138,8 @@ _ = a + b not c ### "got identifier, want in"
 ---
 f(1+2 = 3) ### "keyword argument must have form name=expr"
 ---
-print(1, 2, 3 ### `got end of file, want '\)'`
+print(1, 2, 3
+### `got end of file, want '\)'`
 ---
 _ = a if b ### "conditional expression without else clause"
 ---


### PR DESCRIPTION
Previously, the REPL used a heuristic: it would consume a single line
and attempt to parse it; if that failed, it would consume lines up to
a blank line then parse the whole as a file. This was suboptimal for
various reasons: it failed to parse lines ending with an unfinished
multi-line string literal, for example, and it would prematurely
stop reading even while parentheses were open.

This change integrates the REPL with the scanner and parser (as Python
does). The REPL invokes a new parser entry point, ParseCompoundStmt,
that consumes only enough input to parse a compound statement, defined
as (a) blank line, (b) a semicolon-separated list of simple statements
all on one line, or (c) a complex statement such as def, if or for.

If the 'src' value provided to the scanner is a function of type
func() ([]byte, error), then the scanner will call it each time
it runs out of input.

Fixes #81