### PR TITLE
resolve: report likely identifier misspelling

### DIFF
--- a/internal/spell/spell.go
+++ b/internal/spell/spell.go
@@ -1,16 +1,16 @@
-package starlark
-
-// This file defines a simple spell checker for use in attribute errors
-// ("no such field .foo; did you mean .food?")
+// Package spell file defines a simple spelling checker for use in attribute errors
+// such as "no such field .foo; did you mean .food?".
+package spell
 
 import (
 	"strings"
 	"unicode"
 )
 
-// nearest returns the element of candidates
-// nearest to x using the Levenshtein metric.
-func nearest(x string, candidates []string) string {
+// Nearest returns the element of candidates
+// nearest to x using the Levenshtein metric,
+// or "" if none were promising.
+func Nearest(x string, candidates []string) string {
 	// Ignore underscores and case when matching.
 	fold := func(s string) string {
 		return strings.Map(func(r rune) rune {
@@ -62,6 +62,10 @@ func levenshtein(x, y string, max int) int {
 		return len(y)
 	}
 
+	if d := abs(len(x) - len(y)); d > max {
+		return d // excessive length divergence
+	}
+
 	row := make([]int, len(y)+1)
 	for i := range row {
 		row[i] = i
@@ -86,10 +90,26 @@ func levenshtein(x, y string, max int) int {
 	return row[len(y)]
 }
 
+func b2i(b bool) int {
+	if b {
+		return 1
+	} else {
+		return 0
+	}
+}
+
 func min(x, y int) int {
 	if x < y {
 		return x
 	} else {
 		return y
+	}
+}
+
+func abs(x int) int {
+	if x >= 0 {
+		return x
+	} else {
+		return -x
 	}
 }

--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -310,3 +310,16 @@ U = 1 # ok (legacy)
 # https://github.com/bazelbuild/starlark/starlark/issues/21
 def f(**kwargs): pass
 f(a=1, a=1) ### `keyword argument a repeated`
+
+
+---
+# spelling
+
+print = U
+
+hello = 1
+print(hollo) ### `undefined: hollo \(did you mean hello\?\)`
+
+def f(abc):
+   print(abd) ### `undefined: abd \(did you mean abc\?\)`
+   print(goodbye) ### `undefined: goodbye$`

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	"go.starlark.net/internal/compile"
+	"go.starlark.net/internal/spell"
 	"go.starlark.net/resolve"
 	"go.starlark.net/syntax"
 )
@@ -452,36 +453,44 @@ func listExtend(x *List, y Iterable) {
 
 // getAttr implements x.dot.
 func getAttr(x Value, name string) (Value, error) {
-	var hint string
-
-	// field or method?
-	if x, ok := x.(HasAttrs); ok {
-		if v, err := x.Attr(name); v != nil || err != nil {
-			return v, err
-		}
-
-		// check spelling
-		if n := nearest(name, x.AttrNames()); n != "" {
-			hint = fmt.Sprintf(" (did you mean .%s?)", n)
-		}
+	hasAttr, ok := x.(HasAttrs)
+	if !ok {
+		return nil, fmt.Errorf("%s has no .%s field or method", x.Type(), name)
 	}
 
-	return nil, fmt.Errorf("%s has no .%s field or method%s", x.Type(), name, hint)
+	var errmsg string
+	v, err := hasAttr.Attr(name)
+	if err == nil {
+		if v != nil {
+			return v, nil // success
+		}
+		// (nil, nil) => generic error
+		errmsg = fmt.Sprintf("%s has no .%s field or method", x.Type(), name)
+	} else if nsa, ok := err.(NoSuchAttrError); ok {
+		errmsg = string(nsa)
+	} else {
+		return nil, err // return error as is
+	}
+
+	// add spelling hint
+	if n := spell.Nearest(name, hasAttr.AttrNames()); n != "" {
+		errmsg = fmt.Sprintf("%s (did you mean .%s?)", errmsg, n)
+	}
+
+	return nil, fmt.Errorf("%s", errmsg)
 }
 
 // setField implements x.name = y.
 func setField(x Value, name string, y Value) error {
 	if x, ok := x.(HasSetField); ok {
-		if err := x.SetField(name, y); err != ErrNoSuchField {
-			return err
+		err := x.SetField(name, y)
+		if _, ok := err.(NoSuchAttrError); ok {
+			// No such field: check spelling.
+			if n := spell.Nearest(name, x.AttrNames()); n != "" {
+				err = fmt.Errorf("%s (did you mean .%s?)", err, n)
+			}
 		}
-
-		// No such field: check spelling.
-		var hint string
-		if n := nearest(name, x.AttrNames()); n != "" {
-			hint = fmt.Sprintf(" (did you mean .%s?)", n)
-		}
-		return fmt.Errorf("%s has no .%s field%s", x.Type(), name, hint)
+		return err
 	}
 
 	return fmt.Errorf("can't assign to .%s field of %s", name, x.Type())

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -226,8 +226,8 @@ func (hf *hasfields) SetField(name string, val starlark.Value) error {
 	if hf.frozen {
 		return fmt.Errorf("cannot set field on a frozen hasfields")
 	}
-	if strings.HasPrefix(name, "no") {
-		return starlark.ErrNoSuchField // for testing
+	if strings.HasPrefix(name, "no") { // for testing
+		return starlark.NoSuchAttrError(fmt.Sprintf("no .%s field", name))
 	}
 	hf.attrs[name] = val
 	return nil

--- a/starlark/testdata/module.star
+++ b/starlark/testdata/module.star
@@ -6,3 +6,12 @@ assert.eq(type(assert), "module")
 assert.eq(str(assert), '<module "assert">')
 assert.eq(dir(assert), ["contains", "eq", "fail", "fails", "lt", "ne", "true"])
 assert.fails(lambda : {assert: None}, "unhashable: module")
+
+def assignfield():
+    assert.foo = None
+
+assert.fails(assignfield, "can't assign to .foo field of module")
+
+# no such field
+assert.fails(lambda : assert.nonesuch, "module has no .nonesuch field or method$")
+assert.fails(lambda : assert.falls, "module has no .falls field or method .did you mean .fails\?")

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -68,7 +68,6 @@ package starlark // import "go.starlark.net/starlark"
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -321,19 +320,21 @@ var (
 
 // A HasSetField value has fields that may be written by a dot expression (x.f = y).
 //
-// An implementation of SetField may return ErrNoSuchField,
-// in which case the runtime will report a better error that
-// includes the field name and warns of possible misspelling.
+// An implementation of SetField may return a NoSuchAttrError,
+// in which case the runtime may augment the error message to
+// warn of possible misspelling.
 type HasSetField interface {
 	HasAttrs
 	SetField(name string, val Value) error
 }
 
-// ErrNoSuchField may be returned by an implementation of
-// HasSetField.SetField to indicate that no such field exists.
-// In that case the runtime will report a better error that
-// includes the field name and warns of possible misspelling.
-var ErrNoSuchField = errors.New("no such field")
+// A NoSuchAttrError may be returned by an implementation of
+// HasAttrs.Attr or HasSetField.SetField to indicate that no such field
+// exists. In that case the runtime may augment the error message to
+// warn of possible misspelling.
+type NoSuchAttrError string
+
+func (e NoSuchAttrError) Error() string { return string(e) }
 
 // NoneType is the type of None.  Its only legal value is None.
 // (We represent it as a number, not struct{}, so that None may be constant.)

--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -258,7 +258,8 @@ func (s *Struct) Attr(name string) (starlark.Value, error) {
 	if s.constructor != Default {
 		ctor = s.constructor.String() + " "
 	}
-	return nil, fmt.Errorf("%sstruct has no .%s attribute", ctor, name)
+	return nil, starlark.NoSuchAttrError(
+		fmt.Sprintf("%sstruct has no .%s attribute", ctor, name))
 }
 
 func writeProtoStruct(out *bytes.Buffer, depth int, s *Struct) error {


### PR DESCRIPTION
Move spell.go to internal/spell package to enable re-use.

Unfortunately the resolver API provides no way for it to enumerate
predeclared and universe, so these candidates are missing.