### PR TITLE
starlark: remove deprecated Frame type

### DIFF
--- a/starlark/debug.go
+++ b/starlark/debug.go
@@ -17,7 +17,7 @@ import "go.starlark.net/syntax"
 // This function is provided only for debugging tools.
 //
 // THIS API IS EXPERIMENTAL AND MAY CHANGE WITHOUT NOTICE.
-func (fr *Frame) Local(i int) Value { return fr.locals[i] }
+func (fr *frame) Local(i int) Value { return fr.locals[i] }
 
 // DebugFrame is the debugger API for a frame of the interpreter's call stack.
 //

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -36,16 +36,17 @@ func (fn *Function) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Va
 	f := fn.funcode
 	fr := thread.frameAt(0)
 	nlocals := len(f.Locals)
-	stack := make([]Value, nlocals+f.MaxStack)
-	locals := stack[:nlocals:nlocals] // local variables, starting with parameters
-	stack = stack[nlocals:]
+	nspace := nlocals + f.MaxStack
+	space := make([]Value, nspace)
+	locals := space[:nlocals:nlocals] // local variables, starting with parameters
+	stack := space[nlocals:]          // operand stack
 
 	err := setArgs(locals, fn, args, kwargs)
 	if err != nil {
 		return nil, thread.evalError(err)
 	}
 
-	fr.locals = locals // for debugger
+	fr.locals = locals
 
 	if vmdebug {
 		fmt.Printf("Entering %s @ %s\n", f.Name, f.Position(0))


### PR DESCRIPTION
Also, an optimization: use the slack portion of the
Thread.stack slice as a free-list of frames, to avoid
allocating a frame on most calls.

THIS IS A BREAKING API CHANGE.
It will be submitted on May 6.
Clients: please switch to the new CallStack API before then.
