### PR TITLE
travis: bump to Go version 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ language: go
 go_import_path: go.starlark.net
 
 go:
-    - 1.9.x
+    - 1.10.x
     - master


### PR DESCRIPTION
Now that 1.12 is out, 1.10 is the minimum supported version.