### PR TITLE
syntax: fix bug scanning ~=

### DIFF
--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -685,7 +685,7 @@ start:
 	// other punctuation
 	defer sc.endToken(val)
 	switch c {
-	case '=', '<', '>', '!', '+', '-', '%', '/', '&', '|', '^', '~': // possibly followed by '='
+	case '=', '<', '>', '!', '+', '-', '%', '/', '&', '|', '^': // possibly followed by '='
 		start := sc.pos
 		sc.readRune()
 		if sc.peekRune() == '=' {
@@ -765,18 +765,18 @@ start:
 			return PIPE
 		case '^':
 			return CIRCUMFLEX
-		case '~':
-			return TILDE
 		}
 		panic("unreachable")
 
-	case ':', ';': // single-char tokens (except comma)
+	case ':', ';', '~': // single-char tokens (except comma)
 		sc.readRune()
 		switch c {
 		case ':':
 			return COLON
 		case ';':
 			return SEMI
+		case '~':
+			return TILDE
 		}
 		panic("unreachable")
 

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -209,6 +209,8 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		// github.com/google/starlark-go/issues/80
 		{"([{<>}])", "( [ { < > } ] ) EOF"},
 		{"f();", "f ( ) ; EOF"},
+		// github.com/google/starlark-go/issues/107
+		{"~= ~= 5", "~ = ~ = 5 EOF"},
 	} {
 		got, err := scan(test.input)
 		if err != nil {


### PR DESCRIPTION
'~' is not like the operators that accept a following '='.

Fixes #107
