### PR TITLE
Support required keyword-only parameters

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -941,7 +941,7 @@ f(1, 2, 3, 4)           # (1, 2, (3, 4))
 
 <b>Keyword-variadic functions:</b> Some functions allow callers to
 provide an arbitrary sequence of `name=value` keyword arguments.
-A function definition may include a final _keyworded arguments_ or
+A function definition may include a final _keyword arguments_ or
 _kwargs_ parameter, indicated by a double-star preceding the parameter
 name: `**kwargs`.
 Any surplus named arguments that do not correspond to named parameters
@@ -959,8 +959,8 @@ f(x=2, y=1, z=3)        # (2, 1, {"z": 3})
 It is a static error if any two parameters of a function have the same name.
 
 Just as a function definition may accept an arbitrary number of
-positional or keyworded arguments, a function call may provide an
-arbitrary number of positional or keyworded arguments supplied by a
+positional or named arguments, a function call may provide an
+arbitrary number of positional or named arguments supplied by a
 list or dictionary:
 
 ```python
@@ -2529,11 +2529,27 @@ name preceded by a `*`.  This is the called the _varargs_ parameter,
 and it accumulates surplus positional arguments specified by a call.
 It is conventionally named `*args`.
 
-The varargs parameter may be followed by zero or more optional
-parameters, again of the form `name=expression`, but these optional parameters
-differ from earlier ones in that they are "keyword-only":
-a call must provide their values as keyword arguments,
-not positional ones.
+The varargs parameter may be followed by zero or more
+parameters, again of the forms `name` or `name=expression`,
+but these parameters differ from earlier ones in that they are
+_keyword-only_: if a call provides their values, it must do so as
+keyword arguments, not positional ones.
+
+```python
+def f(a, *, b=2, c):
+  print(a, b, c)
+
+f(1)                    # error: function f missing 1 argument (c)
+f(1, 3)                 # error: function f accepts 1 positional argument (2 given)
+f(1, c=3)               # "1 2 3"
+
+def g(a, *args, b=2, c):
+  print(a, b, c, args)
+
+g(1, 3)                 # error: function g missing 1 argument (c)
+g(1, 4, c=3)            # "1 2 3 (4,)"
+
+```
 
 A non-variadic function may also declare keyword-only parameters,
 by using a bare `*` in place of the `*args` parameter.

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -775,7 +775,7 @@ func (r *resolver) function(pos syntax.Position, name string, function *syntax.F
 			if starStar != nil {
 				r.errorf(param.NamePos, "required parameter may not follow **%s", starStar.Name)
 			} else if star != nil {
-				r.errorf(param.NamePos, "required parameter may not follow * parameter")
+				numKwonlyParams++
 			} else if seenOptional {
 				r.errorf(param.NamePos, "required parameter may not follow optional")
 			}
@@ -827,7 +827,7 @@ func (r *resolver) function(pos syntax.Position, name string, function *syntax.F
 			}
 			function.HasVarargs = true
 		} else if numKwonlyParams == 0 {
-			r.errorf(star.OpPos, "bare * must be followed by optional parameters")
+			r.errorf(star.OpPos, "bare * must be followed by keyword-only parameters")
 		}
 	}
 	if starStar != nil {

--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -233,27 +233,27 @@ def h(**kwargs1, **kwargs2): ### `multiple \*\* parameters not allowed`
 ---
 # Only keyword-only params and **kwargs may follow *args in a declaration.
 
-def f(*args, x): ### `required parameter may not follow \* parameter`
+def f(*args, x): # ok
   pass
 
 def g(*args1, *args2): ### `multiple \* parameters not allowed`
   pass
 
-def h(*, ### `bare \* must be followed by optional parameters`
+def h(*, ### `bare \* must be followed by keyword-only parameters`
       *): ### `multiple \* parameters not allowed`
   pass
 
 def i(*args, *): ### `multiple \* parameters not allowed`
   pass
 
-def j(*,      ### `bare \* must be followed by optional parameters`
+def j(*,      ### `bare \* must be followed by keyword-only parameters`
       *args): ### `multiple \* parameters not allowed`
   pass
 
-def k(*, **kwargs): ### `bare \* must be followed by optional parameters`
+def k(*, **kwargs): ### `bare \* must be followed by keyword-only parameters`
   pass
 
-def l(*): ### `bare \* must be followed by optional parameters`
+def l(*): ### `bare \* must be followed by keyword-only parameters`
   pass
 
 def m(*args, a=1, **kwargs): # ok

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -272,6 +272,10 @@ def g(a, b=42, *args, c=123, **kwargs):
 	return a, b, args, c, kwargs
 def h(a, b=42, *, c=123, **kwargs):
 	return a, b, c, kwargs
+def i(a, b=42, *, c, d=123, e, **kwargs):
+	return a, b, c, d, e, kwargs
+def j(a, b=42, *args, c, d=123, e, **kwargs):
+	return a, b, args, c, d, e, kwargs
 `
 
 	thread := new(starlark.Thread)
