### PR TITLE
internal/compile: record column information for each PC offset

### DIFF
--- a/internal/compile/compile_test.go
+++ b/internal/compile/compile_test.go
@@ -54,8 +54,8 @@ y = mul(x, n)
 		t.Fatalf("newProg.Init call returned err %v, want *EvalError", err)
 	}
 	const want = `Traceback (most recent call last):
-  mul.star:5: in <toplevel>
-  mul.star:3: in mul
+  mul.star:5:8: in <toplevel>
+  mul.star:3:14: in mul
 Error: unknown binary op: string * NoneType`
 	if got := evalErr.Backtrace(); got != want {
 		t.Fatalf("got <<%s>>, want <<%s>>", got, want)

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -432,8 +432,8 @@ f()
 	if _, err := starlark.ExecFile(thread, "foo.star", src, nil); err != nil {
 		t.Fatal(err)
 	}
-	want := "foo.star:2: <toplevel>: hello\n" +
-		"foo.star:3: f: hello, world\n"
+	want := "foo.star:2:6: <toplevel>: hello\n" +
+		"foo.star:3:15: f: hello, world\n"
 	if got := buf.String(); got != want {
 		t.Errorf("output was %s, want %s", got, want)
 	}
@@ -507,12 +507,12 @@ i()
 	_, err := starlark.ExecFile(thread, "crash.star", src, nil)
 	// Compiled code currently has no column information.
 	const want = `Traceback (most recent call last):
-  crash.star:6: in <toplevel>
-  crash.star:5: in i
-  crash.star:4: in h
+  crash.star:6:2: in <toplevel>
+  crash.star:5:18: in i
+  crash.star:4:20: in h
   <builtin>: in min
-  crash.star:3: in g
-  crash.star:2: in f
+  crash.star:3:12: in g
+  crash.star:2:19: in f
 Error: floored division by zero`
 	if got := getBacktrace(err); got != want {
 		t.Errorf("error was %s, want %s", got, want)
@@ -529,12 +529,12 @@ f()
 `
 	for i, want := range []string{
 		0: `Traceback (most recent call last):
-  crash.star:3: in <toplevel>
-  crash.star:2: in f
+  crash.star:3:2: in <toplevel>
+  crash.star:2:20: in f
 Error: floored division by zero`,
 		1: `Traceback (most recent call last):
-  crash.star:3: in <toplevel>
-  crash.star:2: in f
+  crash.star:3:2: in <toplevel>
+  crash.star:2:17: in f
   <builtin>: in join
 Error: join: in list, want string, got int`,
 	} {


### PR DESCRIPTION
Prior to this CL, the line-number table in the compiled code
recorded only the line number for each program counter value.
This change causes it to record columns too.

By stealing bits from the PC and line fields, we can encode the
additional information in the same 16 bits of space, again using
the same delta encoding approach for columns.

The field widths (uint4 for Δpc, int5 for Δline, and int6 for Δcol)
were chosen after analysis of a large set of files to minimize
the frequency of overflows, which are more common now but still
account for only about 2.5% of all rows.

The decompressed LNTs are 50% bigger, but only a minority
of functions' LNTs are materialized in a typical program
due to calls to Funcode.Position via Thread.CallStack.

Fixes #176
