### PR TITLE
starlark: return EvalErr for errors originating in built-ins

### DIFF
--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -576,12 +576,6 @@ loop:
 		iter.Done()
 	}
 
-	if err != nil {
-		if _, ok := err.(*EvalError); !ok {
-			err = fr.errorf(f.Position(fr.pc), "%s", err.Error())
-		}
-	}
-
 	fr.locals = nil
 
 	return result, err

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -185,21 +185,19 @@ var tokenNames = [...]string{
 // A Position describes the location of a rune of input.
 type Position struct {
 	file *string // filename (indirect for compactness)
-	Line int32   // 1-based line number
-	Col  int32   // 1-based column number (strictly: rune)
+	Line int32   // 1-based line number; 0 if line unknown
+	Col  int32   // 1-based column (rune) number; 0 if column unknown
 }
 
 // IsValid reports whether the position is valid.
-func (p Position) IsValid() bool {
-	return p.Line >= 1
-}
+func (p Position) IsValid() bool { return p.file != nil }
 
 // Filename returns the name of the file containing this position.
 func (p Position) Filename() string {
 	if p.file != nil {
 		return *p.file
 	}
-	return "<unknown>"
+	return "<invalid>"
 }
 
 // MakePosition returns position with the specified components.
@@ -217,10 +215,14 @@ func (p Position) add(s string) Position {
 }
 
 func (p Position) String() string {
-	if p.Col > 0 {
-		return fmt.Sprintf("%s:%d:%d", p.Filename(), p.Line, p.Col)
+	file := p.Filename()
+	if p.Line > 0 {
+		if p.Col > 0 {
+			return fmt.Sprintf("%s:%d:%d", file, p.Line, p.Col)
+		}
+		return fmt.Sprintf("%s:%d", file, p.Line)
 	}
-	return fmt.Sprintf("%s:%d", p.Filename(), p.Line)
+	return file
 }
 
 func (p Position) isBefore(q Position) bool {


### PR DESCRIPTION
Previously, only errors originating in Starlark code would be
represented as EvalErr. The backtrace would include frames for
built-in functions that the exception passed through, but not
for the originating frame.

Also, report `<builtin>` not `<builtin>:1` for the position
of such frames. Position.Line==0 no longer implies !IsValid.

Added test of errors originating in a built-in frame.
