### PR TITLE
.travis.yml: test that module is tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ go:
     - "1.11.x"
     - "master"
 
+env:
+    - "GO111MODULE=on"
+
 script:
     - "go test -mod=readonly ./..."
     - "cp go.mod go.mod.orig"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
-sudo: false
-
 language: go
 
 go_import_path: go.starlark.net
 
 go:
-    - 1.10.x
-    - master
+    - "1.11.x"
+    - "master"
+
+script:
+    - "go test -mod=readonly ./..."
+    - "cp go.mod go.mod.orig"
+    - "cp go.sum go.sum.orig"
+    - "go mod tidy"
+    - "diff go.mod.orig go.mod"
+    - "diff go.sum.orig go.sum"


### PR DESCRIPTION
Removed "sudo: false". It has no effect.

Added explicit test script.

* 'go test -mod=readonly ./...' will report an error if go.mod or
  go.sum is incomplete, since no requirements may be added with
  -mod=readonly.
* The rest of the script checks that go.mod and go.sum do not change
  after running 'go mod tidy'. This verifies that there are no
  redundant requirements or sums to remove.

Changed minimum Go version to 1.11.x. This is the oldest version
with support for modules. Older versions will still work in GOPATH
mode, but versions lower than 1.12 are unsupported by the Go, so
there's little point in adding additional test code for them.