### PR TITLE
type Int struct{ impl intImpl } should type Int struct{ in…

### DIFF
--- a/starlark/int.go
+++ b/starlark/int.go
@@ -16,7 +16,7 @@ import (
 // Int is the type of a Starlark int.
 //
 // The zero value is not a legal value; use MakeInt(0).
-type Int struct{ impl intImpl }
+type Int struct{ intImpl }
 
 // --- high-level accessors ---
 


### PR DESCRIPTION
type Int struct{ impl intImpl } raise bug at starlark/int_generic.go:22.
should be type Int struct{ intImpl }