### PR TITLE
starlark: fix tests for 386

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1027,7 +1027,8 @@ func tupleRepeat(elems Tuple, n Int) (Tuple, error) {
 	// Inv: i > 0, len > 0
 	sz := len(elems) * i
 	if sz < 0 || sz >= maxAlloc { // sz < 0 => overflow
-		return nil, fmt.Errorf("excessive repeat (%d elements)", sz)
+		// Don't print sz.
+		return nil, fmt.Errorf("excessive repeat (%d * %d elements)", len(elems), i)
 	}
 	res := make([]Value, sz)
 	// copy elems into res, doubling each time
@@ -1053,7 +1054,8 @@ func stringRepeat(s String, n Int) (String, error) {
 	// Inv: i > 0, len > 0
 	sz := len(s) * i
 	if sz < 0 || sz >= maxAlloc { // sz < 0 => overflow
-		return "", fmt.Errorf("excessive repeat (%d elements)", sz)
+		// Don't print sz.
+		return "", fmt.Errorf("excessive repeat (%d * %d elements)", len(s), i)
 	}
 	return String(strings.Repeat(string(s), i)), nil
 }

--- a/starlark/int_generic.go
+++ b/starlark/int_generic.go
@@ -19,7 +19,7 @@ type intImpl struct {
 // small is defined only if big is nil.
 // small is sign-extended to 64 bits for ease of subsequent arithmetic.
 func (i Int) get() (small int64, big *big.Int) {
-	return i.small_, i.big_
+	return i.impl.small_, i.impl.big_
 }
 
 // Precondition: math.MinInt32 <= x && x <= math.MaxInt32

--- a/starlark/testdata/string.star
+++ b/starlark/testdata/string.star
@@ -25,7 +25,7 @@ assert.eq(1 * "abc", "abc")
 assert.eq(5 * "abc", "abcabcabcabcabc")
 assert.fails(lambda: 1.0 * "abc", "unknown.*float \\* str")
 assert.fails(lambda : "abc" * (1000000 * 1000000), "repeat count 1000000000000 too large")
-assert.fails(lambda : "abc" * 1000000 * 1000000, "excessive repeat .3000000000000 elements")
+assert.fails(lambda : "abc" * 1000000 * 1000000, "excessive repeat \\(3000000 \\* 1000000 elements")
 
 # len
 assert.eq(len("Hello, 世界!"), 14)

--- a/starlark/testdata/tuple.star
+++ b/starlark/testdata/tuple.star
@@ -36,7 +36,7 @@ assert.eq(tuple(), ())
 assert.eq(tuple("abc".elems()), ("a", "b", "c"))
 assert.eq(tuple(["a", "b", "c"]), ("a", "b", "c"))
 assert.eq(tuple([1]), (1,))
-assert.fails(lambda : tuple(1), "got int, want iterable")
+assert.fails(lambda: tuple(1), "got int, want iterable")
 
 # tuple * int,  int * tuple
 abc = tuple("abc".elems())
@@ -48,8 +48,8 @@ assert.eq(0 * abc, ())
 assert.eq(-1 * abc, ())
 assert.eq(1 * abc, abc)
 assert.eq(3 * abc, ("a", "b", "c", "a", "b", "c", "a", "b", "c"))
-assert.fails(lambda : abc * (1000000 * 1000000), "repeat count 1000000000000 too large")
-assert.fails(lambda : abc * 1000000 * 1000000, "excessive repeat .3000000000000 elements")
+assert.fails(lambda: abc * (1000000 * 1000000), "repeat count 1000000000000 too large")
+assert.fails(lambda: abc * 1000000 * 1000000, "excessive repeat \\(3000000 \\* 1000000 elements")
 
 # TODO(adonovan): test use of tuple as sequence
 # (for loop, comprehension, library functions).


### PR DESCRIPTION
The recent int change didn't compile on 386. Fixed.
Thanks to user @anyktx for pointing this out.

Also, tests of string * int and tuple * int printed a bad
error message containing an integer overflow. Now fixed.
