### PR TITLE
syntax: expose Binding concept

### DIFF
--- a/internal/compile/serial.go
+++ b/internal/compile/serial.go
@@ -96,7 +96,7 @@ func (prog *Program) Encode() []byte {
 	e.p = append(e.p, "????"...) // string data offset; filled in later
 	e.int(Version)
 	e.string(prog.Toplevel.Pos.Filename())
-	e.idents(prog.Loads)
+	e.bindings(prog.Loads)
 	e.int(len(prog.Names))
 	for _, name := range prog.Names {
 		e.string(name)
@@ -118,7 +118,7 @@ func (prog *Program) Encode() []byte {
 			e.string(c.Text(10))
 		}
 	}
-	e.idents(prog.Globals)
+	e.bindings(prog.Globals)
 	e.function(prog.Toplevel)
 	e.int(len(prog.Functions))
 	for _, fn := range prog.Functions {
@@ -161,29 +161,29 @@ func (e *encoder) bytes(b []byte) {
 	e.s = append(e.s, b...)
 }
 
-func (e *encoder) ident(id Ident) {
-	e.string(id.Name)
-	e.int(int(id.Pos.Line))
-	e.int(int(id.Pos.Col))
+func (e *encoder) binding(bind Binding) {
+	e.string(bind.Name)
+	e.int(int(bind.Pos.Line))
+	e.int(int(bind.Pos.Col))
 }
 
-func (e *encoder) idents(ids []Ident) {
-	e.int(len(ids))
-	for _, id := range ids {
-		e.ident(id)
+func (e *encoder) bindings(binds []Binding) {
+	e.int(len(binds))
+	for _, bind := range binds {
+		e.binding(bind)
 	}
 }
 
 func (e *encoder) function(fn *Funcode) {
-	e.ident(Ident{fn.Name, fn.Pos})
+	e.binding(Binding{fn.Name, fn.Pos})
 	e.string(fn.Doc)
 	e.bytes(fn.Code)
 	e.int(len(fn.pclinetab))
 	for _, x := range fn.pclinetab {
 		e.int64(int64(x))
 	}
-	e.idents(fn.Locals)
-	e.idents(fn.Freevars)
+	e.bindings(fn.Locals)
+	e.bindings(fn.Freevars)
 	e.int(fn.MaxStack)
 	e.int(fn.NumParams)
 	e.int(fn.NumKwonlyParams)
@@ -228,7 +228,7 @@ func DecodeProgram(data []byte) (_ *Program, err error) {
 	filename := d.string()
 	d.filename = &filename
 
-	loads := d.idents()
+	loads := d.bindings()
 
 	names := make([]string, d.int())
 	for i := range names {
@@ -252,7 +252,7 @@ func DecodeProgram(data []byte) (_ *Program, err error) {
 		constants[i] = c
 	}
 
-	globals := d.idents()
+	globals := d.bindings()
 	toplevel := d.function()
 	funcs := make([]*Funcode, d.int())
 	for i := range funcs {
@@ -323,33 +323,33 @@ func (d *decoder) bytes() []byte {
 	return r
 }
 
-func (d *decoder) ident() Ident {
+func (d *decoder) binding() Binding {
 	name := d.string()
 	line := int32(d.int())
 	col := int32(d.int())
-	return Ident{Name: name, Pos: syntax.MakePosition(d.filename, line, col)}
+	return Binding{Name: name, Pos: syntax.MakePosition(d.filename, line, col)}
 }
 
-func (d *decoder) idents() []Ident {
-	idents := make([]Ident, d.int())
-	for i := range idents {
-		idents[i] = d.ident()
+func (d *decoder) bindings() []Binding {
+	bindings := make([]Binding, d.int())
+	for i := range bindings {
+		bindings[i] = d.binding()
 	}
-	return idents
+	return bindings
 }
 
 func (d *decoder) bool() bool { return d.int() != 0 }
 
 func (d *decoder) function() *Funcode {
-	id := d.ident()
+	id := d.binding()
 	doc := d.string()
 	code := d.bytes()
 	pclinetab := make([]uint16, d.int())
 	for i := range pclinetab {
 		pclinetab[i] = uint16(d.int())
 	}
-	locals := d.idents()
-	freevars := d.idents()
+	locals := d.bindings()
+	freevars := d.bindings()
 	maxStack := d.int()
 	numParams := d.int()
 	numKwonlyParams := d.int()

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1247,7 +1247,7 @@ func setArgs(locals []Value, fn *Function, args Tuple, kwargs []Tuple) error {
 	return nil
 }
 
-func findParam(params []compile.Ident, name string) int {
+func findParam(params []compile.Binding, name string) int {
 	for i, param := range params {
 		if param.Name == name {
 			return i

--- a/syntax/binding.go
+++ b/syntax/binding.go
@@ -1,0 +1,43 @@
+package syntax
+
+// This file defines resolver data types referenced by the syntax tree.
+// We cannot guarantee API stability for these types
+// as they are closely tied to the implementation.
+
+// A Binding ties together all identifiers that denote the same variable.
+// The resolver computes a binding for every Ident.
+type Binding struct {
+	Scope Scope
+
+	// Index records the index into the enclosing
+	// - {DefStmt,File}.Locals, if Scope==Local
+	// - DefStmt.FreeVars,      if Scope==Free
+	// - File.Globals,          if Scope==Global.
+	// It is zero if Scope is Predeclared, Universal, or Undefined.
+	Index int
+
+	First *Ident // first binding use (iff Scope==Local/Free/Global)
+}
+
+// The Scope of Binding indicates what kind of scope it has.
+type Scope uint8
+
+const (
+	UndefinedScope   Scope = iota // name is not defined
+	LocalScope                    // name is local to its function
+	FreeScope                     // name is local to some enclosing function
+	GlobalScope                   // name is global to module
+	PredeclaredScope              // name is predeclared for this module (e.g. glob)
+	UniversalScope                // name is universal (e.g. len)
+)
+
+var scopeNames = [...]string{
+	UndefinedScope:   "undefined",
+	LocalScope:       "local",
+	FreeScope:        "free",
+	GlobalScope:      "global",
+	PredeclaredScope: "predeclared",
+	UniversalScope:   "universal",
+}
+
+func (scope Scope) String() string { return scopeNames[scope] }

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -71,8 +71,8 @@ type File struct {
 	Stmts []Stmt
 
 	// set by resolver:
-	Locals  []*Ident // this file's (comprehension-)local variables
-	Globals []*Ident // this file's global variables
+	Locals  []*Binding // this file's (comprehension-)local variables
+	Globals []*Binding // this file's global variables
 }
 
 func (x *File) Span() (start, end Position) {
@@ -126,11 +126,11 @@ type Function struct {
 	Body     []Stmt
 
 	// set by resolver:
-	HasVarargs      bool     // whether params includes *args (convenience)
-	HasKwargs       bool     // whether params includes **kwargs (convenience)
-	NumKwonlyParams int      // number of keyword-only optional parameters
-	Locals          []*Ident // this function's local variables, parameters first
-	FreeVars        []*Ident // enclosing local variables to capture in closure
+	HasVarargs      bool       // whether params includes *args (convenience)
+	HasKwargs       bool       // whether params includes **kwargs (convenience)
+	NumKwonlyParams int        // number of keyword-only optional parameters
+	Locals          []*Binding // this function's local variables, parameters first
+	FreeVars        []*Binding // enclosing local variables to capture in closure
 }
 
 func (x *Function) Span() (start, end Position) {
@@ -260,10 +260,8 @@ type Ident struct {
 	NamePos Position
 	Name    string
 
-	// set by resolver:
-
-	Scope uint8 // see type resolve.Scope
-	Index int   // index into enclosing {DefStmt,File}.Locals (if scope==Local) or DefStmt.FreeVars (if scope==Free) or File.Globals (if scope==Global)
+	// set by resolver
+	Binding *Binding
 }
 
 func (x *Ident) Span() (start, end Position) {


### PR DESCRIPTION
This refactoring exposes the concept of Binding, which was previously
internal to the resolver. Previously the Scope and Index fields of the
binding were copied into each Ident; now the relationship is indirect.

A Binding is the entity created by the first binding occurrence of a
name, and the binding ties together all uses of that name.

This change is a preparation for fixing issue #170, which requires
that we mark the bindings that need to be allocated indirectly in
closure cells. Currently, in the absence of an indirect relationship
there is no way to mark a binding so that all Idents are affected.

This change leads to some a minor simplification in lookupLexical,
which used to synthesize a new Ident, when logically it is creating
only a new binding.

Unfortunately, Binding and Scope must be declared in the syntax
package even though it logically belongs to the resolver,
because the (resolved) syntax trees refer to it.

(If you're familiar with the go/types package, syntax.Binding
corresponds to types.Var. go/types solves its analogous dependency
problem by putting resolver-derived facts in an external map, not the
syntax tree, which is expensive. So perhaps it's more accurate to
say Binding corresponds to the deprecated ast.Object.)

Change-Id: I5976a638fd62a249a485b37aec6a476650fe32b3