### PR TITLE
starlark: add support for addressing

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1505,7 +1505,7 @@ Operand = identifier
         | ListExpr | ListComp
         | DictExpr | DictComp
         | '(' [Expression] [,] ')'
-        | ('-' | '+') PrimaryExpr
+        | ('-' | '+' | '*' | '&') PrimaryExpr
         .
 
 DotSuffix   = '.' identifier .
@@ -1637,13 +1637,15 @@ Examples:
 
 ### Unary operators
 
-There are three unary operators, all appearing before their operand:
-`+`, `-`, `~`, and `not`.
+Starlark has the following unary operators, which all appear before their operand:
+`+`, `-`, `~`, `*`, `&`, and `not`.
 
 ```grammar {.good}
 UnaryExpr = '+' PrimaryExpr
           | '-' PrimaryExpr
           | '~' PrimaryExpr
+          | '*' PrimaryExpr
+          | '&' PrimaryExpr
           | 'not' Test
           .
 ```
@@ -1690,9 +1692,21 @@ The bitwise inversion of x is defined as -(x+1).
 ~0                              # -1
 ```
 
+The Go implementation of Starlark additionally has the unary
+prefix operators `*` and `&`, in order to support Stargo, which
+provides Starlark bindings for Go variables.
+These operators are not part of standard Starlark, and must be enabled
+in Go by the `-addressing` flag.
+
+The expression `*ptr` dereferences a pointer value, `ptr`.
+The expression `&expr` returns the address of an expression `expr`;
+it may be applied only to field selection or index expressions
+such as `&a[i]`, `&x.f`, or `&x[i].f[j].g`.
+Consult the Stargo documentation for more details.
+
 <b>Implementation note:</b>
 The parser in the Java implementation of Starlark does not accept unary
-`+` and `~` expressions.
+`+` and `~` expressions, nor `*` and `&` as unary operators.
 
 ### Binary operators
 

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func setOptions(src string) {
+	resolve.AllowAddressing = option(src, "addressing")
 	resolve.AllowBitwise = option(src, "bitwise")
 	resolve.AllowFloat = option(src, "float")
 	resolve.AllowGlobalReassign = option(src, "globalreassign")

--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -311,3 +311,47 @@ U = 1 # ok (legacy)
 # https://github.com/bazelbuild/starlark/starlark/issues/21
 def f(**kwargs): pass
 f(a=1, a=1) ### `keyword argument a repeated`
+
+---
+ptr = &U.x ### "dialect does not support address operations"
+
+x = *ptr ### "dialect does not support address operations"
+
+---
+# The & operator can be applied only to &x.f or &a[i].
+# option:addressing
+
+x, i, j = U
+
+def use(x): pass
+
+# ok
+use(&x.f)
+use(&x[i])
+use(&x.f[i].g[j])
+use(&(x.f[i].g[j]))
+use(&x[i])
+(&x.f).f = 1
+
+# bad
+use(&x)      ### `& operator can be applied only to &x.f or &a\[i\]`
+use(&(1+2))  ### `& operator can be applied only to &x.f or &a\[i\]`
+use(&x(x))   ### `& operator can be applied only to &x.f or &a\[i\]`
+
+
+---
+# The * operator dereferences a pointer, or creates a pointer type.
+# option:addressing
+
+ptr, f, int = U
+
+intptr = *int
+
+*ptr = 1
+y = *ptr
+
++ptr = 1 ### `can't assign to unaryexpr`
+
+f(*ptr) # ok, but means varargs, not dereference
+f(*ptr, 0) ### `argument may not follow \*args`
+f((*ptr), 0) # the workaround

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -154,7 +154,7 @@ loop:
 			stack[sp] = z
 			sp++
 
