### PR TITLE
spec: fix a broken link

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1257,7 +1257,7 @@ The [dot expression](#dot-expressions) `.split` is a dynamic operation
 on the value returned by `get_filename()`.
 
 
-## Value concepts {#value-concepts}
+## Value concepts
 
 Starlark has eleven core [data types](#data-types).  An application
 that embeds the Starlark intepreter may define additional types that


### PR DESCRIPTION
The ToC links to #value-concepts, but the actual anchor being generated was #value-concepts-value-concepts.

I changed the anchor, but let me know if you'd rather I changed the ToC link