### PR TITLE
Add functionality for parsing floats

### DIFF
--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -202,6 +202,12 @@ func unpackOneArg(v Value, ptr interface{}) error {
 	case *int, *int8, *int16, *int32, *int64,
 		*uint, *uint8, *uint16, *uint32, *uint64, *uintptr:
 		return AsInt(v, ptr)
+    case *float64:
+        f, ok := v.(Float)
+        if !ok {
+            return fmt.Errorf("got %s, want float", v.Type())
+        }
+        *ptr = float64(f)
 	case **List:
 		list, ok := v.(*List)
 		if !ok {

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -202,12 +202,12 @@ func unpackOneArg(v Value, ptr interface{}) error {
 	case *int, *int8, *int16, *int32, *int64,
 		*uint, *uint8, *uint16, *uint32, *uint64, *uintptr:
 		return AsInt(v, ptr)
-    case *float64:
-        f, ok := v.(Float)
-        if !ok {
-            return fmt.Errorf("got %s, want float", v.Type())
-        }
-        *ptr = float64(f)
+	case *float64:
+		f, ok := v.(Float)
+		if !ok {
+			return fmt.Errorf("got %s, want float", v.Type())
+		}
+		*ptr = float64(f)
 	case **List:
 		list, ok := v.(*List)
 		if !ok {


### PR DESCRIPTION
The UnpackArgs command does not support parsing floats out of arguments. This pull request adds that functionality to the unpackOneArg function which then adds that functionality to the UnpackArgs command.