-		case compile.UPLUS, compile.UMINUS, compile.TILDE:
+		case compile.UPLUS, compile.UMINUS, compile.USTAR, compile.TILDE:
 			var unop syntax.Token
 			if op == compile.TILDE {
 				unop = syntax.TILDE
@@ -241,6 +241,7 @@ loop:
 			}
 			if kwargs != nil {
 				// Add key/value items from **kwargs dictionary.
+				// TODO: support any enumerable mapping, such a Go map.
 				dict, ok := kwargs.(*Dict)
 				if !ok {
 					err = fmt.Errorf("argument after ** must be a mapping, not %s", kwargs.Type())
@@ -546,6 +547,36 @@ loop:
 		case compile.UNIVERSAL:
 			stack[sp] = Universe[f.Prog.Names[arg]]
 			sp++
+
+		case compile.ADDRESS:
+			x := stack[sp-1]
+			v, ok := x.(Variable)
+			if !ok {
+				err = fmt.Errorf("%s value has no address", x.Type())
+				break loop
+			}
+			stack[sp-1] = v.Address()
+
+		case compile.VALUE:
+			x := stack[sp-1]
+			if v, ok := x.(Variable); ok {
+				x = v.Value()
+			}
+			stack[sp-1] = x
+
+		case compile.SETVALUE:
+			y := stack[sp-1]
+			x := stack[sp-2]
+			sp -= 2
+			v, ok := x.(Variable)
+			if !ok {
+				err = fmt.Errorf("cannot set value of %s", x.Type())
+				break loop
+			}
+			if err2 := v.SetValue(y); err2 != nil {
+				err = err2
+				break loop
+			}
 
 		default:
 			err = fmt.Errorf("unimplemented: %s", op)

--- a/starlark/testdata/address.star
+++ b/starlark/testdata/address.star
@@ -1,0 +1,13 @@
+# Minimal tests of addressing operators.
+# See Stargo for more comprehensive tests,
+# including variables of aggregate (struct/array) type.
+# option:addressing
+
+load("assert.star", "assert")
+
+assert.eq(addr.v, None)
+ptr = &addr.v
+assert.eq(type(ptr), "pointer")
+*ptr = 2
+assert.eq(addr.v, 2)
+assert.eq((*ptr), 2) # parens are required

--- a/starlark/var.go
+++ b/starlark/var.go
@@ -1,0 +1,81 @@
+package starlark
+
+// A Variable represents an addressable variable.
+//
+// Addressable variables are used only in Stargo,
+// which sets the resolve.AllowAddressing mode flag.
+//
+// An addressable variable supports three operations:
+// it contains a value, retrieved using the Value method;
+// it has an address (a value that denotes the variable's identity),
+// obtained using the Address method;
+// and its contents may be updated, using the SetValue method.
+//
+// Ordinary Starlark variables are not addressable, but they always
+// contain a reference. To perform an update such as x[i].f = 1, the
+// expression x[i] is evaluated, which yields a reference; then the
+// operation "set field .f to 1" is applied to the reference.
+// Similarly x.f[i] = 2 is executed by evaluating x.f to obtain a
+// reference, then applying the operation "set element i to 2" to it.
+// One may introduce a temporary variable for the reference without
+// changing the meaning of the statement, for example:
+//    tmp = x.f; tmp[i] = 2.
+//
+// By contrast, in Go, an expression such as x[i].f, where x is variable
+// of type array-of-structs, has a dual meaning. When it appears in an
+// ordinary expression, it means: find the variable x[i].f within x and
+// retrieve its value. But when it appears on the left side of an
+// assignment, as in x[i].f = 1, it means find the variable x[i].f
+// within x and update its value. It cannot be decomposed into two
+// operations tmp = x[i]; tmp.f = 2 without changing its meaning because
+// the first operation would make a copy of the variable x[i] and the
+// second would mutate the copy, not the original. It can be
+// decomposed only by using pointers, for example:
+//    ptr = &x[i]; ptr.f = 2.
+// A Go compiler implicitly does this decomposition using pointers when
+// it generates code for x[i].f on the left side of an assignment, or
+// as the operand of a &-operator. This is called "l-mode" (l for left),
+// opposed to r-mode code generation, in which the expression's value,
+// not its address, is needed.
+//
+// In order to support these operations on Go variables with the usual
+// semantics, in AllowAddressing mode the Starlark compiler, like a Go
+// compiler, generates different code for sequences of operations such
+// as x[i].f based on whether they appear on the left or right side of
+// an assignment (l-mode or r-mode).
+//
+// In both cases the compiler generates a sequence of calls to
+// Indexable.Index and HasAttrs.Attr for all but the last field/index
+// operation. The sequence is then followed by a call to one of the
+// following.
+// 1. Variable.Value, for an r-mode expression. If the operand is not a
+// Variable, it is assumed to be an ordinary Starlark value and is left
+// unchanged.
+// 2. SetIndexable.SetIndex, for an element update.
+// 3. HasSetField.SetField, for a field update;
+// 4. Variable.Address, for an explicit & operation.
+//
+// The *x operation may also yield a Variable (when x is a pointer), so
+// the Starlark compiler follows all *x operations by a call to
+// Variable.Value to yield the contents of the variable.
+//
+// Variables are technically Values but they are used only transiently
+// during one of the four above operations. They should generally not be
+// visible to Starlark programs. In Stargo, Variables used for globals
+// of a Go package such as http.DefaultServeMux are always accessed
+// using a dot expression.
+//
+// A concrete type that satisfies Variable could be represented by a
+// non-nil Go pointer, p: Address would return p; Value would return *p;
+// and SetValue(x) would execute *p=x. But the Variable is logically an
+// abstraction of the variable *p, not the pointer itself. An
+// alternative representation is reflect.Value, which is capable of
+// representing both ordinary values and addressable variables; see
+// reflect.Value.CanAddr.
+//
+type Variable interface {
+	Value
+	Address() Value
+	Value() Value
+	SetValue(Value) error
+}

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -590,7 +590,7 @@ var precedence [maxToken]int8
 
 // preclevels groups operators of equal precedence.
 // Comparisons are nonassociative; other binary operators associate to the left.
-// Unary MINUS, unary PLUS, and TILDE have higher precedence so are handled in parsePrimary.
+// Unary -/+/&/*/~ have higher precedence so are handled in parsePrimary.
 // See https://github.com/google/starlark-go/blob/master/doc/spec.md#binary-operators
 var preclevels = [...][]Token{
 	{OR},                                   // or
@@ -749,7 +749,7 @@ func (p *parser) parseArgs() []Expr {
 //          | '[' ...                    // list literal or comprehension
 //          | '{' ...                    // dict literal or comprehension
 //          | '(' ...                    // tuple or parenthesized expression
-//          | ('-'|'+'|'~') primary_with_suffix
+//          | ('-'|'+'|'~'|'&') primary_with_suffix
 func (p *parser) parsePrimary() Expr {
 	switch p.tok {
 	case IDENT:
@@ -795,7 +795,7 @@ func (p *parser) parsePrimary() Expr {
 			Rparen: rparen,
 		}
 
-	case MINUS, PLUS, TILDE: // unary
+	case MINUS, PLUS, TILDE, AMP, STAR: // unary
 		tok := p.tok
 		pos := p.nextToken()
 		x := p.parsePrimaryWithSuffix()

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -106,6 +106,9 @@ func TestExprParseTrees(t *testing.T) {
 			`(BinaryExpr X=a Op=and Y=(UnaryExpr Op=not X=b))`},
 		{`[e for x in y if cond1 if cond2]`,
 			`(Comprehension Body=e Clauses=((ForClause Vars=x X=y) (IfClause Cond=cond1) (IfClause Cond=cond2)))`}, // github.com/google/skylark/issues/53
+		{`&a[i].f[j]`, `(UnaryExpr Op=& X=(IndexExpr X=(DotExpr X=(IndexExpr X=a Y=i) Name=f) Y=j))`},
+		{`&x + y`, `(BinaryExpr X=(UnaryExpr Op=& X=x) Op=+ Y=y)`},
+		{`&x * y`, `(BinaryExpr X=(UnaryExpr Op=& X=x) Op=* Y=y)`},
 	} {
 		e, err := syntax.ParseExpr("foo.star", test.input, 0)
 		if err != nil {

--- a/syntax/testdata/errors.star
+++ b/syntax/testdata/errors.star
@@ -8,7 +8,7 @@ x = 1 +
 
 ---
 
-_ = *x ### `got '\*', want primary`
+_ = %x ### `got '%', want primary`
 
 ---
 


### PR DESCRIPTION
This change adds support for addressable variables and the unary
prefix operators * and &, which are needed to correctly support
Stargo (see wip-stargo branch), an upcoming extension that enables
Starlark bindings for Go types and variables.

Start reading at the starlark.Variable interface for background.

All new features are behind the -addressing flag.