### PR TITLE
starlark: use Unhashable errors to indicate hash failures

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -806,9 +806,12 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 			return False, nil
 		case Mapping: // e.g. dict
-			// Ignore error from Get as we cannot distinguish true
+			_, found, err := y.Get(x)
+			if _, ok := err.(Unhashable); ok {
+				return nil, err
+			}
+			// Ignore other errors from Get as we cannot distinguish true
 			// errors (value cycle, type error) from "key not found".
-			_, found, _ := y.Get(x)
 			return Bool(found), nil
 		case *Set:
 			ok, err := y.Has(x)

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -162,7 +162,7 @@ func (t fib) Freeze()                    {}
 func (t fib) String() string             { return "fib" }
 func (t fib) Type() string               { return "fib" }
 func (t fib) Truth() starlark.Bool       { return true }
-func (t fib) Hash() (uint32, error)      { return 0, fmt.Errorf("fib is unhashable") }
+func (t fib) Hash() (uint32, error)      { return 0, starlark.Unhashable("fib is unhashable") }
 func (t fib) Iterate() starlark.Iterator { return &fibIterator{0, 1} }
 
 type fibIterator struct{ x, y int }

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -936,7 +936,7 @@ func (r rangeValue) String() string {
 }
 func (r rangeValue) Type() string          { return "range" }
 func (r rangeValue) Truth() Bool           { return r.len > 0 }
-func (r rangeValue) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: range") }
+func (r rangeValue) Hash() (uint32, error) { return 0, Unhashable("unhashable: range") }
 
 func (x rangeValue) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(rangeValue)

--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -34,7 +34,7 @@ assert.true(4 not in (1, 2, 3))
 assert.fails(lambda: 3 in "foo", "in.*requires string as left operand")
 assert.true(123 in {123: ""})
 assert.true(456 not in {123:""})
-assert.true([] not in {123: ""})
+assert.fails(lambda: [] not in {123: ""}, "unhashable type: list")
 
 # sorted
 assert.eq(sorted([42, 123, 3]), [3, 42, 123])

--- a/starlarkstruct/module.go
+++ b/starlarkstruct/module.go
@@ -21,7 +21,7 @@ var _ starlark.HasAttrs = (*Module)(nil)
 func (m *Module) Attr(name string) (starlark.Value, error) { return m.Members[name], nil }
 func (m *Module) AttrNames() []string                      { return m.Members.Keys() }
 func (m *Module) Freeze()                                  { m.Members.Freeze() }
-func (m *Module) Hash() (uint32, error)                    { return 0, fmt.Errorf("unhashable: %s", m.Type()) }
+func (m *Module) Hash() (uint32, error)                    { return 0, starlark.Unhashable("unhashable: " + m.Type()) }
 func (m *Module) String() string                           { return fmt.Sprintf("<module %q>", m.Name) }
 func (m *Module) Truth() starlark.Bool                     { return true }
 func (m *Module) Type() string                             { return "module" }

--- a/starlarkstruct/struct_test.go
+++ b/starlarkstruct/struct_test.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"go.starlark.net/starlark"
 	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/starlarktest"
 )
@@ -67,8 +67,8 @@ func (sym *symbol) Name() string          { return sym.name }
 func (sym *symbol) String() string        { return sym.name }
 func (sym *symbol) Type() string          { return "symbol" }
 func (sym *symbol) Freeze()               {} // immutable
-func (sym *symbol) Truth() starlark.Bool   { return starlark.True }
-func (sym *symbol) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", sym.Type()) }
+func (sym *symbol) Truth() starlark.Bool  { return starlark.True }
+func (sym *symbol) Hash() (uint32, error) { return 0, starlark.Unhashable("unhashable: " + sym.Type()) }
 
 func (sym *symbol) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) > 0 {


### PR DESCRIPTION
Fixes #113. See that issue for discussion.