### PR TITLE
ci: Add support for go 1.15.x to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 go_import_path: go.starlark.net
 
 go:
-    - "1.12.x"
     - "1.13.x"
     - "1.14.x"
+    - "1.15.x"
     - "master"
 
 env:


### PR DESCRIPTION
Also drops testing against go 1.12.x

It might be worth adding support for Github Actions down the road to reduce the chance of a missed "check" on PRs in the future.

For now, testing with a recent go version would be nice.