### PR TITLE
starlark: report "uninitialized cell" errors gracefully

### DIFF
--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -547,11 +547,9 @@ loop:
 			locals[arg] = stack[sp-1]
 			sp--
 
-		case compile.SETCELL:
-			x := stack[sp-2]
-			y := stack[sp-1]
-			sp -= 2
-			y.(*cell).v = x
+		case compile.SETLOCALCELL:
+			locals[arg].(*cell).v = stack[sp-1]
+			sp--
 
 		case compile.SETGLOBAL:
 			fn.module.globals[arg] = stack[sp-1]
@@ -570,9 +568,23 @@ loop:
 			stack[sp] = fn.freevars[arg]
 			sp++
 
-		case compile.CELL:
-			x := stack[sp-1]
-			stack[sp-1] = x.(*cell).v
+		case compile.LOCALCELL:
+			v := locals[arg].(*cell).v
+			if v == nil {
+				err = fmt.Errorf("local variable %s referenced before assignment", f.Locals[arg].Name)
+				break loop
+			}
+			stack[sp] = v
+			sp++
+
+		case compile.FREECELL:
+			v := fn.freevars[arg].(*cell).v
+			if v == nil {
+				err = fmt.Errorf("local variable %s referenced before assignment", f.Freevars[arg].Name)
+				break loop
+			}
+			stack[sp] = v
+			sp++
 
 		case compile.GLOBAL:
 			x := fn.module.globals[arg]
@@ -641,7 +653,7 @@ func (mandatory) Hash() (uint32, error) { return 0, nil }
 // A cell is a box containing a Value.
 // Local variables marked as cells hold their value indirectly
 // so that they may be shared by outer and inner nested functions.
-// Cells are always accessed using indirect CELL/SETCELL instructions.
+// Cells are always accessed using indirect {FREE,LOCAL,SETLOCAL}CELL instructions.
 // The FreeVars tuple contains only cells.
 // The FREE instruction always yields a cell.
 type cell struct{ v Value }

--- a/starlark/testdata/function.star
+++ b/starlark/testdata/function.star
@@ -288,6 +288,23 @@ def e():
 
 assert.fails(e, "local variable x referenced before assignment")
 
+def f():
+    def inner():
+        return x
+    if False:
+        x = 0
+    return x # fails (x is an uninitialized cell of this function)
+
+assert.fails(f, "local variable x referenced before assignment")
+
+def g():
+    def inner():
+        return x # fails (x is an uninitialized cell of the enclosing function)
+    if False:
+        x = 0
+    return inner()
+
+assert.fails(g, "local variable x referenced before assignment")
 
 ---
 # A trailing comma is allowed in any function definition or call.


### PR DESCRIPTION
The contents of a cell may be null, just like any other local.
We should report this as an error.

So that we can name the variable in the error message,
we change the instruction set so that `LOCAL<local>+CELL`
are combined into a single `LOCALCELL<local>` instruction,
and `FREE<free>+CELL` become a single `FREECELL<free>` instruction.
For symmetry we also combine `LOCAL<local>+SETCELL` into `SETLOCALCELL`,
though it cannot fail. (Happily, all three changes are optimizations
previously described by TODO comments.)

Fixes #340
