### PR TITLE
starlark: use portable syscall wrapper for mmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 // indirect
+	golang.org/x/sys v0.0.0-20200803210538-64077c9b5642
 )

--- a/starlark/int_posix64.go
+++ b/starlark/int_posix64.go
@@ -22,9 +22,9 @@ import (
 	"log"
 	"math"
 	"math/big"
-	"runtime"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // intImpl represents a union of (int32, *big.Int) in a single pointer,
@@ -59,15 +59,7 @@ func makeBigInt(x *big.Int) Int { return Int{intImpl(x)} }
 var smallints = reserveAddresses(1 << 32)
 
 func reserveAddresses(len int) uintptr {
-	// Use syscall to avoid golang.org/x/sys/unix dependency.
-	MAP_ANON := 0x1000 // darwin (and all BSDs)
-	switch runtime.GOOS {
-	case "linux", "android":
-		MAP_ANON = 0x20
-	case "solaris":
-		MAP_ANON = 0x100
-	}
-	b, err := syscall.Mmap(-1, 0, len, syscall.PROT_READ, syscall.MAP_PRIVATE|MAP_ANON)
+	b, err := unix.Mmap(-1, 0, len, unix.PROT_READ, unix.MAP_PRIVATE|unix.MAP_ANON)
 	if err != nil {
 		log.Fatalf("mmap: %v", err)
 	}


### PR DESCRIPTION
Also, add test to ensure that new dependencies (such as golang.org/x/sys/unix)
are not added casually.

Fixes #320
