### PR TITLE
starlark,resolve,internal/compile: replace log.Fatal with panic

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1000,7 +1000,7 @@ func (fcomp *fcomp) set(id *syntax.Ident) {
 	case resolve.Global:
 		fcomp.emit1(SETGLOBAL, uint32(bind.Index))
 	default:
-		log.Fatalf("%s: set(%s): not global/local/cell (%d)", id.NamePos, id.Name, bind.Scope)
+		log.Panicf("%s: set(%s): not global/local/cell (%d)", id.NamePos, id.Name, bind.Scope)
 	}
 }
 
@@ -1028,7 +1028,7 @@ func (fcomp *fcomp) lookup(id *syntax.Ident) {
 	case resolve.Universal:
 		fcomp.emit1(UNIVERSAL, fcomp.pcomp.nameIndex(id.Name))
 	default:
-		log.Fatalf("%s: compiler.lookup(%s): scope = %d", id.NamePos, id.Name, bind.Scope)
+		log.Panicf("%s: compiler.lookup(%s): scope = %d", id.NamePos, id.Name, bind.Scope)
 	}
 }
 
@@ -1224,7 +1224,7 @@ func (fcomp *fcomp) stmt(stmt syntax.Stmt) {
 
 	default:
 		start, _ := stmt.Span()
-		log.Fatalf("%s: exec: unexpected statement %T", start, stmt)
+		log.Panicf("%s: exec: unexpected statement %T", start, stmt)
 	}
 }
 
@@ -1374,7 +1374,7 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 		case syntax.TILDE:
 			fcomp.emit(TILDE)
 		default:
-			log.Fatalf("%s: unexpected unary op: %s", e.OpPos, e.Op)
+			log.Panicf("%s: unexpected unary op: %s", e.OpPos, e.Op)
 		}
 
 	case *syntax.BinaryExpr:
@@ -1436,7 +1436,7 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 
 	default:
 		start, _ := e.Span()
-		log.Fatalf("%s: unexpected expr %T", start, e)
+		log.Panicf("%s: unexpected expr %T", start, e)
 	}
 }
 
@@ -1619,7 +1619,7 @@ func (fcomp *fcomp) binop(pos syntax.Position, op syntax.Token) {
 		fcomp.emit(Opcode(op-syntax.EQL) + EQL)
 
 	default:
-		log.Fatalf("%s: unexpected binary op: %s", pos, op)
+		log.Panicf("%s: unexpected binary op: %s", pos, op)
 	}
 }
 
@@ -1778,7 +1778,7 @@ func (fcomp *fcomp) comprehension(comp *syntax.Comprehension, clauseIndex int) {
 	}
 
 	start, _ := clause.Span()
-	log.Fatalf("%s: unexpected comprehension clause %T", start, clause)
+	log.Panicf("%s: unexpected comprehension clause %T", start, clause)
 }
 
 func (fcomp *fcomp) function(f *resolve.Function) {

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -557,7 +557,7 @@ func (r *resolver) stmt(stmt syntax.Stmt) {
 		}
 
 	default:
-		log.Fatalf("unexpected stmt %T", stmt)
+		log.Panicf("unexpected stmt %T", stmt)
 	}
 }
 
@@ -782,7 +782,7 @@ func (r *resolver) expr(e syntax.Expr) {
 		r.expr(e.X)
 
 	default:
-		log.Fatalf("unexpected expr %T", e)
+		log.Panicf("unexpected expr %T", e)
 	}
 }
 
@@ -901,7 +901,7 @@ func lookupLocal(use use) *Binding {
 		if bind, ok := env.bindings[use.id.Name]; ok {
 			if bind.Scope == Free {
 				// shouldn't exist till later
-				log.Fatalf("%s: internal error: %s, %v", use.id.NamePos, use.id.Name, bind)
+				log.Panicf("%s: internal error: %s, %v", use.id.NamePos, use.id.Name, bind)
 			}
 			return bind // found
 		}

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -377,7 +377,7 @@ func makeToplevelFunction(prog *compile.Program, predeclared StringDict) *Functi
 		case float64:
 			v = Float(c)
 		default:
-			log.Fatalf("unexpected constant %T: %v", c, c)
+			log.Panicf("unexpected constant %T: %v", c, c)
 		}
 		constants[i] = v
 	}


### PR DESCRIPTION
I've replaced some calls to `log.Fatal` and `log.Fatalf` with panics. I believe those are all unreachable internal errors (in practice) so this is a somewhat inconsequential nitpick; however if this code were ever to execute, I believe a recoverable panic, carrying stacktrace information is preferrable to getting the calling process instantly killed.