### PR TITLE
starlark: support thread cancellation and limits on computation

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -13,9 +13,11 @@ import (
 	"math/big"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
+	"unsafe"
 
 	"go.starlark.net/internal/compile"
 	"go.starlark.net/internal/spell"
@@ -46,12 +48,41 @@ type Thread struct {
 	// See example_test.go for some example implementations of Load.
 	Load func(thread *Thread, module string) (StringDict, error)
 
+	// Steps is a count of abstract computation steps executed by
+	// this thread. It is incremented by the interpreter. If after
+	// being incremented, its value is zero, the interpreter calls
+	// thread.Cancel("too many steps").
+	//
+	// Steps may be used as a measure the approximate cost of
+	// Starlark execution, by computing the difference in its value
+	// before and after a computation. It may also be used to limit
+	// a computation to k steps by setting its initial value to
+	// 1<<64 - k.
+	Steps uint64
+
+	// cancelReason records the reason from the first call to Cancel.
+	cancelReason *string
+
 	// locals holds arbitrary "thread-local" Go values belonging to the client.
 	// They are accessible to the client but not to any Starlark program.
 	locals map[string]interface{}
 
 	// proftime holds the accumulated execution time since the last profile event.
 	proftime time.Duration
+}
+
+// Cancel causes execution of Starlark code in the specified thread to
+// promptly fail with an EvalError that includes the specified reason.
+// There may be a delay before the interpreter observes the cancellation
+// if the thread is currently in a call to a built-in function.
+//
+// Cancellation cannot be undone.
+//
+// Unlike most methods of Thread, it is safe to call Cancel from any
+// goroutine, even if the thread is actively executing.
+func (thread *Thread) Cancel(reason string) {
+	// Atomically set cancelReason, preserving earlier reason if any.
+	atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&thread.cancelReason)), nil, unsafe.Pointer(&reason))
 }
 
 // SetLocal sets the thread-local value associated with the specified key.

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -834,3 +834,64 @@ func TestREPLChunk(t *testing.T) {
 		t.Fatalf("chunk2: got %s, want %s", got, want)
 	}
 }
+
+func TestCancel(t *testing.T) {
+	// A thread cancelled before it begins executes no code.
+	{
+		thread := new(starlark.Thread)
+		thread.Cancel("nope")
+		_, err := starlark.ExecFile(thread, "precancel.star", `x = 1//0`, nil)
+		if fmt.Sprint(err) != "Starlark computation cancelled: nope" {
+			t.Errorf("execution returned error %q, want cancellation", err)
+		}
+
+		// cancellation is sticky
+		_, err = starlark.ExecFile(thread, "precancel.star", `x = 1//0`, nil)
+		if fmt.Sprint(err) != "Starlark computation cancelled: nope" {
+			t.Errorf("execution returned error %q, want cancellation", err)
+		}
+	}
+	// A thread cancelled during a built-in executes no more code.
+	{
+		thread := new(starlark.Thread)
+		predeclared := starlark.StringDict{
+			"stopit": starlark.NewBuiltin("stopit", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+				thread.Cancel(fmt.Sprint(args[0]))
+				return starlark.None, nil
+			}),
+		}
+		_, err := starlark.ExecFile(thread, "stopit.star", `msg = 'nope'; stopit(msg); x = 1//0`, predeclared)
+		if fmt.Sprint(err) != `Starlark computation cancelled: "nope"` {
+			t.Errorf("execution returned error %q, want cancellation", err)
+		}
+	}
+}
+
+func TestSteps(t *testing.T) {
+	// A Thread records the number of computation steps.
+	thread := new(starlark.Thread)
+	countSteps := func(n int) (uint64, error) {
+		predeclared := starlark.StringDict{"n": starlark.MakeInt(n)}
+		steps0 := thread.Steps
+		_, err := starlark.ExecFile(thread, "steps.star", `squares = [x*x for x in range(n)]`, predeclared)
+		return thread.Steps - steps0, err
+	}
+	steps100, err := countSteps(1000)
+	if err != nil {
+		t.Errorf("execution failed: %v", err)
+	}
+	steps10000, err := countSteps(100000)
+	if err != nil {
+		t.Errorf("execution failed: %v", err)
+	}
+	if ratio := float64(steps10000) / float64(steps100); ratio < 99 || ratio > 101 {
+		t.Errorf("computation steps did not increase linearly: f(100)=%d, f(10000)=%d, ratio=%g, want ~100", steps100, steps10000, ratio)
+	}
+
+	// Overflow of thread.Steps causes cancellation.
+	thread.Steps = 1<<64 - 1000
+	_, err = countSteps(1000)
+	if fmt.Sprint(err) != "Starlark computation cancelled: too many steps" {
+		t.Errorf("execution returned error %q, want cancellation", err)
+	}
+}

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -5,6 +5,8 @@ package starlark
 import (
 	"fmt"
 	"os"
+	"sync/atomic"
+	"unsafe"
 
 	"go.starlark.net/internal/compile"
 	"go.starlark.net/internal/spell"
@@ -85,6 +87,15 @@ func (fn *Function) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Va
 	code := f.Code
 loop:
 	for {
+		thread.Steps++
+		if thread.Steps == 0 {
+			thread.Cancel("too many steps")
+		}
+		if reason := atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&thread.cancelReason))); reason != nil {
+			err = fmt.Errorf("Starlark computation cancelled: %s", *(*string)(reason))
+			break loop
+		}
+
 		fr.pc = pc
 
 		op := compile.Opcode(code[pc])


### PR DESCRIPTION
This change adds two related features:
(1) asynchronous cancellation of Starlark threads (Thread.Cancel), and
(2) recording and limiting of the number of abstract computation steps.

Fixes issue #252
Fixes issue #160
