### PR TITLE
Small int as int64

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -352,7 +352,7 @@ func makeToplevelFunction(funcode *compile.Funcode, predeclared StringDict) *Fun
 		case int64:
 			v = MakeInt64(c)
 		case *big.Int:
-			v = Int{c}
+			v = MakeBigInt(c)
 		case string:
 			v = String(c)
 		case float64:
@@ -1063,7 +1063,8 @@ func slice(x, lo, hi, step_ Value) (Value, error) {
 }
 
 // From Hacker's Delight, section 2.8.
-func signum(x int) int { return int(uint64(int64(x)>>63) | (uint64(-x) >> 63)) }
+func signum64(x int64) int { return int(uint64(x>>63) | uint64(-x)>>63) }
+func signum(x int) int     { return signum64(int64(x)) }
 
 // indices converts start_ and end_ to indices in the range [0:len].
 // The start index defaults to 0 and the end index defaults to len.
@@ -1375,13 +1376,13 @@ func interpolate(format string, x Value) (Value, error) {
 			}
 			switch c {
 			case 'd', 'i':
-				buf.WriteString(i.bigint.Text(10))
+				fmt.Fprintf(&buf, "%d", i)
 			case 'o':
-				buf.WriteString(i.bigint.Text(8))
+				fmt.Fprintf(&buf, "%o", i)
 			case 'x':
-				buf.WriteString(i.bigint.Text(16))
+				fmt.Fprintf(&buf, "%x", i)
 			case 'X':
-				buf.WriteString(strings.ToUpper(i.bigint.Text(16)))
+				fmt.Fprintf(&buf, "%X", i)
 			}
 		case 'e', 'f', 'g', 'E', 'F', 'G':
 			f, ok := AsFloat(arg)

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -8,36 +8,44 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 
 	"go.starlark.net/syntax"
 )
 
 // Int is the type of a Starlark int.
