### PR TITLE
starlark: preserve the backtrace in load() errors

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -190,6 +190,7 @@ func (stack CallStack) String() string {
 type EvalError struct {
 	Msg       string
 	CallStack CallStack
+	cause     error
 }
 
 // A CallFrame represents the function name and current
@@ -210,6 +211,7 @@ func (thread *Thread) evalError(err error) *EvalError {
 	return &EvalError{
 		Msg:       err.Error(),
 		CallStack: thread.CallStack(),
+		cause:     err,
 	}
 }
 
@@ -220,6 +222,8 @@ func (e *EvalError) Error() string { return e.Msg }
 func (e *EvalError) Backtrace() string {
 	return fmt.Sprintf("%sError: %s", e.CallStack, e.Msg)
 }
+
+func (e *EvalError) Unwrap() error { return e.cause }
 
 // A Program is a compiled Starlark program.
 //

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -503,7 +503,10 @@ loop:
 			dict, err2 := thread.Load(thread, module)
 			thread.beginProfSpan()
 			if err2 != nil {
-				err = fmt.Errorf("cannot load %s: %v", module, err2)
+				err = wrappedError{
+					msg:   fmt.Sprintf("cannot load %s: %v", module, err2),
+					cause: err2,
+				}
 				break loop
 			}
 
@@ -588,6 +591,21 @@ loop:
 	fr.locals = nil
 
 	return result, err
+}
+
+type wrappedError struct {
+	msg   string
+	cause error
+}
+
+func (e wrappedError) Error() string {
+	return e.msg
+}
+
+// Implements the xerrors.Wrapper interface
+// https://godoc.org/golang.org/x/xerrors#Wrapper
+func (e wrappedError) Unwrap() error {
+	return e.cause
 }
 
 // mandatory is a sentinel value used in a function's defaults tuple


### PR DESCRIPTION
The errors from a load() were dropping the stack trace on the floor. Hopefully this should be non-controversial.

I also considered using the Go 1.13 error wrapping API, but decided that there are probably too many starlark users on Go 1.12 