### PR TITLE
syntax: support setting initial line/col for scanner

### DIFF
--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -28,7 +28,7 @@ const (
 // If src != nil, ParseFile parses the source from src and the filename
 // is only used when recording position information.
 // The type of the argument for the src parameter must be string,
-// []byte, or io.Reader.
+// []byte, io.Reader, or FilePortion.
 // If src == nil, ParseFile parses the file specified by filename.
 func Parse(filename string, src interface{}, mode Mode) (f *File, err error) {
 	in, err := newScanner(filename, src, mode&RetainComments != 0)

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -439,6 +439,27 @@ func TestParseErrors(t *testing.T) {
 	}
 }
 
+func TestFilePortion(t *testing.T) {
+	// Imagine that the Starlark file or expression print(x.f) is extracted
+	// from the middle of a file in some hypothetical template language;
+	// see https://github.com/google/starlark-go/issues/346. For example:
+	// --
+	// {{loop x seq}}
+	//   {{print(x.f)}}
+	// {{end}}
+	// --
+	fp := syntax.FilePortion{Content: []byte("print(x.f)"), FirstLine: 2, FirstCol: 4}
+	file, err := syntax.Parse("foo.template", fp, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	span := fmt.Sprint(file.Stmts[0].Span())
+	want := "foo.template:2:4 foo.template:2:14"
+	if span != want {
+		t.Errorf("wrong span: got %q, want %q", span, want)
+	}
+}
+
 // dataFile is the same as starlarktest.DataFile.
 // We make a copy to avoid a dependency cycle.
 var dataFile = func(pkgdir, filename string) string {


### PR DESCRIPTION
The new FilePortion type, which may be provided to the scanner,
parser, or ExecFile functions, combines a piece of text
with its start line/column numbers, for applications that
extract a Starlark expression from the middle of a larger file.

Fixes https://github.com/google/starlark-go/issues/346
