### PR TITLE
starlark: fix parsing of int('0Oxa', 8)

### DIFF
--- a/starlark/testdata/int.star
+++ b/starlark/testdata/int.star
@@ -90,6 +90,24 @@ assert.fails(lambda: int("-0x12"), "invalid literal with base 10")
 assert.fails(lambda: int("0o123"), "invalid literal.*base 10")
 assert.fails(lambda: int("-0o123"), "invalid literal.*base 10")
 # int from string, explicit base
+assert.eq(int("0"), 0)
+assert.eq(int("00"), 0)
+assert.eq(int("0", base=10), 0)
+assert.eq(int("00", base=10), 0)
+assert.eq(int("0", base=8), 0)
+assert.eq(int("00", base=8), 0)
+assert.eq(int("-0"), 0)
+assert.eq(int("-00"), 0)
+assert.eq(int("-0", base=10), 0)
+assert.eq(int("-00", base=10), 0)
+assert.eq(int("-0", base=8), 0)
+assert.eq(int("-00", base=8), 0)
+assert.eq(int("+0"), 0)
+assert.eq(int("+00"), 0)
+assert.eq(int("+0", base=10), 0)
+assert.eq(int("+00", base=10), 0)
+assert.eq(int("+0", base=8), 0)
+assert.eq(int("+00", base=8), 0)
 assert.eq(int("11", base=9), 10)
 assert.eq(int("-11", base=9), -10)
 assert.eq(int("10011", base=2), 19)
@@ -131,6 +149,8 @@ assert.eq(int("+0o123", 0), +83)
 assert.eq(int("-0o123", 0), -83)
 assert.fails(lambda: int("0123", 0), "invalid literal.*base 0") # valid in Python 2.7
 assert.fails(lambda: int("-0123", 0), "invalid literal.*base 0")
+# github.com/google/starlark-go/issues/108
+assert.fails(lambda: int("0Oxa", 8), "invalid literal with base 8: 0Oxa")
 
 # bitwise union (int|int), intersection (int&int), XOR (int^int), unary not (~int),
 # left shift (int<<int), and right shift (int>>int).


### PR DESCRIPTION
The int function has been simplified, at the cost of an extra memory
allocation for negative numbers.

Fixes #108
