### PR TITLE
starlark: fix bug in int(string, base=int)

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3186,10 +3186,29 @@ If x is a `bool`, the result is 0 for `False` or 1 for `True`.
 If x is a string, it is interpreted as a sequence of digits in the
 specified base, decimal by default.
 If `base` is zero, x is interpreted like an integer literal, the base
-being inferred from an optional base marker such as `0b`, `0o`, or
+being inferred from an optional base prefix such as `0b`, `0o`, or
 `0x` preceding the first digit.
+When the `base` is provided explictly, a matching base prefix is
+also permitted, and has no effect.
 Irrespective of base, the string may start with an optional `+` or `-`
 sign indicating the sign of the result.
+
+```python
+int("11")               # 11
+int("11", 0)            # 11
+int("11", 10)           # 11
+int("11", 2)            # 3
+int("11", 8)            # 9
+int("11", 16)           # 17
+
+int("0x11", 0)          # 17
+int("0x11", 16)         # 17
+int("0b1", 16)          # 177 (0xb1)
+int("0b1", 2)           # 1
+int("0b1", 0)           # 1
+
+int("0x11")             # error: invalid literal with base 10
+```
 
 ### len
 

--- a/starlark/testdata/int.star
+++ b/starlark/testdata/int.star
@@ -154,6 +154,7 @@ assert.eq(0x1000000000000001 * 0x1000000000000001, 0x100000000000000200000000000
 assert.eq(int("1010", 2), 10)
 assert.eq(int("111111101", 2), 509)
 assert.eq(int("0b0101", 0), 5)
+assert.eq(int("0b0101", 2), 5) # prefix is redundant with explicit base
 assert.eq(int("0b00000", 0), 0)
 assert.eq(1111111111111111 * 1111111111111111, 1234567901234567654320987654321)
 assert.fails(lambda: int("0x123", 8), "invalid literal.*base 8")
@@ -161,6 +162,16 @@ assert.fails(lambda: int("-0x123", 8), "invalid literal.*base 8")
 assert.fails(lambda: int("0o123", 16), "invalid literal.*base 16")
 assert.fails(lambda: int("-0o123", 16), "invalid literal.*base 16")
 assert.fails(lambda: int("0x110", 2), "invalid literal.*base 2")
+
+# Base prefix is honored only if base=0, or if the prefix matches the explicit base.
+# See https://github.com/google/starlark-go/issues/337
+assert.fails(lambda: int("0b0"), "invalid literal.*base 10")
+assert.eq(int("0b0", 0), 0)
+assert.eq(int("0b0", 2), 0)
+assert.eq(int("0b0", 16), 0xb0)
+assert.eq(int("0x0b0", 16), 0xb0)
+assert.eq(int("0x0b0", 0), 0xb0)
+assert.eq(int("0x0b0101", 16), 0x0b0101)
 
 # int from string, auto detect base
 assert.eq(int("123", 0), 123)

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -251,10 +251,10 @@ func (x *Ident) Span() (start, end Position) {
 // A Literal represents a literal string or number.
 type Literal struct {
 	commentsRef
-	Token    Token // = STRING | INT
+	Token    Token // = STRING | INT | FLOAT
 	TokenPos Position
 	Raw      string      // uninterpreted text
-	Value    interface{} // = string | int64 | *big.Int
+	Value    interface{} // = string | int64 | *big.Int | float64
 }
 
 func (x *Literal) Span() (start, end Position) {


### PR DESCRIPTION
Previously, when int was called with an explicit base,
it would report an error if the digit string starts
with a base prefix for a different base, such as int("0b101", 16).
Now, it uses the base prefix only if it matches the requested
base, so the example above would return 0x0b101, as would
int("0x0b101", 16).

The int(string, int) case has been split out for clarity.

Update doc.

Fixes #337
