### PR TITLE
fix: `mmap: bad file descriptor` on android arm64

### DIFF
--- a/starlark/int_posix64.go
+++ b/starlark/int_posix64.go
@@ -63,6 +63,7 @@ func reserveAddresses(len int) uintptr {
 	MAP_ANON := 0x1000 // darwin (and all BSDs)
 	switch runtime.GOOS {
 	case "linux":
+	case "android":
 		MAP_ANON = 0x20
 	case "solaris":
 		MAP_ANON = 0x100


### PR DESCRIPTION
Fix https://github.com/google/starlark-go/issues/290#issuecomment-660674313