@@ -281,38 +285,51 @@ def h(a, b=42, *, c=123, **kwargs):
 	}
 
 	for _, test := range []struct{ src, want string }{
+		// a()
 		{`a()`, `None`},
-		{`a(1)`, `function a takes no arguments (1 given)`},
-		{`b()`, `function b takes exactly 2 positional arguments (0 given)`},
-		{`b(1)`, `function b takes exactly 2 positional arguments (1 given)`},
+		{`a(1)`, `function a accepts no arguments (1 given)`},
+
+		// b(a, b)
+		{`b()`, `function b missing 2 arguments (a, b)`},
+		{`b(1)`, `function b missing 1 argument (b)`},
+		{`b(a=1)`, `function b missing 1 argument (b)`},
+		{`b(b=1)`, `function b missing 1 argument (a)`},
 		{`b(1, 2)`, `(1, 2)`},
 		{`b`, `<function b>`}, // asserts that b's parameter b was treated as a local variable
-		{`b(1, 2, 3)`, `function b takes exactly 2 positional arguments (3 given)`},
+		{`b(1, 2, 3)`, `function b accepts 2 positional arguments (3 given)`},
 		{`b(1, b=2)`, `(1, 2)`},
-		{`b(1, a=2)`, `function b got multiple values for keyword argument "a"`},
+		{`b(1, a=2)`, `function b got multiple values for parameter "a"`},
 		{`b(1, x=2)`, `function b got an unexpected keyword argument "x"`},
 		{`b(a=1, b=2)`, `(1, 2)`},
 		{`b(b=1, a=2)`, `(2, 1)`},
 		{`b(b=1, a=2, x=1)`, `function b got an unexpected keyword argument "x"`},
 		{`b(x=1, b=1, a=2)`, `function b got an unexpected keyword argument "x"`},
-		{`c()`, `function c takes at least 1 positional argument (0 given)`},
+
+		// c(a, b=42)
+		{`c()`, `function c missing 1 argument (a)`},
 		{`c(1)`, `(1, 42)`},
 		{`c(1, 2)`, `(1, 2)`},
-		{`c(1, 2, 3)`, `function c takes at most 2 positional arguments (3 given)`},
+		{`c(1, 2, 3)`, `function c accepts at most 2 positional arguments (3 given)`},
 		{`c(1, b=2)`, `(1, 2)`},
-		{`c(1, a=2)`, `function c got multiple values for keyword argument "a"`},
+		{`c(1, a=2)`, `function c got multiple values for parameter "a"`},
 		{`c(a=1, b=2)`, `(1, 2)`},
 		{`c(b=1, a=2)`, `(2, 1)`},
+
+		// d(*args)
 		{`d()`, `()`},
 		{`d(1)`, `(1,)`},
 		{`d(1, 2)`, `(1, 2)`},
 		{`d(1, 2, k=3)`, `function d got an unexpected keyword argument "k"`},
 		{`d(args=[])`, `function d got an unexpected keyword argument "args"`},
+
+		// e(**kwargs)
 		{`e()`, `{}`},
-		{`e(1)`, `function e takes exactly 0 positional arguments (1 given)`},
+		{`e(1)`, `function e accepts 0 positional arguments (1 given)`},
 		{`e(k=1)`, `{"k": 1}`},
 		{`e(kwargs={})`, `{"kwargs": {}}`},
-		{`f()`, `function f takes at least 1 positional argument (0 given)`},
+
+		// f(a, b=42, *args, **kwargs)
+		{`f()`, `function f missing 1 argument (a)`},
 		{`f(0)`, `(0, 42, (), {})`},
 		{`f(0)`, `(0, 42, (), {})`},
 		{`f(0, 1)`, `(0, 1, (), {})`},
@@ -320,34 +337,69 @@ def h(a, b=42, *, c=123, **kwargs):
 		{`f(0, 1, 2, 3)`, `(0, 1, (2, 3), {})`},
 		{`f(a=0)`, `(0, 42, (), {})`},
 		{`f(0, b=1)`, `(0, 1, (), {})`},
-		{`f(0, a=1)`, `function f got multiple values for keyword argument "a"`},
+		{`f(0, a=1)`, `function f got multiple values for parameter "a"`},
 		{`f(0, b=1, c=2)`, `(0, 1, (), {"c": 2})`},
 		{`f(0, 1, x=2, *[3, 4], y=5, **dict(z=6))`, // github.com/google/skylark/issues/135
 			`(0, 1, (3, 4), {"x": 2, "y": 5, "z": 6})`},
 
-		{`g()`, `function g takes at least 1 positional argument (0 given)`},
+		// g(a, b=42, *args, c=123, **kwargs)
+		{`g()`, `function g missing 1 argument (a)`},
 		{`g(0)`, `(0, 42, (), 123, {})`},
 		{`g(0, 1)`, `(0, 1, (), 123, {})`},
 		{`g(0, 1, 2)`, `(0, 1, (2,), 123, {})`},
 		{`g(0, 1, 2, 3)`, `(0, 1, (2, 3), 123, {})`},
 		{`g(a=0)`, `(0, 42, (), 123, {})`},
 		{`g(0, b=1)`, `(0, 1, (), 123, {})`},
-		{`g(0, a=1)`, `function g got multiple values for keyword argument "a"`},
+		{`g(0, a=1)`, `function g got multiple values for parameter "a"`},
 		{`g(0, b=1, c=2, d=3)`, `(0, 1, (), 2, {"d": 3})`},
 		{`g(0, 1, x=2, *[3, 4], y=5, **dict(z=6))`,
 			`(0, 1, (3, 4), 123, {"x": 2, "y": 5, "z": 6})`},
 
-		{`h()`, `function h takes at least 1 positional argument (0 given)`},
-		{`h(0)`, `(0, 42, 123, {})`},
+		// h(a, b=42, *, c=123, **kwargs)
+		{`h()`, `function h missing 1 argument (a)`},
 		{`h(0)`, `(0, 42, 123, {})`},
 		{`h(0, 1)`, `(0, 1, 123, {})`},
-		{`h(0, 1, 2)`, `function h takes at most 2 positional arguments (3 given)`},
+		{`h(0, 1, 2)`, `function h accepts at most 2 positional arguments (3 given)`},
 		{`h(a=0)`, `(0, 42, 123, {})`},
 		{`h(0, b=1)`, `(0, 1, 123, {})`},
-		{`h(0, a=1)`, `function h got multiple values for keyword argument "a"`},
+		{`h(0, a=1)`, `function h got multiple values for parameter "a"`},
 		{`h(0, b=1, c=2)`, `(0, 1, 2, {})`},
 		{`h(0, b=1, d=2)`, `(0, 1, 123, {"d": 2})`},
 		{`h(0, b=1, c=2, d=3)`, `(0, 1, 2, {"d": 3})`},
+		{`h(0, b=1, c=2, d=3)`, `(0, 1, 2, {"d": 3})`},
+
+		// i(a, b=42, *, c, d=123, e, **kwargs)
+		{`i()`, `function i missing 3 arguments (a, c, e)`},
+		{`i(0)`, `function i missing 2 arguments (c, e)`},
+		{`i(0, 1)`, `function i missing 2 arguments (c, e)`},
+		{`i(0, 1, 2)`, `function i accepts at most 2 positional arguments (3 given)`},
+		{`i(0, 1, e=2)`, `function i missing 1 argument (c)`},
+		{`i(0, 1, 2, 3)`, `function i accepts at most 2 positional arguments (4 given)`},
+		{`i(a=0)`, `function i missing 2 arguments (c, e)`},
+		{`i(0, b=1)`, `function i missing 2 arguments (c, e)`},
+		{`i(0, a=1)`, `function i got multiple values for parameter "a"`},
+		{`i(0, b=1, c=2)`, `function i missing 1 argument (e)`},
+		{`i(0, b=1, d=2)`, `function i missing 2 arguments (c, e)`},
+		{`i(0, b=1, c=2, d=3)`, `function i missing 1 argument (e)`},
+		{`i(0, b=1, c=2, d=3, e=4)`, `(0, 1, 2, 3, 4, {})`},
+		{`i(0, 1, b=1, c=2, d=3, e=4)`, `function i got multiple values for parameter "b"`},
+
+		// j(a, b=42, *args, c, d=123, e, **kwargs)
+		{`j()`, `function j missing 3 arguments (a, c, e)`},
+		{`j(0)`, `function j missing 2 arguments (c, e)`},
+		{`j(0, 1)`, `function j missing 2 arguments (c, e)`},
+		{`j(0, 1, 2)`, `function j missing 2 arguments (c, e)`},
+		{`j(0, 1, e=2)`, `function j missing 1 argument (c)`},
+		{`j(0, 1, 2, 3)`, `function j missing 2 arguments (c, e)`},
+		{`j(a=0)`, `function j missing 2 arguments (c, e)`},
+		{`j(0, b=1)`, `function j missing 2 arguments (c, e)`},
+		{`j(0, a=1)`, `function j got multiple values for parameter "a"`},
+		{`j(0, b=1, c=2)`, `function j missing 1 argument (e)`},
+		{`j(0, b=1, d=2)`, `function j missing 2 arguments (c, e)`},
+		{`j(0, b=1, c=2, d=3)`, `function j missing 1 argument (e)`},
+		{`j(0, b=1, c=2, d=3, e=4)`, `(0, 1, (), 2, 3, 4, {})`},
+		{`j(0, 1, b=1, c=2, d=3, e=4)`, `function j got multiple values for parameter "b"`},
+		{`j(0, 1, 2, c=3, e=4)`, `(0, 1, (2,), 3, 123, 4, {})`},
 	} {
 		var got string
 		if v, err := starlark.Eval(thread, "<expr>", test.src, globals); err != nil {

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -200,6 +200,10 @@ loop:
 			stack[sp] = False
 			sp++
 
+		case compile.MANDATORY:
+			stack[sp] = mandatory{}
+			sp++
+
 		case compile.JMP:
 			pc = arg
 
@@ -559,3 +563,13 @@ loop:
 
 	return result, err
 }
+
+// mandatory is a sentinel value used in a function's defaults tuple
+// to indicate that a (keyword-only) parameter is mandatory.
+type mandatory struct{}
+
+func (mandatory) String() string        { return "mandatory" }
+func (mandatory) Type() string          { return "mandatory" }
+func (mandatory) Freeze()               {} // immutable
+func (mandatory) Truth() Bool           { return False }
+func (mandatory) Hash() (uint32, error) { return 0, nil }

--- a/starlark/testdata/function.star
+++ b/starlark/testdata/function.star
@@ -175,7 +175,7 @@ assert.fails(lambda: f(
     33, 34, 35, 36, 37, 38, 39, 40,
     41, 42, 43, 44, 45, 46, 47, 48,
     49, 50, 51, 52, 53, 54, 55, 56,
-    57, 58, 59, 60, 61, 62, 63, 64), "takes exactly 65 positional arguments .64 given.")
+    57, 58, 59, 60, 61, 62, 63, 64), "missing 1 argument \(mm\)")
 
 assert.fails(lambda: f(
     1, 2, 3, 4, 5, 6, 7, 8,
@@ -186,7 +186,7 @@ assert.fails(lambda: f(
     41, 42, 43, 44, 45, 46, 47, 48,
     49, 50, 51, 52, 53, 54, 55, 56,
     57, 58, 59, 60, 61, 62, 63, 64, 65,
-    mm = 100), 'multiple values for keyword argument "mm"')
+    mm = 100), 'multiple values for parameter "mm"')
 
 ---
 # Regression test for github.com/google/starlark-go/issues/21,
@@ -200,13 +200,13 @@ def f(*args, **kwargs):
   return args, kwargs
 
 assert.eq(f(x=1, y=2), ((), {"x": 1, "y": 2}))
-assert.fails(lambda: f(x=1, **dict(x=2)), 'multiple values for keyword argument "x"')
+assert.fails(lambda: f(x=1, **dict(x=2)), 'multiple values for parameter "x"')
 
 def g(x, y):
   return x, y
 
 assert.eq(g(1, y=2), (1, 2))
-assert.fails(lambda: g(1, y=2, **{'y': 3}), 'multiple values for keyword argument "y"')
+assert.fails(lambda: g(1, y=2, **{'y': 3}), 'multiple values for parameter "y"')
 
 ---
 # Regression test for a bug in CALL_VAR_KW.


### PR DESCRIPTION
In def f(a, b=1, *, d, e=2, f), the parameters d and f
are keyword-only (because they come after the * or *args parameter),
but have no default value, so they are mandatory.

Also:
- improve the error messages
- spec update
- avoid need for "defined" bitset in setArgs

Updates bazelbuild/starlark#23