### PR TITLE
spec: add '0' as valid decimal_lit

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -331,7 +331,7 @@ TODO: define string_lit, indent, outdent, semicolon, newline, eof
 
 These are the main data types built in to the interpreter:
 
-```shell
+```python
 NoneType                     # the type of None
 bool                         # True or False
 int                          # a signed integer of arbitrary magnitude

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -307,7 +307,7 @@ Integer and floating-point literal tokens are defined by the following grammar:
 
 ```grammar {.good}
 int         = decimal_lit | octal_lit | hex_lit | binary_lit .
-decimal_lit = ('1' … '9') {decimal_digit} .
+decimal_lit = ('1' … '9') {decimal_digit} | '0' .
 octal_lit   = '0' ('o'|'O') octal_digit {octal_digit} .
 hex_lit     = '0' ('x'|'X') hex_digit {hex_digit} .
 binary_lit  = '0' ('b'|'B') binary_digit {binary_digit} .


### PR DESCRIPTION
Since each of octal_lit, hex_lit and binary_lit
specify a mandatory prefix (e.g. 0o, 0x and 0b),
we extend decimal_lit to allow for the decimal
literal zero.