### PR TITLE
repl: treat load bindings as global in the REPL

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -30,6 +30,7 @@ import (
 	"os/signal"
 
 	"github.com/chzyer/readline"
+	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 )
@@ -112,6 +113,13 @@ func rep(rl *readline.Instance, thread *starlark.Thread, globals starlark.String
 		PrintError(err)
 		return nil
 	}
+
+	// Treat load bindings as global (like they used to be) in the REPL.
+	// This is a workaround for github.com/google/starlark-go/issues/224.
+	// TODO(adonovan): not safe wrt concurrent interpreters.
+	// Come up with a more principled solution (or plumb options everywhere).
+	defer func(prev bool) { resolve.LoadBindsGlobally = prev }(resolve.LoadBindsGlobally)
+	resolve.LoadBindsGlobally = true
 
 	if expr := soleExpr(f); expr != nil {
 		// eval


### PR DESCRIPTION
PR #178 made them local to the file, but each statement in the REPL is
its own "file". This change sets (and restores) the flag for the
legacy behavior in the REPL.

This change is more workaround than fix, as it is not safe w.r.t.
concurrent interpreters, but we already have problems of that kind.
Perhaps we need to plumb options more thoroughly instead of using
globals.

Updates #224