### PR TITLE
starlark: NewDict(n) creates a dict with space for n elements

### DIFF
--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -36,6 +36,22 @@ type entry struct {
 	prevLink   **entry // address of link to this entry (perhaps &head)
 }
 
+func (ht *hashtable) init(size int) {
+	if size < 0 {
+		panic("size < 0")
+	}
+	nb := 1
+	for overloaded(size, nb) {
+		nb = nb << 1
+	}
+	if nb < 2 {
+		ht.table = ht.bucket0[:1]
+	} else {
+		ht.table = make([]bucket, nb)
+	}
+	ht.tailLink = &ht.head
+}
+
 func (ht *hashtable) freeze() {
 	if !ht.frozen {
 		ht.frozen = true
@@ -61,8 +77,7 @@ func (ht *hashtable) insert(k, v Value) error {
 		return fmt.Errorf("cannot insert into hash table during iteration")
 	}
 	if ht.table == nil {
-		ht.table = ht.bucket0[:1]
-		ht.tailLink = &ht.head
+		ht.init(1)
 	}
 	h, err := k.Hash()
 	if err != nil {

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -659,8 +659,19 @@ func (b *Builtin) BindReceiver(recv Value) *Builtin {
 }
 
 // A *Dict represents a Starlark dictionary.
+// The zero value of Dict is a valid empty dictionary.
+// If you know the exact final number of entries,
+// it is more efficient to call NewDict.
 type Dict struct {
 	ht hashtable
+}
+
+// NewDict returns a set with initial space for
+// at least size insertions before rehashing.
+func NewDict(size int) *Dict {
+	dict := new(Dict)
+	dict.ht.init(size)
+	return dict
 }
 
 func (d *Dict) Clear() error                                    { return d.ht.clear() }
@@ -916,8 +927,19 @@ func (it *tupleIterator) Next(p *Value) bool {
 func (it *tupleIterator) Done() {}
 
 // A Set represents a Starlark set value.
+// The zero value of Set is a valid empty set.
+// If you know the exact final number of elements,
+// it is more efficient to call NewSet.
 type Set struct {
 	ht hashtable // values are all None
+}
+
+// NewSet returns a dictionary with initial space for
+// at least size insertions before rehashing.
+func NewSet(size int) *Set {
+	set := new(Set)
+	set.ht.init(size)
+	return set
 }
 
 func (s *Set) Delete(k Value) (found bool, err error) { _, found, err = s.ht.delete(k); return }


### PR DESCRIPTION
Hashtable growth keeps showing up in my profiling.
Preallocating the table when the size is known makes it much faster.
The NewDict function lets API clients control this.

Also NewSet.