### PR TITLE
starlark: reject double-signs and misplaced signs in int

### DIFF
--- a/starlark/library.go
+++ b/starlark/library.go
@@ -660,6 +660,12 @@ func int_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 			}
 		}
 
+		// we explicitly handled sign above.
+		// if a sign remains, it is invalid.
+		if s != "" && (s[0] == '-' || s[0] == '+') {
+			goto invalid
+		}
+
 		// s has no sign or base prefix.
 		//
 		// int(x) permits arbitrary precision, unlike the scanner.

--- a/starlark/testdata/int.star
+++ b/starlark/testdata/int.star
@@ -151,6 +151,11 @@ assert.fails(lambda: int("0123", 0), "invalid literal.*base 0") # valid in Pytho
 assert.fails(lambda: int("-0123", 0), "invalid literal.*base 0")
 # github.com/google/starlark-go/issues/108
 assert.fails(lambda: int("0Oxa", 8), "invalid literal with base 8: 0Oxa")
+# follow-on bugs to issue 108
+assert.fails(lambda: int("--4"), "invalid literal with base 10: --4")
+assert.fails(lambda: int("++4"), "invalid literal with base 10: \+\+4")
+assert.fails(lambda: int("+-4"), "invalid literal with base 10: \+-4")
+assert.fails(lambda: int("0x-4", 16), "invalid literal with base 16: 0x-4")
 
 # bitwise union (int|int), intersection (int&int), XOR (int^int), unary not (~int),
 # left shift (int<<int), and right shift (int>>int).


### PR DESCRIPTION
The implementation of the int built-in explicitly handles signs
and then strips them. It then passes the remaining string to math/big.
However, math/big also accepts and handles signs. This led to
int("--4") returning 4 (somewhat correctly), and to
int("0x-4", 16) returning -4 (again, somewhat correctly).

Since we are handling sign explicitly, check for and complain about
signs in strings we are about to pass in to math/big.

Follow-up to #108 and #109.