### PR TITLE
Fix ineffective assignments

### DIFF
--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -276,6 +276,7 @@ func readSource(filename string, src interface{}) ([]byte, error) {
 		data, err := ioutil.ReadAll(src)
 		if err != nil {
 			err = &os.PathError{Op: "read", Path: filename, Err: err}
+			return nil, err
 		}
 		return data, nil
 	case nil:
@@ -1018,7 +1019,7 @@ func (sc *scanner) scanNumber(val *tokenValue, c rune) Token {
 			val.int, err = strconv.ParseInt(s, 0, 64)
 			if err != nil {
 				num := new(big.Int)
-				var ok bool = true
+				var ok bool
 				val.bigInt, ok = num.SetString(s, 0)
 				if ok {
 					err = nil


### PR DESCRIPTION
* `return nil, err` after assigning to `err` (rather than ignoring it)
* removed initialization of a variable just before it's re-assigned

Both of these issues were found in the Go Repord Card:
https://goreportcard.com/report/github.com/google/starlark-go#ineffassign