### PR TITLE
starlark: make built-ins require True/False for bool params

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1066,6 +1066,12 @@ in the environment of a specific module.
 Except where noted, built-in functions accept only positional arguments.
 The parameter names serve merely as documentation.
 
+Most built-in functions that have a Boolean parameter require its
+argument to be `True` or `False`. Unlike `if` statements, other values
+are not implicitly converted to their truth value and instead cause a
+dynamic error.
+
+
 ## Name binding and variables
 
 After a Starlark file is parsed, but before its execution begins, the
@@ -2846,12 +2852,12 @@ application-specific dialect) without breaking existing programs.
 
 ### any
 
-`any(x)` returns `True` if any element of the iterable sequence x is true.
+`any(x)` returns `True` if any element of the iterable sequence x has a truth value of true.
 If the iterable is empty, it returns `False`.
 
 ### all
 
-`all(x)` returns `False` if any element of the iterable sequence x is false.
+`all(x)` returns `False` if any element of the iterable sequence x has a truth-value of false.
 If the iterable is empty, it returns `True`.
 
 ### bool

--- a/starlark/testdata/bool.star
+++ b/starlark/testdata/bool.star
@@ -1,4 +1,5 @@
 # Tests of Starlark 'bool'
+# option:float
 
 load("assert.star", "assert")
 
@@ -46,3 +47,10 @@ assert.fails(lambda : 0 or "" or [] or 0 or 1 // 0, "division by zero")
 assert.eq(1 and "a" and [1] and 123, 123)
 assert.eq(1 and "a" and [1] and 0 and 1 // 0, 0)
 assert.fails(lambda : 1 and "a" and [1] and 123 and 1 // 0, "division by zero")
+
+# Built-ins that want a bool want an actual bool, not a truth value.
+# See github.com/bazelbuild/starlark/issues/30
+assert.eq(''.splitlines(True), [''])
+assert.fails(lambda: ''.splitlines(1), 'got int, want bool')
+assert.fails(lambda: ''.splitlines("hello"), 'got string, want bool')
+assert.fails(lambda: ''.splitlines(0.0), 'got float, want bool')


### PR DESCRIPTION
Previously they would accept any value and use it truth-value.
Python permits any bool or int, more by historical accident than design.

This change may cause existing programs to have dynamic errors!

Updates bazelbuild/starlark#30