### PR TITLE
starlark: work around vet false positive

### DIFF
--- a/starlark/library.go
+++ b/starlark/library.go
@@ -215,7 +215,7 @@ func chr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	if i > unicode.MaxRune {
 		return nil, fmt.Errorf("chr: Unicode code point U+%X out of range (>0x10FFFF)", i)
 	}
-	return String(string(i)), nil
+	return String(string(rune(i))), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict


### PR DESCRIPTION
The stringintconv checker added in
https://go-review.googlesource.com/c/tools/+/235797
requires an explicit rune type for the operand of a string(int) conversion.
