### PR TITLE
starlark: capture free variables by reference

### DIFF
--- a/internal/compile/serial.go
+++ b/internal/compile/serial.go
@@ -35,6 +35,8 @@ package compile
 //	pclinetab	[]varint
 //	numlocals	varint
 //	locals		[]Ident
+//	numcells	varint
+//	cells		[]int
 //	numfreevars	varint
 //	freevar		[]Ident
 //	maxstack	varint
@@ -183,6 +185,10 @@ func (e *encoder) function(fn *Funcode) {
 		e.int64(int64(x))
 	}
 	e.bindings(fn.Locals)
+	e.int(len(fn.Cells))
+	for _, index := range fn.Cells {
+		e.int(index)
+	}
 	e.bindings(fn.Freevars)
 	e.int(fn.MaxStack)
 	e.int(fn.NumParams)
@@ -338,6 +344,14 @@ func (d *decoder) bindings() []Binding {
 	return bindings
 }
 
+func (d *decoder) ints() []int {
+	ints := make([]int, d.int())
+	for i := range ints {
+		ints[i] = d.int()
+	}
+	return ints
+}
+
 func (d *decoder) bool() bool { return d.int() != 0 }
 
 func (d *decoder) function() *Funcode {
@@ -349,6 +363,7 @@ func (d *decoder) function() *Funcode {
 		pclinetab[i] = uint16(d.int())
 	}
 	locals := d.bindings()
+	cells := d.ints()
 	freevars := d.bindings()
 	maxStack := d.int()
 	numParams := d.int()
@@ -363,6 +378,7 @@ func (d *decoder) function() *Funcode {
 		Code:            code,
 		pclinetab:       pclinetab,
 		Locals:          locals,
+		Cells:           cells,
 		Freevars:        freevars,
 		MaxStack:        maxStack,
 		NumParams:       numParams,

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -482,8 +482,7 @@ func TestInt(t *testing.T) {
 
 func TestBacktrace(t *testing.T) {
 	// This test ensures continuity of the stack of active Starlark
-	// functions, including propagation through built-ins such as 'min'
-	// (though min does not itself appear in the stack).
+	// functions, including propagation through built-ins such as 'min'.
 	const src = `
 def f(x): return 1//x
 def g(x): f(x)

--- a/starlark/testdata/assign.star
+++ b/starlark/testdata/assign.star
@@ -153,14 +153,16 @@ g = 1
 
 ---
 # option:nesteddef
-# free variable captured before assignment
+# Free variables are captured by reference, so this is ok.
+load("assert.star", "assert")
 
 def f():
-   def g(): ### "local variable outer referenced before assignment"
+   def g():
      return outer
    outer = 1
+   return g()
 
-f()
+assert.eq(f(), 1)
 
 ---
 load("assert.star", "assert")

--- a/syntax/binding.go
+++ b/syntax/binding.go
@@ -25,7 +25,8 @@ type Scope uint8
 const (
 	UndefinedScope   Scope = iota // name is not defined
 	LocalScope                    // name is local to its function
-	FreeScope                     // name is local to some enclosing function
+	CellScope                     // name is local but shared with a nested function
+	FreeScope                     // name is cell of some enclosing function
 	GlobalScope                   // name is global to module
 	PredeclaredScope              // name is predeclared for this module (e.g. glob)
 	UniversalScope                // name is universal (e.g. len)
@@ -35,6 +36,7 @@ var scopeNames = [...]string{
 	UndefinedScope:   "undefined",
 	LocalScope:       "local",
 	FreeScope:        "free",
+	CellScope:        "cell",
 	GlobalScope:      "global",
 	PredeclaredScope: "predeclared",
 	UniversalScope:   "universal",

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -129,8 +129,8 @@ type Function struct {
 	HasVarargs      bool       // whether params includes *args (convenience)
 	HasKwargs       bool       // whether params includes **kwargs (convenience)
 	NumKwonlyParams int        // number of keyword-only optional parameters
-	Locals          []*Binding // this function's local variables, parameters first
-	FreeVars        []*Binding // enclosing local variables to capture in closure
+	Locals          []*Binding // this function's local/cell variables, parameters first
+	FreeVars        []*Binding // enclosing cells to capture in closure
 }
 
 func (x *Function) Span() (start, end Position) {


### PR DESCRIPTION
This change causes closures for nested functions to capture their
enclosing functions' variables by reference. Even though an inner
function cannot update outer variables, it must observe updates to
them made by the outer function.

A special case of this is a nested recursive function f:

   def outer():
       def f(): ...f()...

The def f statement constructs a closure which captures f, and then
binds the closure value to f. If the closure captures by value (as
before this change), the def statement will fail because f is
undefined (see issue #170). Now, the closure captures a reference
to f, so it is safe to execute before f has been assigned.

This is implemented as follows. During resolving, captured local
variables such as f are marked as as "cells". The compiler assumes and
guarantees that such locals are values of a special internal type
called 'cell', and it emits explicit instructions to load from and
store into the cell. At runtime, cells are created on entry to the function;
parameters may be "spilled" into cells as needed.
Each cell variable gets its own allocation to avoid spurious liveness.
A function's tuple of free variables contains only cells.

Fixes #170