### PR TITLE
Remove an unused Thread in the sequential load example

### DIFF
--- a/starlark/example_test.go
+++ b/starlark/example_test.go
@@ -116,8 +116,7 @@ func ExampleThread_Load_sequential() {
 		return e.globals, e.err
 	}
 
-	thread := &starlark.Thread{Name: "exec c.star", Load: load}
-	globals, err := load(thread, "c.star")
+	globals, err := load(nil, "c.star")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
A Thread is created before the outermost `load` and is then never used. (In `load`, a thread is created for each module being loaded.)