### PR TITLE
internal/compile: opt: emit a combined tuple for defaults + freevars

### DIFF
--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -64,7 +64,7 @@ func TestPlusFolding(t *testing.T) {
 			t.Errorf("#%d: %v", i, err)
 			continue
 		}
-		got := disassemble(Expr(expr, "<expr>", locals))
+		got := disassemble(Expr(expr, "<expr>", locals).Toplevel)
 		if test.want != got {
 			t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
 				test.src, got, test.want)


### PR DESCRIPTION
The function knows where to split it.

Also, refactor the common parts of all Functions in the same module---
program, predeclared, globals, constants---into a separate data structure,
module. This reduces the size of Function from 14 words to 8.
