### PR TITLE
hash: allow only strings, and use a deterministic algorithm

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -710,8 +710,7 @@ values include `None`, Booleans, numbers, and strings, and tuples
 composed from hashable values.  Most mutable values, such as lists,
 dictionaries, and sets, are not hashable, even when frozen.
 Attempting to use a non-hashable value as a key in a dictionary
-results in a dynamic error, as does passing one to the built-in
-`hash` function.
+results in a dynamic error.
 
 A [dictionary expression](#dictionary-expressions) specifies a
 dictionary as a set of key/value pairs enclosed in braces:
@@ -1270,7 +1269,6 @@ application-defined, implement a few basic behaviors:
 str(x)		-- return a string representation of x
 type(x)		-- return a string describing the type of x
 bool(x)		-- convert x to a Boolean truth value
-hash(x)		-- return a hash code for x
 ```
 
 ### Identity and mutation
@@ -1349,8 +1347,7 @@ third without the possibility of a race condition.
 The `dict` and `set` data types are implemented using hash tables, so
 only _hashable_ values are suitable as keys of a `dict` or elements of
 a `set`. Attempting to use a non-hashable value as the key in a hash
-table, or as the operand of the `hash` built-in function, results in a
-dynamic error.
+table results in a dynamic error.
 
 The hash of a value is an unspecified integer chosen so that two equal
 values have the same hash, in other words, `x == y => hash(x) == hash(y)`.
@@ -3014,12 +3011,20 @@ getattr("banana", "split")("a")	       # ["b", "n", "n", ""], equivalent to "ban
 
 ### hash
 
-`hash(x)` returns an integer hash value for x such that `x == y` implies `hash(x) == hash(y)`.
+`hash(x)` returns an integer hash of a string x
+such that two equal strings have the same hash.
+In other words `x == y` implies `hash(x) == hash(y)`.
 
-`hash` fails if x, or any value upon which its hash depends, is unhashable.
+In the interests of reproducibility of Starlark program behavior over time and
+across implementations, the specific hash function is the same as that implemented by
+[java.lang.String.hashCode](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#hashCode),
+a simple polynomial accumulator over the UTF-16 transcoding of the string:
+ ```
+s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]
+```
 
-<b>Implementation note:</b> the Java implementation of the `hash`
-function accepts only strings.
+`hash` fails if given a non-string operand,
+even if the value is hashable and thus suitable as the key of dictionary.
 
 ### int
 
@@ -4100,7 +4105,6 @@ See [Starlark spec issue 20](https://github.com/bazelbuild/starlark/issues/20).
 * The parser accepts unary `+` expressions.
 * A method call `x.f()` may be separated into two steps: `y = x.f; y()`.
 * Dot expressions may appear on the left side of an assignment: `x.f = 1`.
-* `hash` accepts operands besides strings.
 * `sorted` accepts the additional parameters `key` and `reverse`.
 * `type(x)` returns `"builtin_function_or_method"` for built-in functions.
 * `if`, `for`, and `while` are permitted at top level (option: `-globalreassign`).

--- a/starlark/testdata/float.star
+++ b/starlark/testdata/float.star
@@ -199,7 +199,7 @@ assert.fails(lambda: float("+NaN"), "invalid syntax")
 assert.fails(lambda: float("-NaN"), "invalid syntax")
 
 # hash
-# Check that equal float and int values have the same hash.
+# Check that equal float and int values have the same internal hash.
 def checkhash():
   for a in [1.23e100, 1.23e10, 1.23e1, 1.23,
             1, 4294967295, 8589934591, 9223372036854775807]:
@@ -207,10 +207,10 @@ def checkhash():
       f = float(b)
       i = int(b)
       if f == i:
-        fh = hash(f)
-        ih = hash(i)
+        fh = {f: None}
+        ih = {i: None}
         if fh != ih:
-          assert.true(False, "hash(%s) = %d, hash(%s) = %s" % (f, fh, i, ih))
+          assert.true(False, "{%v: None} != {%v: None}: hashes vary" % fh, ih)
 checkhash()
 
 # string formatting

--- a/starlark/testdata/function.star
+++ b/starlark/testdata/function.star
@@ -110,11 +110,9 @@ yang(True)
 assert.eq(calls, ["yang", "yin"])
 
 
-# hash(builtin_function_or_method) should be deterministic.
+# builtin_function_or_method use identity equivalence.
 closures = set(["".count for _ in range(10)])
 assert.eq(len(closures), 10)
-hashes = set([hash("".count) for _ in range(10)])
-assert.eq(len(hashes), 1)
 
 ---
 # Default values of function parameters are mutable.

--- a/starlark/testdata/string.star
+++ b/starlark/testdata/string.star
@@ -142,6 +142,17 @@ assert.fails(lambda: "" in 1, "unknown binary op: string in int")
 assert.eq("hello", "he"+"llo")
 assert.ne("hello", "Hello")
 
+# hash must follow java.lang.String.hashCode.
+wanthash = {
+    "": 0,
+    "\0" * 100: 0,
+    "hello": 99162322,
+    "world": 113318802,
+    "Hello, 世界!": 417292677,
+}
+gothash = {s: hash(s) for s in wanthash}
+assert.eq(gothash, wanthash)
+
 # TODO(adonovan): ordered comparisons
 
 # string % tuple formatting

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -101,7 +101,8 @@ type Value interface {
 
 	// Hash returns a function of x such that Equals(x, y) => Hash(x) == Hash(y).
 	// Hash may fail if the value's type is not hashable, or if the value
-	// contains a non-hashable value.
+	// contains a non-hashable value. The hash is used only by dictionaries and
+	// is not exposed to the Starlark program.
 	Hash() (uint32, error)
 }
 


### PR DESCRIPTION
Previously, hash would allow any operand defined as hashable
by the spec, and would use (for strings at least) a fast
hardware implementation that varies across process restarts.

+ Test.