-type Int struct{ bigint *big.Int }
+type Int struct {
+	// big != nil <=> value is not representable as int32.
+	// We use only the signed 32 bit range of small to ensure
+	// that small+small and small*small do not overflow.
+
+	small int64    // minint32 <= small <= maxint32
+	big   *big.Int // big.BitLen() >= 32
+}
+
+// newBig allocates a new big.Int.
+func newBig(x int64) *big.Int {
+	if 0 <= x && int64(big.Word(x)) == x {
+		// x is guaranteed to fit into a single big.Word.
+		// Most starlark ints are small,
+		// but math/big assumes that since you've chosen to use math/big,
+		// your big.Ints will probably grow, so it over-allocates.
+		// Avoid that over-allocation by manually constructing a single-word slice.
+		// See https://golang.org/cl/150999, which will hopefully land in Go 1.13.
+		return new(big.Int).SetBits([]big.Word{big.Word(x)})
+	}
+	return big.NewInt(x)
+}
 
 // MakeInt returns a Starlark int for the specified signed integer.
 func MakeInt(x int) Int { return MakeInt64(int64(x)) }
 
 // MakeInt64 returns a Starlark int for the specified int64.
 func MakeInt64(x int64) Int {
-	if 0 <= x {
-		if x < int64(len(smallint)) {
-			if !smallintok {
-				panic("MakeInt64 used before initialization")
-			}
-			return Int{&smallint[x]}
-		}
-		if int64(big.Word(x)) == x {
-			// x is guaranteed to fit into a single big.Word.
-			// Most starlark ints are small,
-			// but math/big assumes that since you've chosen to use math/big,
-			// your big.Ints will probably grow, so it over-allocates.
-			// Avoid that over-allocation by manually constructing a single-word slice.
-			// See https://golang.org/cl/150999, which will hopefully land in Go 1.13.
-			return Int{new(big.Int).SetBits([]big.Word{big.Word(x)})}
-		}
+	if math.MinInt32 <= x && x <= math.MaxInt32 {
+		return Int{small: x}
 	}
-	return Int{big.NewInt(x)}
+	return Int{big: newBig(x)}
 }
 
 // MakeUint returns a Starlark int for the specified unsigned integer.
@@ -45,36 +53,31 @@ func MakeUint(x uint) Int { return MakeUint64(uint64(x)) }
 
 // MakeUint64 returns a Starlark int for the specified uint64.
 func MakeUint64(x uint64) Int {
-	if x < uint64(len(smallint)) {
-		if !smallintok {
-			panic("MakeUint64 used before initialization")
-		}
-		return Int{&smallint[x]}
+	if x <= math.MaxInt32 {
+		return Int{small: int64(x)}
 	}
 	if uint64(big.Word(x)) == x {
-		// See comment in MakeInt64 for an explanation of this optimization.
-		return Int{new(big.Int).SetBits([]big.Word{big.Word(x)})}
+		// See comment in newBig for an explanation of this optimization.
+		return Int{big: new(big.Int).SetBits([]big.Word{big.Word(x)})}
 	}
-	return Int{new(big.Int).SetUint64(x)}
+	return Int{big: new(big.Int).SetUint64(x)}
+}
+
+// MakeBigInt returns a Starlark int for the specified big.Int.
+// The caller must not subsequently modify x.
+func MakeBigInt(x *big.Int) Int {
+	if n := x.BitLen(); n < 32 || n == 32 && x.Int64() == math.MinInt32 {
+		return Int{small: x.Int64()}
+	}
+	return Int{big: x}
 }
 
 var (
-	smallint   [256]big.Int
-	smallintok bool
-	zero, one  Int
+	zero, one = Int{small: 0}, Int{small: 1}
+	oneBig    = newBig(1)
 
 	_ HasUnary = Int{}
 )
-
-func init() {
-	for i := range smallint {
-		smallint[i].SetInt64(int64(i))
-	}
-	smallintok = true
-
-	zero = MakeInt64(0)
-	one = MakeInt64(1)
-}
 
 // Unary implements the operations +int, -int, and ~int.
 func (i Int) Unary(op syntax.Token) (Value, error) {
@@ -92,21 +95,39 @@ func (i Int) Unary(op syntax.Token) (Value, error) {
 // Int64 returns the value as an int64.
 // If it is not exactly representable the result is undefined and ok is false.
 func (i Int) Int64() (_ int64, ok bool) {
-	x, acc := bigintToInt64(i.bigint)
-	if acc != big.Exact {
-		return // inexact
+	if i.big != nil {
+		x, acc := bigintToInt64(i.big)
+		if acc != big.Exact {
+			return // inexact
+		}
+		return x, true
 	}
-	return x, true
+	return i.small, true
+}
+
+// BigInt returns the value as a big.Int.
+// The returned variable must not be modified by the client.
+func (i Int) BigInt() *big.Int {
+	if i.big != nil {
+		return i.big
+	}
+	return newBig(i.small)
 }
 
 // Uint64 returns the value as a uint64.
 // If it is not exactly representable the result is undefined and ok is false.
 func (i Int) Uint64() (_ uint64, ok bool) {
-	x, acc := bigintToUint64(i.bigint)
-	if acc != big.Exact {
+	if i.big != nil {
+		x, acc := bigintToUint64(i.big)
+		if acc != big.Exact {
+			return // inexact
+		}
+		return x, true
+	}
+	if i.small < 0 {
 		return // inexact
 	}
-	return x, true
+	return uint64(i.small), true
 }
 
 // The math/big API should provide this function.
@@ -142,61 +163,146 @@ var (
 	maxint64 = new(big.Int).SetInt64(math.MaxInt64)
 )
 
-func (i Int) String() string { return i.bigint.String() }
-func (i Int) Type() string   { return "int" }
-func (i Int) Freeze()        {} // immutable
-func (i Int) Truth() Bool    { return i.Sign() != 0 }
+func (i Int) Format(s fmt.State, ch rune) {
+	if i.big != nil {
+		i.big.Format(s, ch)
+		return
+	}
+	newBig(i.small).Format(s, ch)
+}
+func (i Int) String() string {
+	if i.big != nil {
+		return i.big.Text(10)
+	}
+	return strconv.FormatInt(i.small, 10)
+}
+func (i Int) Type() string { return "int" }
+func (i Int) Freeze()      {} // immutable
+func (i Int) Truth() Bool  { return i.Sign() != 0 }
 func (i Int) Hash() (uint32, error) {
 	var lo big.Word
-	if i.bigint.Sign() != 0 {
-		lo = i.bigint.Bits()[0]
+	if i.big != nil {
+		lo = i.big.Bits()[0]
+	} else {
+		lo = big.Word(i.small)
 	}
 	return 12582917 * uint32(lo+3), nil
 }
-func (x Int) CompareSameType(op syntax.Token, y Value, depth int) (bool, error) {
-	return threeway(op, x.bigint.Cmp(y.(Int).bigint)), nil
+func (x Int) CompareSameType(op syntax.Token, v Value, depth int) (bool, error) {
+	y := v.(Int)
+	if x.big != nil || y.big != nil {
+		return threeway(op, x.BigInt().Cmp(y.BigInt())), nil
+	}
+	return threeway(op, signum64(x.small-y.small)), nil
 }
 
 // Float returns the float value nearest i.
 func (i Int) Float() Float {
-	// TODO(adonovan): opt: handle common values without allocation.
-	f, _ := new(big.Float).SetInt(i.bigint).Float64()
-	return Float(f)
+	if i.big != nil {
+		f, _ := new(big.Float).SetInt(i.big).Float64()
+		return Float(f)
+	}
+	return Float(i.small)
 }
 
-func (x Int) Sign() int      { return x.bigint.Sign() }
-func (x Int) Add(y Int) Int  { return Int{new(big.Int).Add(x.bigint, y.bigint)} }
-func (x Int) Sub(y Int) Int  { return Int{new(big.Int).Sub(x.bigint, y.bigint)} }
-func (x Int) Mul(y Int) Int  { return Int{new(big.Int).Mul(x.bigint, y.bigint)} }
-func (x Int) Or(y Int) Int   { return Int{new(big.Int).Or(x.bigint, y.bigint)} }
-func (x Int) And(y Int) Int  { return Int{new(big.Int).And(x.bigint, y.bigint)} }
-func (x Int) Xor(y Int) Int  { return Int{new(big.Int).Xor(x.bigint, y.bigint)} }
-func (x Int) Not() Int       { return Int{new(big.Int).Not(x.bigint)} }
-func (x Int) Lsh(y uint) Int { return Int{new(big.Int).Lsh(x.bigint, y)} }
-func (x Int) Rsh(y uint) Int { return Int{new(big.Int).Rsh(x.bigint, y)} }
+func (x Int) Sign() int {
+	if x.big != nil {
+		return x.big.Sign()
+	}
+	return signum64(x.small)
+}
+
+func (x Int) Add(y Int) Int {
+	if x.big != nil || y.big != nil {
+		return MakeBigInt(new(big.Int).Add(x.BigInt(), y.BigInt()))
+	}
+	return MakeInt64(x.small + y.small)
+}
+func (x Int) Sub(y Int) Int {
+	if x.big != nil || y.big != nil {
+		return MakeBigInt(new(big.Int).Sub(x.BigInt(), y.BigInt()))
+	}
+	return MakeInt64(x.small - y.small)
+}
+func (x Int) Mul(y Int) Int {
+	if x.big != nil || y.big != nil {
+		return MakeBigInt(new(big.Int).Mul(x.BigInt(), y.BigInt()))
+	}
+	return MakeInt64(x.small * y.small)
+}
+func (x Int) Or(y Int) Int {
+	if x.big != nil || y.big != nil {
+		return Int{big: new(big.Int).Or(x.BigInt(), y.BigInt())}
+	}
+	return Int{small: x.small | y.small}
+}
+func (x Int) And(y Int) Int {
+	if x.big != nil || y.big != nil {
+		return MakeBigInt(new(big.Int).And(x.BigInt(), y.BigInt()))
+	}
+	return Int{small: x.small & y.small}
+}
+func (x Int) Xor(y Int) Int {
+	if x.big != nil || y.big != nil {
+		return MakeBigInt(new(big.Int).Xor(x.BigInt(), y.BigInt()))
+	}
+	return Int{small: x.small ^ y.small}
+}
+func (x Int) Not() Int {
+	if x.big != nil {
+		return MakeBigInt(new(big.Int).Not(x.big))
+	}
+	return Int{small: ^x.small}
+}
+func (x Int) Lsh(y uint) Int { return MakeBigInt(new(big.Int).Lsh(x.BigInt(), y)) }
+func (x Int) Rsh(y uint) Int { return MakeBigInt(new(big.Int).Rsh(x.BigInt(), y)) }
 
 // Precondition: y is nonzero.
 func (x Int) Div(y Int) Int {
 	// http://python-history.blogspot.com/2010/08/why-pythons-integer-division-floors.html
-	var quo, rem big.Int
-	quo.QuoRem(x.bigint, y.bigint, &rem)
-	if (x.bigint.Sign() < 0) != (y.bigint.Sign() < 0) && rem.Sign() != 0 {
-		quo.Sub(&quo, one.bigint)
+	if x.big != nil || y.big != nil {
+		xb, yb := x.BigInt(), y.BigInt()
+
+		var quo, rem big.Int
+		quo.QuoRem(xb, yb, &rem)
+		if (xb.Sign() < 0) != (yb.Sign() < 0) && rem.Sign() != 0 {
+			quo.Sub(&quo, oneBig)
+		}
+		return MakeBigInt(&quo)
 	}
-	return Int{&quo}
+	quo := x.small / y.small
+	rem := x.small % y.small
+	if (x.small < 0) != (y.small < 0) && rem != 0 {
+		quo -= 1
+	}
+	return MakeInt64(quo)
 }
 
 // Precondition: y is nonzero.
 func (x Int) Mod(y Int) Int {
-	var quo, rem big.Int
-	quo.QuoRem(x.bigint, y.bigint, &rem)
-	if (x.bigint.Sign() < 0) != (y.bigint.Sign() < 0) && rem.Sign() != 0 {
-		rem.Add(&rem, y.bigint)
+	if x.big != nil || y.big != nil {
+		xb, yb := x.BigInt(), y.BigInt()
+
+		var quo, rem big.Int
+		quo.QuoRem(xb, yb, &rem)
+		if (xb.Sign() < 0) != (yb.Sign() < 0) && rem.Sign() != 0 {
+			rem.Add(&rem, yb)
+		}
+		return MakeBigInt(&rem)
 	}
-	return Int{&rem}
+	rem := x.small % y.small
+	if (x.small < 0) != (y.small < 0) && rem != 0 {
+		rem += y.small
+	}
+	return Int{small: rem}
 }
 
-func (i Int) rational() *big.Rat { return new(big.Rat).SetInt(i.bigint) }
+func (i Int) rational() *big.Rat {
+	if i.big != nil {
+		return new(big.Rat).SetInt(i.big)
+	}
+	return new(big.Rat).SetInt64(i.small)
+}
 
 // AsInt32 returns the value of x if is representable as an int32.
 func AsInt32(x Value) (int, error) {
@@ -204,13 +310,10 @@ func AsInt32(x Value) (int, error) {
 	if !ok {
 		return 0, fmt.Errorf("got %s, want int", x.Type())
 	}
-	if i.bigint.BitLen() <= 32 {
-		v := i.bigint.Int64()
-		if v >= math.MinInt32 && v <= math.MaxInt32 {
-			return int(v), nil
-		}
+	if i.big != nil {
+		return 0, fmt.Errorf("%s out of range", i)
 	}
-	return 0, fmt.Errorf("%s out of range", i)
+	return int(i.small), nil
 }
 
 // NumberToInt converts a number x to an integer value.
@@ -236,16 +339,13 @@ func NumberToInt(x Value) (Int, error) {
 // finiteFloatToInt converts f to an Int, truncating towards zero.
 // f must be finite.
 func finiteFloatToInt(f Float) Int {
-	var i big.Int
 	if math.MinInt64 <= f && f <= math.MaxInt64 {
 		// small values
-		i.SetInt64(int64(f))
-	} else {
-		rat := f.rational()
-		if rat == nil {
-			panic(f) // non-finite
-		}
-		i.Div(rat.Num(), rat.Denom())
+		return MakeInt64(int64(f))
 	}
-	return Int{&i}
+	rat := f.rational()
+	if rat == nil {
+		panic(f) // non-finite
+	}
+	return MakeBigInt(new(big.Int).Div(rat.Num(), rat.Denom()))
 }

--- a/starlark/int_test.go
+++ b/starlark/int_test.go
@@ -1,0 +1,72 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package starlark
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+)
+
+// TestIntOpts exercises integer arithmetic, especially at the boundaries.
+func TestIntOpts(t *testing.T) {
+	f := MakeInt64
+	left, right := big.NewInt(math.MinInt32), big.NewInt(math.MaxInt32)
+
+	for i, test := range []struct {
+		val  Int
+		want string
+	}{
+		// Add
+		{f(math.MaxInt32).Add(f(1)), "80000000"},
+		{f(math.MinInt32).Add(f(-1)), "-80000001"},
+		// Mul
+		{f(math.MaxInt32).Mul(f(math.MaxInt32)), "3fffffff00000001"},
+		{f(math.MinInt32).Mul(f(math.MinInt32)), "4000000000000000"},
+		{f(math.MaxUint32).Mul(f(math.MaxUint32)), "fffffffe00000001"},
+		{f(math.MinInt32).Mul(f(-1)), "80000000"},
+		// Div
+		{f(math.MinInt32).Div(f(-1)), "80000000"},
+		{f(1 << 31).Div(f(2)), "40000000"},
+		// And
+		{f(math.MaxInt32).And(f(math.MaxInt32)), "7fffffff"},
+		{f(math.MinInt32).And(f(math.MinInt32)), "-80000000"},
+		{f(1 << 33).And(f(1 << 32)), "0"},
+		// Mod
+		{f(1 << 32).Mod(f(2)), "0"},
+		// Or
+		{f(1 << 32).Or(f(0)), "100000000"},
+		{f(math.MaxInt32).Or(f(0)), "7fffffff"},
+		{f(math.MaxUint32).Or(f(0)), "ffffffff"},
+		{f(math.MinInt32).Or(f(math.MinInt32)), "-80000000"},
+		// Xor
+		{f(math.MinInt32).Xor(f(-1)), "7fffffff"},
+		// Not
+		{f(math.MinInt32).Not(), "7fffffff"},
+		{f(math.MaxInt32).Not(), "-80000000"},
+		// Shift
+		{f(1).Lsh(31), "80000000"},
+		{f(1).Lsh(32), "100000000"},
+		{f(math.MaxInt32 + 1).Rsh(1), "40000000"},
+		{f(math.MinInt32 * 2).Rsh(1), "-80000000"},
+	} {
+		if got := fmt.Sprintf("%x", test.val); got != test.want {
+			t.Errorf("%d equals %s, want %s", i, got, test.want)
+		}
+		if test.val.small < math.MinInt32 || math.MaxInt32 < test.val.small {
+			t.Errorf("expected big, %d %s", i, test.val)
+		}
+		if test.val.big == nil {
+			continue
+		}
+		if test.val.small != 0 {
+			t.Errorf("expected 0 small, %d %s with %d", i, test.val, test.val.small)
+		}
+		if b := test.val.big; b.Cmp(left) >= 0 && b.Cmp(right) <= 0 {
+			t.Errorf("expected small, %d %s", i, test.val)
+		}
+	}
+}

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -679,7 +679,7 @@ func int_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 		//
 		// int(x) permits arbitrary precision, unlike the scanner.
 		if i, ok := new(big.Int).SetString(s, b); ok {
-			res := Int{i}
+			res := MakeBigInt(i)
 			if neg {
 				res = zero.Sub(res)
 			}

--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -25,3 +25,13 @@ range1000 = range(1000)
 def bench_builtin_method():
     for _ in range1000:
         emptydict.get(None)
+
+def bench_int():
+    a = 0
+    for _ in range1000:
+        a += 1
+
+def bench_bigint():
+    a = 1 << 31 # maxint32 + 1
+    for _ in range1000:
+        a += 1

--- a/starlark/testdata/int.star
+++ b/starlark/testdata/int.star
@@ -11,31 +11,54 @@ assert.eq(5 + 7, 12)
 assert.eq(5 * 7, 35)
 assert.eq(5 - 7, -2)
 
+# int boundaries
+maxint64 = (1 << 63) - 1
+minint64 = -1 << 63
+maxint32 = (1 << 31) - 1
+minint32 = -1 << 31
+assert.eq(maxint64, 9223372036854775807)
+assert.eq(minint64, -9223372036854775808)
+assert.eq(maxint32, 2147483647)
+assert.eq(minint32, -2147483648)
+
+
 # truth
-assert.true(123)
-assert.true(-1)
-assert.true(not 0)
+def truth():
+  assert.true(not 0)
+  for m in [1, maxint32]: # Test small/big ranges
+    assert.true(123*m)
+    assert.true(-1*m)
+
+truth()
 
 # floored division
 # (For real division, see float.star.)
-assert.eq(100 // 7, 14)
-assert.eq(100 // -7, -15)
-assert.eq(-100 // 7, -15) # NB: different from Go/Java
-assert.eq(-100 // -7, 14) # NB: different from Go/Java
-assert.eq(98 // 7, 14)
-assert.eq(98 // -7, -14)
-assert.eq(-98 // 7, -14)
-assert.eq(-98 // -7, 14)
+def division():
+  for m in [1, maxint32]: # Test small/big ranges
+    assert.eq((100*m) // (7*m), 14)
+    assert.eq((100*m) // (-7*m), -15)
+    assert.eq((-100*m) // (7*m), -15) # NB: different from Go/Java
+    assert.eq((-100*m) // (-7*m), 14) # NB: different from Go/Java
+    assert.eq((98*m) // (7*m), 14)
+    assert.eq((98*m) // (-7*m), -14)
+    assert.eq((-98*m) // (7*m), -14)
+    assert.eq((-98*m) // (-7*m), 14)
+
+division()
 
 # remainder
-assert.eq(100 % 7, 2)
-assert.eq(100 % -7, -5) # NB: different from Go/Java
-assert.eq(-100 % 7, 5) # NB: different from Go/Java
-assert.eq(-100 % -7, -2)
-assert.eq(98 % 7, 0)
-assert.eq(98 % -7, 0)
-assert.eq(-98 % 7, 0)
-assert.eq(-98 % -7, 0)
+def remainder():
+  for m in [1, maxint32]: # Test small/big ranges
+    assert.eq((100*m) % (7*m), 2*m)
+    assert.eq((100*m) % (-7*m), -5*m) # NB: different from Go/Java
+    assert.eq((-100*m) % (7*m), 5*m) # NB: different from Go/Java
+    assert.eq((-100*m) % (-7*m), -2*m)
+    assert.eq((98*m) % (7*m), 0)
+    assert.eq((98*m) % (-7*m), 0)
+    assert.eq((-98*m) % (7*m), 0)
+    assert.eq((-98*m) % (-7*m), 0)
+
+remainder()
 
 # compound assignment
 def compound():
@@ -178,27 +201,36 @@ assert.fails(lambda: 1 << 512, "shift count too large")
 
 # comparisons
 # TODO(adonovan): test: < > == != etc
-assert.lt(-2, -1)
-assert.lt(-1, 0)
-assert.lt(0, 1)
-assert.lt(1, 2)
-assert.true(2 >= 2)
-assert.true(2 > 1)
-assert.true(1 >= 1)
-assert.true(1 > 0)
-assert.true(0 >= 0)
-assert.true(0 > -1)
-assert.true(-1 >= -1)
-assert.true(-1 > -2)
+def comparisons():
+  for m in [1, maxint32/2, maxint32]: # Test small/big ranges
+    assert.lt(-2*m, -1*m)
+    assert.lt(-1*m, 0*m)
+    assert.lt(0*m, 1*m)
+    assert.lt(1*m, 2*m)
+    assert.true(2*m >= 2*m)
+    assert.true(2*m > 1*m)
+    assert.true(1*m >= 1*m)
+    assert.true(1*m > 0*m)
+    assert.true(0*m >= 0*m)
+    assert.true(0*m > -1*m)
+    assert.true(-1*m >= -1*m)
+    assert.true(-1*m > -2*m)
+
+comparisons()
 
 # precision
-maxint64 = 9223372036854775807 # = 2^63
-minint64 = -maxint64 - 1       # = -2^64
 assert.eq(str(maxint64), "9223372036854775807")
 assert.eq(str(maxint64+1), "9223372036854775808")
 assert.eq(str(minint64), "-9223372036854775808")
 assert.eq(str(minint64-1), "-9223372036854775809")
 assert.eq(str(minint64 * minint64), "85070591730234615865843651857942052864")
+assert.eq(str(maxint32+1), "2147483648")
+assert.eq(str(minint32-1), "-2147483649")
+assert.eq(str(minint32 * minint32), "4611686018427387904")
+assert.eq(str(minint32 | maxint32), "-1")
+assert.eq(str(minint32 & minint32), "-2147483648")
+assert.eq(str(minint32 ^ maxint32), "-1")
+assert.eq(str(minint32 // -1), "2147483648")
 
 # string formatting
 assert.eq("%o %x %d" % (0o755, 0xDEADBEEF, 42), "755 deadbeef 42")


### PR DESCRIPTION
Represents small ints as int64 values promoting to big.Int types when needed. Have added some simple benchmarking. Based off of https://github.com/robpike/ivy int/bigint types.

```
Benchmark/bench_bigint-8                   10000            187182 ns/op
Benchmark/bench_int-8                      10000            180208 ns/op

Benchmark/bench_bigint-8                    5000            261473 ns/op
Benchmark/bench_int-8                      10000            128741 ns/op
```