### PR TITLE
resolve: load statements now create local bindings

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1111,7 +1111,7 @@ h = [2*i for i in a]
 The environment of a Starlark program is structured as a tree of
 _lexical blocks_, each of which may contain name bindings.
 The tree of blocks is parallel to the syntax tree.
-Blocks are of four kinds.
+Blocks are of five kinds.
 
 <!-- Avoid the term "built-in" block since that's also a type. -->
 At the root of the tree is the _predeclared_ block,
@@ -1126,24 +1126,33 @@ These additional functions may have side effects on the application.
 Starlark programs cannot change the set of predeclared bindings
 or assign new values to them.
 
-Nested beneath the predeclared block is the _module_ block, which
-contains the bindings of the current file.
-Bindings in the module block (such as `a`, `b`, `c`, and `h` in the
-example) are called _global_.
+Nested beneath the predeclared block is the _module_ block,
+which contains the bindings of the current module.
+Bindings in the module block (such as `c`, and `h` in the
+example) are called _global_ and may be visible to other modules.
 The module block is empty at the start of the file
 and is populated by top-level binding statements.
 
-A module block contains a _function_ block for each top-level
-function, and a _comprehension_ block for each top-level
-comprehension.
-Bindings inside either of these kinds of block are called _local_.
+Nested beneath the module block is the _file_ block,
+which contains bindings local to the current file.
+Names in this block (such as `a` and `b` in the example)
+are bound only by `load` statements.
+The sets of names bound in the file block and in the module block do not overlap:
+it is an error for a load statement to bind the name of a global,
+or for a top-level statement to assign to a name bound by a load statement.
+
+A file block contains a _function_ block for each top-level
+function, and a _comprehension_ block for each top-level comprehension.
+Bindings in either of these kinds of block,
+and in the file block itself, are called _local_.
+(In the example, the bindings for `e`, `f`, `g`, and `i` are all local.)
 Additional functions and comprehensions, and their blocks, may be
 nested in any order, to any depth.
 
 If name is bound anywhere within a block, all uses of the name within
