### PR TITLE
starlark: permit list.pop(i) for -n <= i < 0

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3472,14 +3472,19 @@ x                                       # ["a", "b", "c", "d", "e"]
 `L.pop([index])` removes and returns the last element of the list L, or,
 if the optional index is provided, at that index.
 
-`insert` fails if the index is negative or not less than the length of
-the list, of if the list is frozen or has active iterators.
+`pop` fails if the index is not valid for `L[i]`,
+or if the list is frozen or has active iterators.
 
 ```python
-x = [1, 2, 3]
-x.pop()                                 # 3
-x.pop()                                 # 2
-x                                       # [1]
+x = [1, 2, 3, 4, 5]
+x.pop()                                 # 5
+x                                       # [1, 2, 3, 4]
+x.pop(-2)                               # 3
+x                                       # [1, 2, 4]
+x.pop(-3)                               # 1
+x                                       # [2, 4]
+x.pop()                                 # 4
+x                                       # [2]
 ```
 
 <a id='list·remove'></a>

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -490,16 +490,24 @@ func getIndex(x, y Value) (Value, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s index: %s", x.Type(), err)
 		}
+		origI := i
 		if i < 0 {
 			i += n
 		}
 		if i < 0 || i >= n {
-			return nil, fmt.Errorf("%s index %d out of range [0:%d]",
-				x.Type(), i, n)
+			return nil, outOfRange(origI, n, x)
 		}
 		return x.Index(i), nil
 	}
 	return nil, fmt.Errorf("unhandled index operation %s[%s]", x.Type(), y.Type())
+}
+
+func outOfRange(i, n int, x Value) error {
+	if n == 0 {
+		return fmt.Errorf("index %d out of range: empty %s", i, x.Type())
+	} else {
+		return fmt.Errorf("%s index %d out of range [%d:%d]", x.Type(), i, -n, n-1)
+	}
 }
 
 // setIndex implements x[y] = z.
@@ -511,15 +519,17 @@ func setIndex(x, y, z Value) error {
 		}
 
 	case HasSetIndex:
+		n := x.Len()
 		i, err := AsInt32(y)
 		if err != nil {
 			return err
 		}
+		origI := i
 		if i < 0 {
-			i += x.Len()
+			i += n
 		}
-		if i < 0 || i >= x.Len() {
-			return fmt.Errorf("%s index %d out of range [0:%d]", x.Type(), i, x.Len())
+		if i < 0 || i >= n {
+			return outOfRange(origI, n, x)
 		}
 		return x.SetIndex(i, z)
 

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1439,18 +1439,23 @@ func list_remove(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value,
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·pop
 func list_pop(fnname string, recv Value, args Tuple, kwargs []Tuple) (Value, error) {
 	list := recv.(*List)
-	index := list.Len() - 1
-	if err := UnpackPositionalArgs(fnname, args, kwargs, 0, &index); err != nil {
+	n := list.Len()
+	i := n - 1
+	if err := UnpackPositionalArgs(fnname, args, kwargs, 0, &i); err != nil {
 		return nil, err
 	}
-	if index < 0 || index >= list.Len() {
-		return nil, fmt.Errorf("pop: index %d is out of range [0:%d]", index, list.Len())
+	origI := i
+	if i < 0 {
+		i += n
+	}
+	if i < 0 || i >= n {
+		return nil, outOfRange(origI, n, list)
 	}
 	if err := list.checkMutable("pop from"); err != nil {
 		return nil, err
 	}
-	res := list.elems[index]
-	list.elems = append(list.elems[:index], list.elems[index+1:]...)
+	res := list.elems[i]
+	list.elems = append(list.elems[:i], list.elems[i+1:]...)
 	return res, nil
 }
 

--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -119,7 +119,7 @@ assert.true(4 not in range(4))
 assert.true(1e15 not in range(4)) # too big for int32
 assert.true(1e100 not in range(4)) # too big for int64
 # https://github.com/google/starlark-go/issues/116
-assert.fails(lambda: range(0, 0, 2)[:][0], "range index 0 out of range \[0:0\]")
+assert.fails(lambda: range(0, 0, 2)[:][0], "index 0 out of range: empty range")
 
 # list
 assert.eq(list("abc".elems()), ["a", "b", "c"])

--- a/starlark/testdata/list.star
+++ b/starlark/testdata/list.star
@@ -16,14 +16,14 @@ assert.true(not [])
 
 # indexing, x[i]
 abc = list("abc".elems())
-assert.fails(lambda : abc[-4], "list index -1 out of range \\[0:3\\]")
+assert.fails(lambda : abc[-4], "list index -4 out of range \[-3:2]")
 assert.eq(abc[-3], "a")
 assert.eq(abc[-2], "b")
 assert.eq(abc[-1], "c")
 assert.eq(abc[0], "a")
 assert.eq(abc[1], "b")
 assert.eq(abc[2], "c")
-assert.fails(lambda : abc[3], "list index 3 out of range \\[0:3\\]")
+assert.fails(lambda : abc[3], "list index 3 out of range \[-3:2]")
 
 # x[i] = ...
 x3 = [0, 1, 2]
@@ -98,12 +98,18 @@ listcompblock()
 
 # list.pop
 x4 = [1, 2, 3, 4, 5]
+assert.fails(lambda : x4.pop(-6), "index -6 out of range \[-5:4]")
+assert.fails(lambda : x4.pop(6), "index 6 out of range \[-5:4]")
 assert.eq(x4.pop(), 5)
 assert.eq(x4, [1, 2, 3, 4])
 assert.eq(x4.pop(1), 2)
 assert.eq(x4, [1, 3, 4])
 assert.eq(x4.pop(0), 1)
 assert.eq(x4, [3, 4])
+assert.eq(x4.pop(-2), 3)
+assert.eq(x4, [4])
+assert.eq(x4.pop(-1), 4)
+assert.eq(x4, [])
 
 # TODO(adonovan): test uses of list as sequence
 # (for loop, comprehension, library functions).


### PR DESCRIPTION
Also, improve out-of-range error messages.

Fixes #119