### PR TITLE
starlarkjson: sort dict keys

### DIFF
--- a/starlark/testdata/json.star
+++ b/starlark/testdata/json.star
@@ -21,6 +21,7 @@ assert.eq(json.encode([1, 2, 3]), "[1,2,3]")
 assert.eq(json.encode((1, 2, 3)), "[1,2,3]")
 assert.eq(json.encode(range(3)), "[0,1,2]") # a built-in iterable
 assert.eq(json.encode(dict(x = 1, y = "two")), '{"x":1,"y":"two"}')
+assert.eq(json.encode(dict(y = "two", x = 1)), '{"x":1,"y":"two"}') # key, not insertion, order
 assert.eq(json.encode(struct(x = 1, y = "two")), '{"x":1,"y":"two"}')  # a user-defined HasAttrs
 assert.eq(json.encode("\x80"), '"\\ufffd"') # invalid UTF-8 -> replacement char
 


### PR DESCRIPTION
This is for consistency with the java.starlark.net implementation
and proposed spec.

This is a (minor) incompatible behavior change.
