### PR TITLE
starlark: correctly calculate len when slicing an empty range

### DIFF
--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -118,6 +118,8 @@ assert.fails(lambda: "one" in range(10), "requires integer.*not string")
 assert.true(4 not in range(4))
 assert.true(1e15 not in range(4)) # too big for int32
 assert.true(1e100 not in range(4)) # too big for int64
+# https://github.com/google/starlark-go/issues/116
+assert.fails(lambda: range(0, 0, 2)[:][0], "range index 0 out of range \[0:0\]")
 
 # list
 assert.eq(list("abc".elems()), ["a", "b", "c"])

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -192,7 +192,8 @@ type Sliceable interface {
 	Indexable
 	// For positive strides (step > 0), 0 <= start <= end <= n.
 	// For negative strides (step < 0), -1 <= end <= start < n.
-	// The caller must ensure that the start and end indices are valid.
+	// The caller must ensure that the start and end indices are valid
+	// and that step is non-zero.
 	Slice(start, end, step int) Value
 }
 


### PR DESCRIPTION
The range_ constructor correctly calculated a len of 0 when constructing
an empty range, but slicing a range did not; it calculated a len of 1.

This change unifies the length calculation.
This allow us to simplify range construction along the way.

Fixes #116