### PR TITLE
syntax: drop legacy (0644) octal literals

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -290,7 +290,7 @@ has string, integer, and floating-point literals.
 0                               # int
 123                             # decimal int
 0x7f                            # hexadecimal int
-0755                            # octal int
+0o755                           # octal int
 0b1011                          # binary int
 
 0.0     0.       .0             # float
@@ -307,8 +307,7 @@ Integer and floating-point literal tokens are defined by the following grammar:
 ```grammar {.good}
 int         = decimal_lit | octal_lit | hex_lit | binary_lit .
 decimal_lit = ('1' … '9') {decimal_digit} .
-octal_lit   = '0' {octal_digit} .
-            | '0' ('o'|'O') octal_digit {octal_digit} .
+octal_lit   = '0' ('o'|'O') octal_digit {octal_digit} .
 hex_lit     = '0' ('x'|'X') hex_digit {hex_digit} .
 binary_lit  = '0' ('b'|'B') binary_digit {binary_digit} .
 

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -951,13 +951,8 @@ func (sc *scanner) scanNumber(val *tokenValue, c rune) Token {
 			} else if c == 'e' || c == 'E' {
 				exponent = true
 			} else if octal && !allzeros {
-				// We must support old octal until the Java
-				// implementation groks the new one.
-				// TODO(adonovan): reenable the check.
-				if false {
-					sc.endToken(val)
-					sc.errorf(sc.pos, "obsolete form of octal literal; use 0o%s", val.raw[1:])
-				}
+				sc.endToken(val)
+				sc.errorf(sc.pos, "obsolete form of octal literal; use 0o%s", val.raw[1:])
 			}
 		}
 	} else {

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -183,9 +183,7 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		{"0o12934e1", `10 9.340000e+03 EOF`},
 		{"0o123.", `83 . EOF`},
 		{"0o123.1", `83 1.000000e-01 EOF`},
-		// TODO(adonovan): reenable later.
-		// {"0123", `obsolete form of octal literal; use 0o123`},
-		{"0123", `83 EOF`},
+		{"0123", `foo.star:1:5: obsolete form of octal literal; use 0o123`},
 		{"012834", `foo.star:1:1: invalid int literal`},
 		{"012934", `foo.star:1:1: invalid int literal`},
 		{"i = 012934", `foo.star:1:5: invalid int literal`},


### PR DESCRIPTION
Use 0o644 instead.

See also https://github.com/bazelbuild/bazel/issues/8059
