### PR TITLE
Also run tests with Go 1.12.x and 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go_import_path: go.starlark.net
 
 go:
     - "1.11.x"
+    - "1.12.x"
+    - "1.13.x"
     - "master"
 
 env:


### PR DESCRIPTION
The current setup only runs tests with Go 1.11.x and the latest source
code on the `master` branch, but is not running the more recent releases
1.12.x and 1.13.x which may be widely in use. This change includes both
of those versions as well.