### PR TITLE
Remove `not` from binary operators in the spec

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1720,7 +1720,6 @@ Starlark has the following binary operators, arranged in order of increasing pre
 ```text
 or
 and
-not
 ==   !=   <    >   <=   >=   in   not in
 |
 ^
@@ -1739,7 +1738,6 @@ BinaryExpr = Test {Binop Test} .
 
 Binop = 'or'
       | 'and'
-      | 'not'
       | '==' | '!=' | '<' | '>' | '<=' | '>=' | 'in' | 'not' 'in'
       | '|'
       | '^'


### PR DESCRIPTION
`not` is not a binary operator and shouldn't be mentioned in their precedence order.