-the block are treated as references to that binding, even uses that
-appear before the binding.
-This is true even in the module block, unlike Python.
+the block are treated as references to that binding,
+even if the use appears before the binding.
+This is true even at the top level, unlike Python.
 The binding of `y` on the last line of the example below makes `y`
 local to the function `hello`, so the use of `y` in the print
 statement also refers to the local `y`, even though it appears

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -41,7 +41,7 @@ import (
 const debug = false // TODO(adonovan): use a bitmap of options; and regexp to match files
 
 // Increment this to force recompilation of saved bytecode files.
-const Version = 8
+const Version = 9
 
 type Opcode uint8
 
@@ -1146,7 +1146,7 @@ func (fcomp *fcomp) stmt(stmt syntax.Stmt) {
 		fcomp.setPos(stmt.Load)
 		fcomp.emit1(LOAD, uint32(len(stmt.From)))
 		for i := range stmt.To {
-			fcomp.emit1(SETGLOBAL, uint32(stmt.To[len(stmt.To)-1-i].Binding.Index))
+			fcomp.set(stmt.To[len(stmt.To)-1-i])
 		}
 
 	default:

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -21,6 +21,7 @@ func setOptions(src string) {
 	resolve.AllowNestedDef = option(src, "nesteddef")
 	resolve.AllowRecursion = option(src, "recursion")
 	resolve.AllowSet = option(src, "set")
+	resolve.LoadBindsGlobally = option(src, "loadbindsglobally")
 }
 
 func option(chunk, name string) bool {

--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -343,3 +343,30 @@ print(hollo) ### `undefined: hollo \(did you mean hello\?\)`
 def f(abc):
    print(abd) ### `undefined: abd \(did you mean abc\?\)`
    print(goodbye) ### `undefined: goodbye$`
+
+---
+load("module", "x") # ok
+x = 1 ### `cannot reassign local x`
+load("module", "x") ### `cannot reassign top-level x`
+
+---
+# option:loadbindsglobally
+load("module", "x") # ok
+x = 1 ### `cannot reassign global x`
+load("module", "x") ### `cannot reassign global x`
+
+---
+# option:globalreassign
+load("module", "x") # ok
+x = 1 # ok
+load("module", "x") # ok
+
+---
+# option:globalreassign option:loadbindsglobally
+load("module", "x") # ok
+x = 1
+load("module", "x") # ok
+
+---
+_ = x # forward ref to file-local
+load("module", "x") # ok

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -24,6 +24,7 @@ import (
 func setOptions(src string) {
 	resolve.AllowFloat = option(src, "float")
 	resolve.AllowGlobalReassign = option(src, "globalreassign")
+	resolve.LoadBindsGlobally = option(src, "loadbindsglobally")
 	resolve.AllowLambda = option(src, "lambda")
 	resolve.AllowNestedDef = option(src, "nesteddef")
 	resolve.AllowRecursion = option(src, "recursion")
@@ -181,7 +182,7 @@ func load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	}
 
 	// TODO(adonovan): test load() using this execution path.
-	filename := filepath.Join(filepath.Dir(thread.Caller().Position().Filename()), module)
+	filename := filepath.Join(filepath.Dir(thread.TopFrame().Position().Filename()), module)
 	return starlark.ExecFile(thread, filename, nil, nil)
 }
 

--- a/starlark/testdata/assign.star
+++ b/starlark/testdata/assign.star
@@ -301,3 +301,35 @@ assert.eq(a, 8)
 # parenthesized LHS in augmented assignment (error)
 
 (a) += 5 ### "global variable a referenced before assignment"
+
+---
+# option:globalreassign
+load("assert.star", "assert")
+assert = 1
+load("assert.star", "assert")
+
+---
+# option:globalreassign option:loadbindsglobally
+load("assert.star", "assert")
+assert = 1
+load("assert.star", "assert")
+
+---
+# option:loadbindsglobally
+_ = assert ### "global variable assert referenced before assignment"
+load("assert.star", "assert")
+
+---
+_ = assert ### "local variable assert referenced before assignment"
+load("assert.star", "assert")
+
+---
+def f(): assert.eq(1, 1) # forward ref OK
+load("assert.star", "assert")
+f()
+
+---
+# option:loadbindsglobally
+def f(): assert.eq(1, 1) # forward ref OK
+load("assert.star", "assert")
+f()

--- a/syntax/binding.go
+++ b/syntax/binding.go
@@ -27,8 +27,8 @@ type Scope uint8
 
 const (
 	UndefinedScope   Scope = iota // name is not defined
-	LocalScope                    // name is local to its function
-	CellScope                     // name is local but shared with a nested function
+	LocalScope                    // name is local to its function or file
+	CellScope                     // name is function-local but shared with a nested function
 	FreeScope                     // name is cell of some enclosing function
 	GlobalScope                   // name is global to module
 	PredeclaredScope              // name is predeclared for this module (e.g. glob)
@@ -38,8 +38,8 @@ const (
 var scopeNames = [...]string{
 	UndefinedScope:   "undefined",
 	LocalScope:       "local",
-	FreeScope:        "free",
 	CellScope:        "cell",
+	FreeScope:        "free",
 	GlobalScope:      "global",
 	PredeclaredScope: "predeclared",
 	UniversalScope:   "universal",


### PR DESCRIPTION
Previously, load statements created global bindings.
As an often-unwanted consequence, names loaded by one module
would leak into its module dictionary and be visible to others.

This change to the resolver makes load define file-local variables
using a similar approach to Go: a new lexical block (the file block)
between function/comprehension blocks and the globals.
The set of names in the file block and the globals must be disjoint.

This incompatible change is guarded by the LoadBindsGlobally flag,
which is false by default. Users who want the old behavior may set
it to true, but they should prepare for it to go away entirely.
After that point, the old behavior may be simulated thus:
	- load("...", "x")
	+ load("...", _x="x"); x = _x # re-export
