### PR TITLE
starlark: built-in types map of *Builtin

### DIFF
--- a/starlark/library.go
+++ b/starlark/library.go
@@ -69,12 +69,41 @@ func init() {
 	}
 }
 
-type builtinMethod func(b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
+type builtinMethod func(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
+
+type builtins struct {
+	attrs map[string]*Builtin
+	names []string
+}
+
+func (bs *builtins) bindAttr(recv Value, name string) (Value, error) {
+	b := bs.attrs[name]
+	if b == nil {
+		return nil, nil // no such method
+	}
+	return b.BindReceiver(recv), nil
+}
+func (bs *builtins) attrNames() []string {
+	names := make([]string, len(bs.names))
+	copy(names, bs.names)
+	return names
+}
+
+func newBuiltins(methods map[string]builtinMethod) *builtins {
+	attrs := make(map[string]*Builtin, len(methods))
+	names := make([]string, 0, len(methods))
+	for k, m := range methods {
+		attrs[k] = NewBuiltin(k, m)
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return &builtins{attrs: attrs, names: names}
+}
 
 // methods of built-in types
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#built-in-methods
 var (
-	dictMethods = map[string]builtinMethod{
+	dictMethods = newBuiltins(map[string]builtinMethod{
 		"clear":      dict_clear,
 		"get":        dict_get,
 		"items":      dict_items,
@@ -84,9 +113,9 @@ var (
 		"setdefault": dict_setdefault,
 		"update":     dict_update,
 		"values":     dict_values,
-	}
+	})
 
-	listMethods = map[string]builtinMethod{
+	listMethods = newBuiltins(map[string]builtinMethod{
 		"append": list_append,
 		"clear":  list_clear,
 		"extend": list_extend,
@@ -94,9 +123,9 @@ var (
 		"insert": list_insert,
 		"pop":    list_pop,
 		"remove": list_remove,
-	}
+	})
 
-	stringMethods = map[string]builtinMethod{
+	stringMethods = newBuiltins(map[string]builtinMethod{
 		"capitalize":     string_capitalize,
 		"codepoint_ords": string_iterable,
 		"codepoints":     string_iterable, // sic
@@ -130,34 +159,12 @@ var (
 		"strip":          string_strip,
 		"title":          string_title,
 		"upper":          string_upper,
-	}
+	})
 
-	setMethods = map[string]builtinMethod{
+	setMethods = newBuiltins(map[string]builtinMethod{
 		"union": set_union,
-	}
+	})
 )
-
-func builtinAttr(recv Value, name string, methods map[string]builtinMethod) (Value, error) {
-	method := methods[name]
-	if method == nil {
-		return nil, nil // no such method
-	}
-
-	// Allocate a closure over 'method'.
-	impl := func(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-		return method(b, args, kwargs)
-	}
-	return NewBuiltin(name, impl).BindReceiver(recv), nil
-}
-
-func builtinAttrNames(methods map[string]builtinMethod) []string {
-	names := make([]string, 0, len(methods))
-	for name := range methods {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
 
 // ---- built-in functions ----
 
@@ -1067,7 +1074,7 @@ func zip(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 // ---- methods of built-in types ---
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·get
-func dict_get(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var key, dflt Value
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
@@ -1083,7 +1090,7 @@ func dict_get(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·clear
-func dict_clear(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1091,7 +1098,7 @@ func dict_clear(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·items
-func dict_items(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1104,7 +1111,7 @@ func dict_items(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·keys
-func dict_keys(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_keys(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1112,7 +1119,7 @@ func dict_keys(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·pop
-func dict_pop(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var k, d Value
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k, &d); err != nil {
 		return nil, err
@@ -1128,7 +1135,7 @@ func dict_pop(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·popitem
-func dict_popitem(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_popitem(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1145,7 +1152,7 @@ func dict_popitem(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·setdefault
-func dict_setdefault(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_setdefault(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var key, dflt Value = nil, None
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
@@ -1163,7 +1170,7 @@ func dict_setdefault(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
-func dict_update(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(args) > 1 {
 		return nil, fmt.Errorf("update: got %d arguments, want at most 1", len(args))
 	}
@@ -1174,7 +1181,7 @@ func dict_update(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
-func dict_values(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1187,7 +1194,7 @@ func dict_values(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·append
-func list_append(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_append(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var object Value
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &object); err != nil {
 		return nil, err
@@ -1201,7 +1208,7 @@ func list_append(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·clear
-func list_clear(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1212,7 +1219,7 @@ func list_clear(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·extend
-func list_extend(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_extend(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
 	var iterable Iterable
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
@@ -1226,7 +1233,7 @@ func list_extend(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·index
-func list_index(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var value, start_, end_ Value
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &value, &start_, &end_); err != nil {
 		return nil, err
@@ -1249,7 +1256,7 @@ func list_index(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·insert
-func list_insert(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_insert(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
 	var index int
 	var object Value
@@ -1279,7 +1286,7 @@ func list_insert(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·remove
-func list_remove(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
 	var value Value
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &value); err != nil {
@@ -1300,7 +1307,7 @@ func list_remove(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·pop
-func list_pop(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver()
 	list := recv.(*List)
 	n := list.Len()
@@ -1324,7 +1331,7 @@ func list_pop(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·capitalize
-func string_capitalize(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1347,7 +1354,7 @@ func string_capitalize(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 // - codepoints: successive substrings that encode a single Unicode code point.
 // - elem_ords: numeric values of successive bytes
 // - codepoint_ords: numeric values of successive Unicode code points
-func string_iterable(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1359,7 +1366,7 @@ func string_iterable(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·count
-func string_count(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var sub string
 	var start_, end_ Value
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
@@ -1380,7 +1387,7 @@ func string_count(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalnum
-func string_isalnum(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1394,7 +1401,7 @@ func string_isalnum(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalpha
-func string_isalpha(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1408,7 +1415,7 @@ func string_isalpha(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isdigit
-func string_isdigit(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1422,7 +1429,7 @@ func string_isdigit(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·islower
-func string_islower(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_islower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1447,7 +1454,7 @@ func isCasedRune(r rune) bool {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isspace
-func string_isspace(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1461,7 +1468,7 @@ func string_isspace(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·istitle
-func string_istitle(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1494,7 +1501,7 @@ func string_istitle(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isupper
-func string_isupper(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_isupper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1503,12 +1510,12 @@ func string_isupper(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·find
-func string_find(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_find(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	return string_find_impl(b, args, kwargs, true, false)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·format
-func string_format(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_format(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	format := string(b.Receiver().(String))
 	var auto, manual bool // kinds of positional indexing used
 	buf := new(strings.Builder)
@@ -1664,12 +1671,12 @@ func decimal(s string) (x int, ok bool) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·index
-func string_index(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	return string_find_impl(b, args, kwargs, false, false)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·join
-func string_join(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var iterable Iterable
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
@@ -1693,7 +1700,7 @@ func string_join(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lower
-func string_lower(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_lower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1701,7 +1708,7 @@ func string_lower(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·partition
-func string_partition(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var sep string
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sep); err != nil {
@@ -1730,7 +1737,7 @@ func string_partition(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·replace
-func string_replace(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_replace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var old, new string
 	count := -1
@@ -1741,18 +1748,18 @@ func string_replace(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rfind
-func string_rfind(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_rfind(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	return string_find_impl(b, args, kwargs, true, true)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rindex
-func string_rindex(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_rindex(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	return string_find_impl(b, args, kwargs, false, true)
 }
 
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·startswith
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·endswith
-func string_startswith(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	var start, end Value = None, None
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x, &start, &end); err != nil {
@@ -1797,7 +1804,7 @@ func string_startswith(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·strip
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lstrip
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rstrip
-func string_strip(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var chars string
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &chars); err != nil {
 		return nil, err
@@ -1828,7 +1835,7 @@ func string_strip(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·title
-func string_title(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1854,7 +1861,7 @@ func string_title(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·upper
-func string_upper(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_upper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
@@ -1863,7 +1870,7 @@ func string_upper(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·split
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rsplit
-func string_split(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_split(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var sep_ Value
 	maxsplit := -1
@@ -1966,7 +1973,7 @@ func splitspace(s string, max int) []string {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·splitlines
-func string_splitlines(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var keepends bool
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &keepends); err != nil {
 		return nil, err
@@ -1991,7 +1998,7 @@ func string_splitlines(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·union.
-func set_union(b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_union(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &iterable); err != nil {
 		return nil, err

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -489,8 +489,8 @@ func (s String) Slice(start, end, step int) Value {
 	return String(str)
 }
 
-func (s String) Attr(name string) (Value, error) { return stringMethods.bindAttr(s, name) }
-func (s String) AttrNames() []string             { return stringMethods.attrNames() }
+func (s String) Attr(name string) (Value, error) { return builtinAttr(s, name, stringMethods) }
+func (s String) AttrNames() []string             { return builtinAttrNames(stringMethods) }
 
 func (x String) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(String)
@@ -708,8 +708,8 @@ func (d *Dict) Freeze()                                         { d.ht.freeze() 
 func (d *Dict) Truth() Bool                                     { return d.Len() > 0 }
 func (d *Dict) Hash() (uint32, error)                           { return 0, fmt.Errorf("unhashable type: dict") }
 
-func (d *Dict) Attr(name string) (Value, error) { return dictMethods.bindAttr(d, name) }
-func (d *Dict) AttrNames() []string             { return dictMethods.attrNames() }
+func (d *Dict) Attr(name string) (Value, error) { return builtinAttr(d, name, dictMethods) }
+func (d *Dict) AttrNames() []string             { return builtinAttrNames(dictMethods) }
 
 func (x *Dict) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Dict)
@@ -796,8 +796,8 @@ func (l *List) Slice(start, end, step int) Value {
 	return NewList(list)
 }
 
-func (l *List) Attr(name string) (Value, error) { return listMethods.bindAttr(l, name) }
-func (l *List) AttrNames() []string             { return listMethods.attrNames() }
+func (l *List) Attr(name string) (Value, error) { return builtinAttr(l, name, listMethods) }
+func (l *List) AttrNames() []string             { return builtinAttrNames(listMethods) }
 
 func (l *List) Iterate() Iterator {
 	if !l.frozen {
@@ -975,8 +975,8 @@ func (s *Set) Freeze()                                { s.ht.freeze() }
 func (s *Set) Hash() (uint32, error)                  { return 0, fmt.Errorf("unhashable type: set") }
 func (s *Set) Truth() Bool                            { return s.Len() > 0 }
 
-func (s *Set) Attr(name string) (Value, error) { return setMethods.bindAttr(s, name) }
-func (s *Set) AttrNames() []string             { return setMethods.attrNames() }
+func (s *Set) Attr(name string) (Value, error) { return builtinAttr(s, name, setMethods) }
+func (s *Set) AttrNames() []string             { return builtinAttrNames(setMethods) }
 
 func (x *Set) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Set)

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -489,8 +489,8 @@ func (s String) Slice(start, end, step int) Value {
 	return String(str)
 }
 
-func (s String) Attr(name string) (Value, error) { return builtinAttr(s, name, stringMethods) }
-func (s String) AttrNames() []string             { return builtinAttrNames(stringMethods) }
+func (s String) Attr(name string) (Value, error) { return stringMethods.bindAttr(s, name) }
+func (s String) AttrNames() []string             { return stringMethods.attrNames() }
 
 func (x String) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(String)
@@ -708,8 +708,8 @@ func (d *Dict) Freeze()                                         { d.ht.freeze() 
 func (d *Dict) Truth() Bool                                     { return d.Len() > 0 }
 func (d *Dict) Hash() (uint32, error)                           { return 0, fmt.Errorf("unhashable type: dict") }
 
-func (d *Dict) Attr(name string) (Value, error) { return builtinAttr(d, name, dictMethods) }
-func (d *Dict) AttrNames() []string             { return builtinAttrNames(dictMethods) }
+func (d *Dict) Attr(name string) (Value, error) { return dictMethods.bindAttr(d, name) }
+func (d *Dict) AttrNames() []string             { return dictMethods.attrNames() }
 
 func (x *Dict) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Dict)
@@ -796,8 +796,8 @@ func (l *List) Slice(start, end, step int) Value {
 	return NewList(list)
 }
 
-func (l *List) Attr(name string) (Value, error) { return builtinAttr(l, name, listMethods) }
-func (l *List) AttrNames() []string             { return builtinAttrNames(listMethods) }
+func (l *List) Attr(name string) (Value, error) { return listMethods.bindAttr(l, name) }
+func (l *List) AttrNames() []string             { return listMethods.attrNames() }
 
 func (l *List) Iterate() Iterator {
 	if !l.frozen {
@@ -975,8 +975,8 @@ func (s *Set) Freeze()                                { s.ht.freeze() }
 func (s *Set) Hash() (uint32, error)                  { return 0, fmt.Errorf("unhashable type: set") }
 func (s *Set) Truth() Bool                            { return s.Len() > 0 }
 
-func (s *Set) Attr(name string) (Value, error) { return builtinAttr(s, name, setMethods) }
-func (s *Set) AttrNames() []string             { return builtinAttrNames(setMethods) }
+func (s *Set) Attr(name string) (Value, error) { return setMethods.bindAttr(s, name) }
+func (s *Set) AttrNames() []string             { return setMethods.attrNames() }
 
 func (x *Set) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Set)


### PR DESCRIPTION
NewBuiltin and Sort are called at init. Slightly faster method calls:

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkStringHash/hard-1-8         3.90          3.65          -6.41%
BenchmarkStringHash/soft-1-8         2.69          2.21          -17.84%
BenchmarkStringHash/hard-2-8         4.52          4.38          -3.10%
BenchmarkStringHash/soft-2-8         3.55          2.68          -24.51%
BenchmarkStringHash/hard-4-8         5.32          5.07          -4.70%
BenchmarkStringHash/soft-4-8         5.32          3.63          -31.77%
BenchmarkStringHash/hard-8-8         7.58          7.03          -7.26%
BenchmarkStringHash/soft-8-8         6.62          5.60          -15.41%
BenchmarkStringHash/hard-16-8        7.00          6.43          -8.14%
BenchmarkStringHash/soft-16-8        13.1          9.44          -27.94%
BenchmarkStringHash/hard-32-8        7.28          7.12          -2.20%
BenchmarkStringHash/soft-32-8        21.7          21.2          -2.30%
BenchmarkStringHash/hard-64-8        9.13          8.75          -4.16%
BenchmarkStringHash/soft-64-8        50.9          54.1          +6.29%
BenchmarkStringHash/hard-128-8       13.0          12.8          -1.54%
BenchmarkStringHash/soft-128-8       114           112           -1.75%
BenchmarkStringHash/hard-256-8       15.7          15.3          -2.55%
BenchmarkStringHash/soft-256-8       241           235           -2.49%
BenchmarkStringHash/hard-512-8       23.7          23.2          -2.11%
BenchmarkStringHash/soft-512-8       492           483           -1.83%
BenchmarkStringHash/hard-1024-8      38.8          38.5          -0.77%
BenchmarkStringHash/soft-1024-8      987           981           -0.61%
BenchmarkHashtable-8                 2152734       2163910       +0.52%
Benchmark/bench_bigint-8             271664        269095        -0.95%
Benchmark/bench_builtin_method-8     392849        354319        -9.81%
Benchmark/bench_calling-8            643982        638527        -0.85%
Benchmark/bench_int-8                124893        123253        -1.31%
Benchmark/bench_range-8              308           301           -2.27%
BenchmarkProgram/read-8              17762         17676         -0.48%
BenchmarkProgram/compile-8           269868        268148        -0.64%
BenchmarkProgram/encode-8            11632         11434         -1.70%
BenchmarkProgram/decode-8            13839         13554         -2.06%
BenchmarkScan-8                      632375        629915        -0.39%
BenchmarkParse-8                     1310575       1305860       -0.36%
```