### PR TITLE
starlark: add ToInt helper function for unpacking values to Go ints

### DIFF
--- a/starlark/library.go
+++ b/starlark/library.go
@@ -740,7 +740,6 @@ func range_(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 		return nil, err
 	}
 
-	// TODO(adonovan): analyze overflow/underflows cases for 32-bit implementations.
 	if len(args) == 1 {
 		// range(stop)
 		start, stop = 0, start

--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -104,7 +104,8 @@ assert.eq(list(range(10)[1:11:2]), [1, 3, 5, 7, 9])
 assert.eq(list(range(10)[::-2]), [9, 7, 5, 3, 1])
 assert.eq(list(range(0, 10, 2)[::2]), [0, 4, 8])
 assert.eq(list(range(0, 10, 2)[::-2]), [8, 4, 0])
-assert.fails(lambda: range(3000000000), "3000000000 out of range") # signed 32-bit values only
+# range() is limited by the width of the Go int type (int32 or int64).
+assert.fails(lambda: range(1<<64), "... out of range .want value in signed ..-bit range")
 assert.eq(len(range(0x7fffffff)), 0x7fffffff) # O(1)
 # Two ranges compare equal if they denote the same sequence:
 assert.eq(range(0), range(2, 1, 3))       # []

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -20,10 +20,10 @@ type Unpacker interface {
 // supplied parameter variables.  pairs is an alternating list of names
 // and pointers to variables.
 //
-// If the variable is a bool, int, string, *List, *Dict, Callable,
+// If the variable is a bool, integer, string, *List, *Dict, Callable,
 // Iterable, or user-defined implementation of Value,
 // UnpackArgs performs the appropriate type check.
-// An int uses the AsInt32 check.
+// Predeclared Go integer types uses the AsInt check.
 // If the parameter name ends with "?",
 // it and all following parameters are optional.
 //
@@ -199,12 +199,9 @@ func unpackOneArg(v Value, ptr interface{}) error {
 			return fmt.Errorf("got %s, want bool", v.Type())
 		}
 		*ptr = bool(b)
-	case *int:
-		i, err := AsInt32(v)
-		if err != nil {
-			return err
-		}
-		*ptr = i
+	case *int, *int8, *int16, *int32, *int64,
+		*uint, *uint8, *uint16, *uint32, *uint64, *uintptr:
+		return AsInt(v, ptr)
 	case **List:
 		list, ok := v.(*List)
 		if !ok {


### PR DESCRIPTION
Also, use it in Unpack* functions.
This is a minor breaking change: any call that assumed values
unpacked to 'int' were always in the int32 range will need to be modified
to handle possible int64 values.
