### PR TITLE
starlark: new CallStack API (and Frame deprecation)

### DIFF
--- a/starlark/debug.go
+++ b/starlark/debug.go
@@ -1,5 +1,7 @@
 package starlark
 
+import "go.starlark.net/syntax"
+
 // This file defines an experimental API for the debugging tools.
 // Some of these declarations expose details of internal packages.
 // (The debugger makes liberal use of exported fields of unexported types.)
@@ -16,3 +18,25 @@ package starlark
 //
 // THIS API IS EXPERIMENTAL AND MAY CHANGE WITHOUT NOTICE.
 func (fr *Frame) Local(i int) Value { return fr.locals[i] }
+
+// DebugFrame is the debugger API for a frame of the interpreter's call stack.
+//
+// Most applications have no need for this API; use CallFrame instead.
+//
+// Clients must not retain a DebugFrame nor call any of its methods once
+// the current built-in call has returned or execution has resumed
+// after a breakpoint as this may have unpredictable effects, including
+// but not limited to retention of object that would otherwise be garbage.
+type DebugFrame interface {
+	Callable() Callable        // returns the frame's function
+	Local(i int) Value         // returns the value of the (Starlark) frame's ith local variable
+	Position() syntax.Position // returns the current position of execution in this frame
+}
+
+// DebugFrame returns the debugger interface for
+// the specified frame of the interpreter's call stack.
+// Frame numbering is as for Thread.CallFrame.
+//
+// This function is intended for use in debugging tools.
+// Most applications should have no need for it; use CallFrame instead.
+func (thread *Thread) DebugFrame(depth int) DebugFrame { return thread.frameAt(depth) }

--- a/starlark/profile.go
+++ b/starlark/profile.go
@@ -130,7 +130,7 @@ func (thread *Thread) beginProfSpan() {
 		return // profiling not enabled
 	}
 
-	thread.frame.spanStart = nanotime()
+	thread.frameAt(0).spanStart = nanotime()
 }
 
 // TODO(adonovan): experiment with smaller values,
@@ -143,7 +143,7 @@ func (thread *Thread) endProfSpan() {
 	}
 
 	// Add the span to the thread's accumulator.
-	thread.proftime += time.Duration(nanotime() - thread.frame.spanStart)
+	thread.proftime += time.Duration(nanotime() - thread.frameAt(0).spanStart)
 	if thread.proftime < quantum {
 		return
 	}
@@ -159,7 +159,8 @@ func (thread *Thread) endProfSpan() {
 		time:   n * quantum,
 	}
 	ev.stack = ev.stackSpace[:0]
-	for fr := thread.frame; fr != nil; fr = fr.parent {
+	for i := range thread.stack {
+		fr := thread.frameAt(i)
 		ev.stack = append(ev.stack, profFrame{
 			pos: fr.Position(),
 			fn:  fr.Callable(),

--- a/starlarktest/starlarktest.go
+++ b/starlarktest/starlarktest.go
@@ -105,8 +105,9 @@ func error_(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, k
 		return nil, fmt.Errorf("error: got %d arguments, want 1", len(args))
 	}
 	buf := new(strings.Builder)
-	thread.Caller().WriteBacktrace(buf)
-	buf.WriteString("Error: ")
+	stk := thread.CallStack()
+	stk.Pop()
+	fmt.Fprintf(buf, "%sError: ", stk)
 	if s, ok := starlark.AsString(args[0]); ok {
 		buf.WriteString(s)
 	} else {


### PR DESCRIPTION
Prior to this CL, the interpreter stack was implemented as
a "spaghetti stack", a linked tree of Frames. This meant
that EvalError (for example) could make a copy of the stack
just by retaining a *Frame reference at its moment of creation,
but this forced every Starlark call to allocate a new Frame.
Also, in non-error cases (e.g. application built-ins that retain the
call stack), the retained references (linked lists of frames) were
pointers to Frames that were actively mutated by ongoing execution.

This change separates the internal and external data types for Frames.
Internal frames (type Frame) are still, for now, linked trees, but
the Frame type is deprecated and will soon be made private.
It may still be accessed through an interface, DebugFrame, for the
very few clients that need debugger-like powers of reflection.
DebugFrames must not be retained.

The external type for frames (as used by EvalError) is CallFrame,
a simple pair struct of name and position fields, a value type.
It does not reveal the Callable, as that would pin functions in memory.
And it does not lazily compute Position, as that would depend on Frame.pc,
which changes as execution continues.

A slice of CallFrame is represented by CallStack,
and it has various convenience methods.

Follow-up changes in two weeks will remove Frame and other
deprecated declarations, and implement two optimizations:
Frame recycling, by inline slice preallocation in the Thread, and
Frame.locals []Value recycling, by inline slice preallocation in the Frame.

New API:
+ type CallFrame -- a simple Name/Pos pair
+ type CallStack -- a list of CallFrame
+ type DebugFrame -- interface for (soon to be hidden) Frame
+ func (*Thread).CallStack
+ func (*Thread).CallStackDepth
+ func (*Thread).CallFrame
+ EvalError.CallStack field (NB: direction reversed from old Stack method)

Deprecations (will be removed in 2 weeks):
- Frame -- use CallFrame, or DebugFrame if you really must
- func (*EvalError).Stack  -- use CallStack
- func NewFrame -- clients have no business here
- func (*Frame).Parent -- use slice operations on CallStack
- EvalError.Frame field -- use CallStack
- Frame.WriteBacktrace -- use CallStack.Backtrace(); don't start with Frame
