### PR TITLE
Port pytruth as lib/truth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/google/go-cmp v0.5.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -27,7 +29,12 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -70,5 +77,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/lib/truth/README.md
+++ b/lib/truth/README.md
@@ -1,0 +1,225 @@
+package truth // import "go.starlark.net/lib/truth"
+
+Package truth defines builtins and methods to express test
+assertions within Starlark programs in the fashion of https://truth.dev
+
+This package is a Starlark port of PyTruth (2c3717ddad 2021-03-10)
+https://github.com/google/pytruth
+
+The Starlark:
+
+    assert.that(a).is_equal_to(b)
+    assert.that(c).named("my value").is_true()
+    assert.that(d).contains(a)
+    assert.that(d).contains_all_of(a, b).in_order()
+    assert.that(d).contains_any_of(a, b, c)
+
+is equivalent to the following Python:
+
+    from truth.truth import AssertThat
+    AssertThat(a).IsEqualTo(b)
+    AssertThat(c).Named("my value").IsTrue()
+    AssertThat(d).Contains(a)
+    AssertThat(d).ContainsAllOf(a, b).InOrder()
+    AssertThat(d).ContainsAnyOf(a, b, c)
+
+Often, tests assert a relationship between a value produced by the test (the
+"actual" value) and some reference value (the "expected" value). It is
+strongly recommended that the actual value is made the subject of the
+assertion. For example:
+
+    assert.that(actual).is_equal_to(expected)    # Recommended.
+    assert.that(expected).is_equal_to(actual)    # Not recommended.
+    assert.that(actual).is_in(expected_possibilities)     # Recommended.
+    assert.that(expected_possibilities).contains(actual)  # Not recommended.
+
+Some assertions
+
+    assert.that(a).is_equal_to(b)
+    assert.that(a).is_not_equal_to(b)
+    assert.that(a).is_truthy()
+    assert.that(a).is_falsy()
+    assert.that(a).is_true()
+    assert.that(a).is_false()
+    assert.that(a).is_none()
+    assert.that(a).is_not_none()
+    assert.that(a).is_in(b)
+    assert.that(a).is_any_of(b, c, d)
+    assert.that(a).is_not_in(b)
+    assert.that(a).is_none_of(b, c, d)
+    assert.that(a).is_of_type(type(b))
+    assert.that(a).is_not_of_type(type(b))
+    assert.that(a).has_attribute(b)
+    assert.that(a).does_not_have_attribute(b)
+    assert.that(a).is_callable()
+    assert.that(a).is_not_callable()
+    assert.that(a).is_less_than(b)
+    assert.that(a).is_greater_than(b)
+    assert.that(a).is_at_most(b)
+    assert.that(a).is_at_least(b)
+
+Truthiness
+
+    Predicates `.is_true()` and `.is_false()` match *only* `True` and `False`.
+    For `.is_truthy()` and `.is_falsy()`, `(starlark.Value).Truth() bool` is used.
+
+       assert.that(True).is_true()
+       assert.that(False).is_false()
+       assert.that(1).is_true()      # fails
+       assert.that(0).is_false()     # fails
+       assert.that(None).is_true()   # fails
+       assert.that(None).is_false()  # fails
+       assert.that(True).is_truthy()
+       assert.that(False).is_falsy()
+       assert.that(1).is_truthy()
+       assert.that(0).is_falsy()
+       assert.that(None).is_truthy() # fails
+       assert.that(None).is_falsy()
+
+Strings
+
+    assert.that("abc").has_length(3)
+    assert.that("abc").starts_with("a")
+    assert.that("abc").ends_with("c")
+    assert.that("abc").matches("a.+")                # prepends "^" to regexp
+    assert.that("abc").does_not_match("b.+")         # prepends "^" to regexp
+    assert.that("abc").contains_match("b.+")
+    assert.that("abc").does_not_contain_match("c.+")
+
+Numbers
+
+    assert.that(a).is_zero()
+    assert.that(a).is_non_zero()
+    assert.that(a).is_positive_infinity()
+    assert.that(a).is_not_positive_infinity()
+    assert.that(a).is_negative_infinity()
+    assert.that(a).is_not_negative_infinity()
+    assert.that(a).is_finite()
+    assert.that(a).is_not_finite()
+    assert.that(a).is_nan()
+    assert.that(a).is_not_nan()
+    assert.that(a).is_within(delta).of(b)
+    assert.that(a).is_not_within(delta).of(b)
+
+Lists, strings, and other iterables
+
+     `cmp(x,y)` should return negative if x < y, zero if x == y and positive if x > y.
+     *Ordered* means that the iterable's elements must increase (or decrease,
+    depending on `cmp`) from beginning to end. Adjacent elements are allowed to be equal.
+     *Strictly ordered* means that in addition, the elements must be unique
+    (i.e. monotonically increasing or decreasing).
+
+        assert.that(a).has_size(n)
+        assert.that(a).is_empty()
+        assert.that(a).is_not_empty()
+        assert.that(a).contains(b)
+        assert.that(a).does_not_contain(b)
+        assert.that(a).contains_all_of(b, c)
+        assert.that(a).contains_all_in([b, c])
+        assert.that(a).contains_any_of(b, c)
+        assert.that(a).contains_any_in([b, c])
+        assert.that(a).contains_exactly(b, c)
+        assert.that(sorted(a)).contains_exactly_elements_in(sorted(b)).in_order()
+        assert.that(a).contains_none_of(b, c)
+        assert.that(a).contains_none_in([b, c])
+        assert.that(a).contains_no_duplicates()
+        assert.that(a).is_ordered()
+        assert.that(a).is_ordered_according_to(cmp)
+        assert.that(a).is_strictly_ordered()
+        assert.that(a).is_strictly_ordered_according_to(cmp)
+
+Asserting order
+
+     By default, `.contains_all...` and `.contains_exactly...` do not enforce that the
+    order of the elements in the subject under test matches that of the expected
+    value. To do that, append `.in_order()` to the returned predicate.
+
+        assert.that([2, 4, 6]).contains_all_of(6, 2)
+        assert.that([2, 4, 6]).contains_all_of(6, 2).in_order()     # fails
+        assert.that([2, 4, 6]).contains_all_of(2, 6).in_order()
+        assert.that((1, 2, 3)).contains_all_in((1, 3)).in_order()
+        assert.that([2, 4, 6]).contains_exactly(2, 6, 4)
+        assert.that([2, 4, 6]).contains_exactly(2, 6, 4).in_order() # fails
+        assert.that([2, 4, 6]).contains_exactly(2, 4, 6).in_order()
+        assert.that((1, 2, 3)).contains_exactly_elements_in([1, 2, 3]).in_order()
+
+     When using `.in_order()`, ensure that both the subject under test and the expected
+    value have a defined order, otherwise the result is undefined.
+    For example, `assert.that(aList).contains_exactly_elements_in(aSet).in_order()`
+    may or may not succeed, depending on how the `set` implements ordering.
+    The builtin set datatype does not implement ordering.
+    These assertions *may or may not* succeed:
+
+        assert.that((1, 2, 3)).contains_all_in(set([1, 3])).in_order()
+        assert.that(set([3, 2, 1])).contains_exactly_elements_in((1, 2, 3)).in_order()
+        assert.that({1:2, 3:4}).contains_all_in((1, 3)).in_order()
+
+Dictionaries, in addition to the table above
+
+    assert.that(d).contains_key(k)
+    assert.that(d).does_not_contain_key(k)
+    assert.that(d).contains_item(k, v)
+    assert.that(d).does_not_contain_item(k, v)
+    assert.that(d).contains_exactly(k1, v1, k2, v2)
+    assert.that(d1).contains_exactly_items_in(d2)
+    assert.that(d1.items()).contains_all_in(d2.items())
+
+Notes (in no particular order):
+
+     `None` is not comparable (as in Python 3), so assertions involving `<` `>`
+    `<=` `>=` on `None` such as `assert.that(a).is_greater_than(None)`
+    fail with `InvalidAssertion` error.
+    It is recommended to first check the `None`-ness of values with `.is_none()`
+    or `.is_not_none()` before performing inequility assertions.
+
+     As in Python, `0`, `0.0` and `-0.0` all compare equal. The assertions
+    `.is_zero()` and `.is_non_zero()` are provided for semantic convenience.
+
+     Starlark strings are not iterable (unlike Python's) but are iterated on as
+    slices of utf-8 runes when needed in this implementation. This works:
+        assert.that("abcdefg").contains_all_of("a", "c", "e").in_order()
+        assert.that("abcdefg").is_strictly_ordered()
+
+     In `.contains...()` assertions a "duplicate values counter" is used that
+    relies on the `(starlark.Value).String() string` reprensentation of values
+    instead of `(starlark.Value).Hash() (uint32, error)` as some basic types
+    are not hashable (list, dict, set).
+    For this reason **it is recommended to only pass values of the main data types
+    built in to the interpreter to functions of this package:**
+    * NoneType
+    * bool
+    * int
+    * float
+    * string
+    * list
+    * tuple
+    * dict
+    * set
+    * function
+    * builtin_function_or_method
+
+     It is possible to incorrectly express assertions (see all but the last line in
+    this block):
+        assert.that(x)
+        assert.that(x).named(z)
+        assert.that(x).is_within(y)
+        assert.that(x).is_not_within(y)
+        assert.that(x).is_not_within(y).of(z)
+     This is why each call to `.that(...)` first checks that no non-terminated
+    assertions were previously executed in the current thread.
+     A `Close(*starlark.Thread) error` function is also provided to ensure
+    this property holds after the interpreter returns.
+
+     This library is threadsafe; you may execute multiple assertions in parallel.
+
+const Default = "assert"
+var LocalThreadKeyForClose = Default
+func Asserted(th *starlark.Thread) bool
+func Close(th *starlark.Thread) (err error)
+func NewModule(predeclared starlark.StringDict)
+func That(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, ...) (starlark.Value, error)
+type InvalidAssertion string
+type T struct{ ... }
+type TruthAssertion string
+type UnhandledError struct{ ... }
+type UnresolvedError string

--- a/lib/truth/assert_that.go
+++ b/lib/truth/assert_that.go
@@ -1,0 +1,1404 @@
+package truth
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func isNotEqualTo(t *T, args ...starlark.Value) (starlark.Value, error) {
+	other := args[0]
+	ok, err := starlark.Compare(syntax.EQL, t.actual, other)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return nil, t.failComparingValues("is not equal to", other, "")
+	}
+	return starlark.None, nil
+}
+
+func isEqualTo(t *T, args ...starlark.Value) (starlark.Value, error) {
+	arg1 := args[0]
+	switch actual := t.actual.(type) {
+	case starlark.String:
+		if other, ok := arg1.(starlark.String); ok {
+			a := actual.GoString()
+			o := other.GoString()
+			// Use unified diff strategy when comparing multiline strings.
+			if strings.Contains(a, "\n") && strings.Contains(o, "\n") {
+				diff := difflib.ContextDiff{
+					A:        difflib.SplitLines(o),
+					B:        difflib.SplitLines(a),
+					FromFile: "Expected",
+					ToFile:   "Actual",
+					Context:  3,
+					Eol:      "\n",
+				}
+				pretty, err := difflib.GetContextDiffString(diff)
+				if err != nil {
+					return nil, err
+				}
+				if pretty == "" {
+					return starlark.None, nil
+				}
+				msg := "is equal to expected, found diff:\n" + pretty
+				return nil, t.failWithProposition(msg, "")
+			}
+		}
+	case starlark.Iterable:
+		if t.actual.Type() == arg1.Type() {
+			switch other := arg1.(type) {
+			case starlark.IterableMapping: // e.g. dict
+				if _, err := containsExactlyItemsIn(t, other); err != nil {
+					return nil, err
+				}
+				return starlark.None, nil
+			case starlark.Indexable: // e.g. tuple, list
+				if _, err := containsExactlyElementsIn(t, other); err != nil {
+					return nil, err
+				}
+				return inOrder(t)
+			default: // e.g. set (any other Iterable)
+				if _, err := containsExactlyElementsIn(t, other); err != nil {
+					return nil, err
+				}
+				return starlark.None, nil
+			}
+		}
+	default:
+	}
+	ok, err := starlark.Compare(syntax.NEQ, t.actual, arg1)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		suffix := ""
+		if t.actual.String() == arg1.String() {
+			suffix = " However, their str() representations are equal."
+		}
+		return nil, t.failComparingValues("is equal to", arg1, suffix)
+	}
+	return starlark.None, nil
+}
+
+func iterEmpty(able starlark.Iterable) bool {
+	iter := able.Iterate()
+	defer iter.Done()
+	var v starlark.Value
+	return !iter.Next(&v)
+}
+
+func containsExactly(t *T, args ...starlark.Value) (starlark.Value, error) {
+	argc := len(args)
+	switch actual := t.actual.(type) {
+	case starlark.IterableMapping:
+		if argc == 0 {
+			if iterEmpty(actual) {
+				if t.forOrdering == nil {
+					t.forOrdering = &forOrdering{}
+				}
+				return t, nil
+			}
+			return nil, t.failWithProposition("is empty", "")
+		}
+		if argc%2 != 0 {
+			return nil, errMustBeEqualNumberOfKVPairs(argc)
+		}
+		dic := starlark.NewDict(argc / 2)
+		for i := 0; i < argc/2; i += 2 {
+			if err := dic.SetKey(args[i], args[i+1]); err != nil {
+				return nil, err
+			}
+		}
+		return containsExactlyItemsIn(t, dic)
+	case starlark.Iterable:
+		if argc == 0 {
+			if iterEmpty(actual) {
+				if t.forOrdering == nil {
+					t.forOrdering = &forOrdering{}
+				}
+				return t, nil
+			}
+			return nil, t.failWithProposition("is empty", "")
+		}
+		tup := starlark.Tuple(args)
+		expectingSingleIterable := false
+		if argc == 1 {
+			_, isIterable := args[0].(starlark.Iterable)
+			_, isString := args[0].(starlark.String)
+			expectingSingleIterable = isIterable && !isString
+		}
+		return t.containsExactlyElementsIn(tup, expectingSingleIterable)
+	case starlark.String:
+		t.turnActualIntoIterableFromString()
+		return containsExactly(t, args...)
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func inOrder(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if t.forOrdering == nil {
+		return nil, errUnhandled
+	}
+	if err := t.forOrdering.inOrderError; err != nil {
+		return nil, err
+	}
+	return starlark.None, nil
+}
+
+var errDictOrdering = newInvalidAssertion("values of type dict are not ordered")
+
+func containsExactlyItemsIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	arg1 := args[0] // TODO: what when passed **kwargs?
+	if imActual, ok := t.actual.(starlark.IterableMapping); ok {
+		if imExpected, ok := arg1.(starlark.IterableMapping); ok {
+			tt := newT(newTupleSlice(imActual.Items()))
+			tt.forOrdering = &forOrdering{inOrderError: errDictOrdering}
+			return containsExactly(tt, newTupleSlice(imExpected.Items()).Values()...)
+		}
+	}
+	return nil, errUnhandled
+}
+
+func containsExactlyElementsIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.containsExactlyElementsIn(args[0], false)
+}
+
+// Determines if the subject contains exactly the expected elements.
+func (t *T) containsExactlyElementsIn(expected starlark.Value, warnElementsIn bool) (starlark.Value, error) {
+	iterableActual, err := t.failIterable()
+	if err != nil {
+		return nil, err
+	}
+	iterableExpected, err := newT(expected).failIterable()
+	if err != nil {
+		return nil, err
+	}
+
+	missing := newDuplicateCounter()
+	extra := newDuplicateCounter()
+	iterActual := iterableActual.Iterate()
+	defer iterActual.Done()
+	iterExpected := iterableExpected.Iterate()
+	defer iterExpected.Done()
+
+	warning := ""
+	if warnElementsIn {
+		warning = warnContainsExactlySingleIterable
+	}
+
+	forOrderingSet := t.forOrdering != nil
+
+	var elemActual, elemExpected starlark.Value
+	iterations := 0
+	for {
+		// Step through both iterators comparing elements pairwise.
+		if !iterActual.Next(&elemActual) {
+			break
+		}
+		if !iterExpected.Next(&elemExpected) {
+			extra.Increment(elemActual)
+			break
+		}
+		iterations++
+
+		// As soon as we encounter a pair of elements that differ, we know that
+		// in_order cannot succeed, so we can check the rest of the elements
+		// more normally. Since any previous pairs of elements we iterated
+		// over were equal, they have no effect on the result now.
+		ok, err := starlark.Compare(syntax.NEQ, elemActual, elemExpected)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			// Missing elements; elements that are not missing will be removed.
+			missing.Increment(elemExpected)
+			var m starlark.Value
+			for iterExpected.Next(&m) {
+				missing.Increment(m)
+			}
+
+			eStrActual := elemActual.String()
+			// Remove all actual elements from missing, and add any that weren't
+			// in missing to extra.
+			if missing.contains(eStrActual) {
+				missing.decrement(eStrActual)
+			} else {
+				extra.increment(eStrActual)
+			}
+			var e starlark.Value
+			for iterActual.Next(&e) {
+				eStr := e.String()
+				if missing.contains(eStr) {
+					missing.decrement(eStr)
+				} else {
+					extra.increment(eStr)
+				}
+			}
+
+			// Fail if there are either missing or extra elements.
+
+			if !missing.Empty() {
+				if !extra.Empty() {
+					// Subject is missing required elements and has extra elements.
+					msg := fmt.Sprintf("contains exactly <%s>."+
+						" It is missing <%s> and has unexpected items <%s>",
+						expected.String(), missing.String(), extra.String())
+					return nil, t.failWithProposition(msg, warning)
+				}
+				return nil, t.failWithBadResults("contains exactly", expected,
+					"is missing", missing, warning)
+			}
+
+			if !extra.Empty() {
+				return nil, t.failWithBadResults("contains exactly", expected,
+					"has unexpected items", extra, warning)
+			}
+
+			// The iterables were not in the same order.
+			if !forOrderingSet {
+				forOrderingSet = true
+				t.forOrdering = &forOrdering{
+					inOrderError: t.failComparingValues(
+						"contains exactly these elements in order", expected, ""),
+				}
+			}
+		}
+	}
+	if iterations == 0 && missing.Empty() && !extra.Empty() {
+		return nil, t.failWithProposition("is empty", "")
+	}
+
+	// We must have reached the end of one of the iterators without finding any
+	// pairs of elements that differ. If the actual iterator still has elements,
+	// they're extras. If the required iterator has elements, they're missing.
+	var e starlark.Value
+	for iterActual.Next(&e) {
+		extra.Increment(e)
+	}
+	if !extra.Empty() {
+		return nil, t.failWithBadResults("contains exactly", expected,
+			"has unexpected items", extra, warning)
+	}
+
+	var m starlark.Value
+	for iterExpected.Next(&m) {
+		missing.Increment(m)
+	}
+	if !missing.Empty() {
+		return nil, t.failWithBadResults("contains exactly", expected,
+			"is missing", missing, warning)
+	}
+
+	if !forOrderingSet {
+		t.forOrdering = &forOrdering{}
+	}
+
+	// If neither iterator has elements, we reached the end and the elements
+	// were in order.
+	return t, nil
+}
+
+// Adds a prefix to the subject, when it is displayed in error messages.
+//
+// This is especially useful in the context of types that have no helpful
+// string representation (e.g., bool). Writing `assert.that(foo).named("foo").is_true()`
+// then results in a more reasonable error.
+func named(t *T, args ...starlark.Value) (starlark.Value, error) {
+	str, ok := args[0].(starlark.String)
+	if !ok || str.Len() == 0 {
+		return nil, errors.New(".named() expects a (non empty) string")
+	}
+	t.name = str.GoString()
+	return t, nil
+}
+
+func isNone(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if t.actual != starlark.None {
+		return nil, t.failWithProposition("is None", "")
+	}
+	return starlark.None, nil
+}
+
+func isNotNone(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if t.actual == starlark.None {
+		return nil, t.failWithProposition("is not None", "")
+	}
+	return starlark.None, nil
+}
+
+func isFalse(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if b, ok := t.actual.(starlark.Bool); ok && b == starlark.False {
+		return starlark.None, nil
+	}
+	suffix := ""
+	if !t.actual.Truth() {
+		suffix = " However, it is falsy. Did you mean to call .is_falsy() instead?"
+	}
+	return nil, t.failWithProposition("is False", suffix)
+}
+
+func isFalsy(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if t.actual.Truth() {
+		return nil, t.failWithProposition("is falsy", "")
+	}
+	return starlark.None, nil
+}
+
+func isTrue(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if b, ok := t.actual.(starlark.Bool); ok && b == starlark.True {
+		return starlark.None, nil
+	}
+	suffix := ""
+	if t.actual.Truth() {
+		suffix = " However, it is truthy. Did you mean to call .is_truthy() instead?"
+	}
+	return nil, t.failWithProposition("is True", suffix)
+}
+
+func isTruthy(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if !t.actual.Truth() {
+		return nil, t.failWithProposition("is truthy", "")
+	}
+	return starlark.None, nil
+}
+
+func (t *T) comparable(bName, verb string, op syntax.Token, other starlark.Value) (starlark.Value, error) {
+	if err := t.failNone(bName, other); err != nil {
+		return nil, err
+	}
+	ok, err := starlark.Compare(op, t.actual, other)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return nil, t.failComparingValues(verb, other, "")
+	}
+	return starlark.None, nil
+}
+
+func isAtLeast(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.comparable("is_at_least", "is at least", syntax.LT, args[0])
+}
+
+func isAtMost(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.comparable("is_at_most", "is at most", syntax.GT, args[0])
+}
+
+func isGreaterThan(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.comparable("is_greater_than", "is greater than", syntax.LE, args[0])
+}
+
+func isLessThan(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.comparable("is_less_than", "is less than", syntax.GE, args[0])
+}
+
+func isIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch iterable := args[0].(type) {
+	case starlark.Iterable:
+		// NOTE: operates on Dict keys.
+		it := iterable.Iterate()
+		defer it.Done()
+		var e starlark.Value
+		for it.Next(&e) {
+			ok, err := starlark.Compare(syntax.EQL, t.actual, e)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				return starlark.None, nil
+			}
+		}
+		return nil, t.failComparingValues("is equal to any of", iterable, "")
+	case starlark.String:
+		if actual, ok := t.actual.(starlark.String); ok {
+			if strings.Contains(iterable.GoString(), actual.GoString()) {
+				return starlark.None, nil
+			}
+			return nil, t.failComparingValues("is equal to any of", iterable, "")
+		}
+	default:
+	}
+	return nil, errUnhandled
+}
+
+// Asserts that this subject is not a member of the given iterable.
+func isNotIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	arg1 := args[0]
+	switch iterable := arg1.(type) {
+	case starlark.String:
+		if actual, ok := t.actual.(starlark.String); ok {
+			if ix := strings.Index(iterable.GoString(), actual.GoString()); ix != -1 {
+				msg := fmt.Sprintf("is not in %s. It was found at index %d",
+					arg1.String(), ix)
+				return nil, t.failWithProposition(msg, "")
+			}
+			return starlark.None, nil
+		}
+	case starlark.Indexable:
+		for ix := 0; ix < iterable.Len(); ix++ {
+			e := iterable.Index(ix)
+			ok, err := starlark.Compare(syntax.EQL, t.actual, e)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				msg := fmt.Sprintf("is not in %s. It was found at index %d",
+					arg1.String(), ix)
+				return nil, t.failWithProposition(msg, "")
+			}
+		}
+		return starlark.None, nil
+	case starlark.Iterable:
+		// NOTE: operates on Dict keys.
+		it := iterable.Iterate()
+		defer it.Done()
+		var e starlark.Value
+		for it.Next(&e) {
+			ok, err := starlark.Compare(syntax.EQL, t.actual, e)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				msg := fmt.Sprintf("is not in %s", arg1.String())
+				return nil, t.failWithProposition(msg, "")
+			}
+		}
+		return starlark.None, nil
+	default:
+	}
+	return nil, errUnhandled
+}
+
+func isAnyOf(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isIn(t, starlark.Tuple(args))
+}
+
+func isNoneOf(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isNotIn(t, starlark.Tuple(args))
+}
+
+// From https://github.com/google/starlark-go/blob/6677ee5c7211380ec7e6a1b50dc45287e40ca9e1/starlark/library.go#L383
+func (t *T) hasattr(name string) bool {
+	if o, ok := t.actual.(starlark.HasAttrs); ok {
+		v, err := o.Attr(name)
+		if err == nil {
+			return (v != nil)
+		}
+		for _, x := range o.AttrNames() {
+			if x == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasAttribute(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(starlark.String); ok {
+		attr := arg1.GoString()
+		if !t.hasattr(attr) {
+			return nil, t.failComparingValues("has attribute", arg1, "")
+		}
+		return starlark.None, nil
+	}
+	return nil, errUnhandled
+}
+
+func doesNotHaveAttribute(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(starlark.String); ok {
+		attr := arg1.GoString()
+		if t.hasattr(attr) {
+			return nil, t.failComparingValues("does not have attribute", arg1, "")
+		}
+		return starlark.None, nil
+	}
+	return nil, errUnhandled
+}
+
+func isCallable(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if _, ok := t.actual.(starlark.Callable); !ok {
+		return nil, t.failWithProposition("is callable", "")
+	}
+	return starlark.None, nil
+}
+
+func isNotCallable(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if _, ok := t.actual.(starlark.Callable); ok {
+		return nil, t.failWithProposition("is not callable", "")
+	}
+	return starlark.None, nil
+}
+
+func sizeOf(v starlark.Value) int {
+	switch v := v.(type) {
+	case starlark.Indexable:
+		return v.Len()
+	case starlark.Sequence:
+		return v.Len()
+	default:
+		return -1
+	}
+}
+
+type int64Stringer int64
+
+var _ fmt.Stringer = (int64Stringer)(0)
+
+func (i int64Stringer) String() string { return fmt.Sprintf("%d", i) }
+
+func hasSize(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch arg1 := args[0].(type) {
+	case starlark.Int:
+		size, ok := arg1.Int64()
+		if ok {
+			if actualSize := sizeOf(t.actual); actualSize != -1 {
+				if int64(actualSize) != size {
+					x := int64Stringer(actualSize)
+					return nil, t.failWithBadResults("has a size of", arg1, "is", x, "")
+				}
+				return starlark.None, nil
+			}
+		}
+	default:
+	}
+	return nil, errUnhandled
+}
+
+func isEmpty(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch iterable := t.actual.(type) {
+	case starlark.Iterable:
+		if !iterEmpty(iterable) {
+			return nil, t.failWithProposition("is empty", "")
+		}
+		return starlark.None, nil
+	case starlark.String:
+		if iterable.Len() != 0 {
+			return nil, t.failWithProposition("is empty", "")
+		}
+		return starlark.None, nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func isNotEmpty(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch iterable := t.actual.(type) {
+	case starlark.Iterable:
+		if iterEmpty(iterable) {
+			return nil, t.failWithProposition("is not empty", "")
+		}
+		return starlark.None, nil
+	case starlark.String:
+		if iterable.Len() == 0 {
+			return nil, t.failWithProposition("is not empty", "")
+		}
+		return starlark.None, nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func contains(t *T, args ...starlark.Value) (starlark.Value, error) {
+	arg1 := args[0]
+	switch iterable := t.actual.(type) {
+	case starlark.Iterable:
+		// NOTE: operates on Dict keys.
+		it := iterable.Iterate()
+		defer it.Done()
+		var e starlark.Value
+		for it.Next(&e) {
+			ok, err := starlark.Compare(syntax.EQL, e, arg1)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				return starlark.None, nil
+			}
+		}
+		return nil, t.failWithSubject(fmt.Sprintf("should have contained %s", arg1))
+	case starlark.String:
+		if arg1, ok := arg1.(starlark.String); ok {
+			if strings.Contains(iterable.GoString(), arg1.GoString()) {
+				return starlark.None, nil
+			}
+			return nil, t.failWithSubject(fmt.Sprintf("should have contained %s", arg1))
+		}
+	default:
+	}
+	return nil, errUnhandled
+}
+
+func doesNotContain(t *T, args ...starlark.Value) (starlark.Value, error) {
+	arg1 := args[0]
+	switch iterable := t.actual.(type) {
+	case starlark.Iterable:
+		// NOTE: operates on Dict keys.
+		it := iterable.Iterate()
+		defer it.Done()
+		var e starlark.Value
+		for it.Next(&e) {
+			ok, err := starlark.Compare(syntax.EQL, e, arg1)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				return nil, t.failWithSubject(fmt.Sprintf("should not have contained %s", arg1))
+			}
+		}
+		return starlark.None, nil
+	case starlark.String:
+		if arg1, ok := arg1.(starlark.String); ok {
+			if strings.Contains(iterable.GoString(), arg1.GoString()) {
+				return nil, t.failWithSubject(fmt.Sprintf("should not have contained %s", arg1))
+			}
+			return starlark.None, nil
+		}
+	default:
+	}
+	return nil, errUnhandled
+}
+
+// Asserts that this subject contains no two elements that are the same.
+func containsNoDuplicates(t *T, args ...starlark.Value) (starlark.Value, error) {
+	counter := newDuplicateCounter()
+	switch actual := t.actual.(type) {
+	case starlark.IterableMapping, *starlark.Set:
+		// Dictionaries and Sets have unique members by definition; avoid iterating.
+		return starlark.None, nil
+	case starlark.Iterable:
+		it := actual.Iterate()
+		defer it.Done()
+		var e starlark.Value
+		for it.Next(&e) {
+			counter.Increment(e)
+		}
+	case starlark.String:
+		for _, s := range actual.GoString() {
+			counter.increment(fmt.Sprintf("%q", string(s)))
+		}
+	default:
+		return nil, errUnhandled
+	}
+	if counter.HasDupes() {
+		msg := fmt.Sprintf("has the following duplicates: <%s>", counter.Dupes())
+		return nil, t.failWithSubject(msg)
+	}
+	return starlark.None, nil
+}
+
+func containsAllIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(starlark.Iterable); ok {
+		return t.containsAll("contains all elements in", arg1)
+	}
+	return nil, errUnhandled
+}
+
+func containsAllOf(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.containsAll("contains all of", starlark.Tuple(args))
+}
+
+func (t *T) actualAsSlice() ([]starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Iterable:
+		return collect(actual), nil
+	case starlark.String:
+		t.turnActualIntoIterableFromString()
+		return []starlark.Value(t.actual.(starlark.Tuple)), nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func collect(iterable starlark.Iterable) []starlark.Value {
+	var xs []starlark.Value
+	iter := iterable.Iterate()
+	defer iter.Done()
+	var x starlark.Value
+	for iter.Next(&x) {
+		xs = append(xs, x)
+	}
+	return xs
+}
+
+func indexOf(v starlark.Value, xs []starlark.Value) (int, error) {
+	for i, x := range xs {
+		ok, err := starlark.Compare(syntax.EQL, v, x)
+		if err != nil {
+			return -2, err
+		}
+		if ok {
+			return i, nil
+		}
+	}
+	return -1, nil
+}
+
+// Determines if the subject contains all the expected elements.
+func (t *T) containsAll(verb string, expected starlark.Iterable) (starlark.Value, error) {
+	actualSlice, err := t.actualAsSlice()
+	if err != nil {
+		return nil, err
+	}
+	missing := newDuplicateCounter()
+	var actualNotInOrder []starlark.Value // = Tuple
+	ordered := true
+
+	iterExpected := expected.Iterate()
+	defer iterExpected.Done()
+	var i starlark.Value
+	// Step through the expected elements.
+	for iterExpected.Next(&i) {
+		index, err := indexOf(i, actualSlice)
+		if err != nil {
+			return nil, err
+		}
+		if index != -1 {
+			// Drain all the elements before that element into actualNotInOrder.
+			actualNotInOrder = append(actualNotInOrder, actualSlice[0:index]...)
+			// And remove the element from the actual_list.
+			actualSlice = actualSlice[1:]
+			continue
+		}
+
+		// The expected value was not in the actual list.
+		if index, err = indexOf(i, actualNotInOrder); err != nil {
+			return nil, err
+		}
+		if index != -1 {
+			actualNotInOrder = append(actualNotInOrder[:index], actualNotInOrder[index+1:]...)
+			// If it was in actualNotInOrder, we're not in order.
+			ordered = false
+		} else {
+			// It is not in actualNotInOrder, we're missing an expected element.
+			missing.Increment(i)
+		}
+	}
+
+	// If we have any missing expected elements, fail.
+	if !missing.Empty() {
+		return nil, t.failWithBadResults(verb, expected, "is missing", missing, "")
+	}
+
+	t.forOrdering = &forOrdering{}
+	if !ordered {
+		t.forOrdering.inOrderError = t.failComparingValues("contains all elements in order", expected, "")
+	}
+	return t, nil
+}
+
+func containsAnyIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(starlark.Iterable); ok {
+		return t.containsAny("contains any element in", arg1)
+	}
+	return nil, errUnhandled
+}
+
+func containsAnyOf(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.containsAny("contains any of", starlark.Tuple(args))
+}
+
+// Determines if the subject contains any of the expected elements.
+func (t *T) containsAny(verb string, expected starlark.Iterable) (starlark.Value, error) {
+	actualSlice, err := t.actualAsSlice()
+	if err != nil {
+		return nil, err
+	}
+
+	iterExpected := expected.Iterate()
+	defer iterExpected.Done()
+	var i starlark.Value
+	for iterExpected.Next(&i) {
+		index, err := indexOf(i, actualSlice)
+		if err != nil {
+			return nil, err
+		}
+		if index != -1 {
+			return starlark.None, nil
+		}
+	}
+	return nil, t.failComparingValues(verb, expected, "")
+}
+
+func containsNoneIn(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(starlark.Iterable); ok {
+		return t.containsNone("contains no elements in", arg1)
+	}
+	return nil, errUnhandled
+}
+
+func containsNoneOf(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.containsNone("contains none of", starlark.Tuple(args))
+}
+
+// Determines if the subject contains none of the excluded elements.
+func (t *T) containsNone(failVerb string, excluded starlark.Iterable) (starlark.Value, error) {
+	actualSlice, err := t.actualAsSlice()
+	if err != nil {
+		return nil, err
+	}
+
+	iterExcluded := excluded.Iterate()
+	defer iterExcluded.Done()
+	var i starlark.Value
+	present := newDuplicateCounter()
+
+	for iterExcluded.Next(&i) {
+		index, err := indexOf(i, actualSlice)
+		if err != nil {
+			return nil, err
+		}
+		if index != -1 {
+			present.Increment(i)
+		}
+	}
+	if !present.Empty() {
+		return nil, t.failWithBadResults(failVerb, excluded, "contains", present, "")
+	}
+	return starlark.None, nil
+}
+
+func isOrdered(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isOrderedAccordingTo(t, t.registered.Cmp)
+}
+
+func isOrderedAccordingTo(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(*starlark.Function); ok {
+		return t.pairwiseCheck(arg1, false)
+	}
+	return nil, errUnhandled
+}
+
+func isStrictlyOrdered(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isStrictlyOrderedAccordingTo(t, t.registered.Cmp)
+}
+
+func isStrictlyOrderedAccordingTo(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if arg1, ok := args[0].(*starlark.Function); ok {
+		return t.pairwiseCheck(arg1, true)
+	}
+	return nil, errUnhandled
+}
+
+// Iterates over this subject and compares adjacent elements.
+func (t *T) pairwiseCheck(pairComparator *starlark.Function, strict bool) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.IterableMapping:
+		return nil, errDictOrdering
+	case starlark.Iterable:
+		return t.doPairwiseCheck(actual, pairComparator, strict)
+	case starlark.String:
+		t.turnActualIntoIterableFromString()
+		return t.doPairwiseCheck(t.actual.(starlark.Iterable), pairComparator, strict)
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func (t *T) doPairwiseCheck(actual starlark.Iterable, pairComparator *starlark.Function, strict bool) (starlark.Value, error) {
+	iterActual := actual.Iterate()
+	defer iterActual.Done()
+
+	var prev, current starlark.Value
+	if iterActual.Next(&prev) {
+		for {
+			if !iterActual.Next(&current) {
+				break
+			}
+
+			args := starlark.Tuple{prev, current}
+			someInt, err := t.registered.Apply(pairComparator, args)
+			if err != nil {
+				return nil, err
+			}
+			r, err := starlark.AsInt32(someInt)
+			if err != nil {
+				return nil, err
+			}
+			switch {
+			case r < 0:
+			case r == 0 && !strict:
+			default:
+				msg := "is ordered"
+				if strict {
+					msg = "is strictly ordered"
+				}
+				return nil, t.failComparingValues(msg, args, "")
+			}
+			prev = current
+		}
+	}
+	return starlark.None, nil
+}
+
+func containsKey(t *T, args ...starlark.Value) (starlark.Value, error) {
+	key := args[0]
+	if actual, ok := t.actual.(starlark.Mapping); ok {
+		_, found, err := actual.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			msg := fmt.Sprintf("contains key <%s>", key.String())
+			return nil, t.failWithProposition(msg, "")
+		}
+		return starlark.None, nil
+	}
+	return nil, errUnhandled
+}
+
+func doesNotContainKey(t *T, args ...starlark.Value) (starlark.Value, error) {
+	key := args[0]
+	if actual, ok := t.actual.(starlark.Mapping); ok {
+		_, found, err := actual.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			msg := fmt.Sprintf("does not contain key <%s>", key.String())
+			return nil, t.failWithProposition(msg, "")
+		}
+		return starlark.None, nil
+	}
+	return nil, errUnhandled
+}
+
+// Assertion that the subject contains the key mapping to the value.
+func containsItem(t *T, args ...starlark.Value) (starlark.Value, error) {
+	key, value := args[0], args[1]
+	if actual, ok := t.actual.(starlark.Mapping); ok {
+		val, found, err := actual.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			ok, err := starlark.Compare(syntax.EQL, value, val)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				return starlark.None, nil
+			}
+			msg := fmt.Sprintf(
+				"contains item <%s>. However, it has a mapping from <%s> to <%s>",
+				starlark.Tuple{key, value}.String(),
+				key.String(),
+				val.String(),
+			)
+			return nil, t.failWithProposition(msg, "")
+		}
+
+		if actual, ok := t.actual.(starlark.IterableMapping); ok {
+			var otherKeys []starlark.Value
+			for _, kv := range actual.Items() {
+				if len(kv) != 2 {
+					break
+				}
+				ok, err := starlark.Compare(syntax.EQL, value, kv[1])
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					otherKeys = append(otherKeys, kv[0])
+				}
+			}
+			if len(otherKeys) != 0 {
+				msg := fmt.Sprintf(
+					"contains item <%s>. However, the following keys are mapped to <%s>: %s",
+					starlark.Tuple{key, value}.String(),
+					value.String(),
+					starlark.NewList(otherKeys).String(),
+				)
+				return nil, t.failWithProposition(msg, "")
+			}
+		}
+
+		msg := fmt.Sprintf("contains item <%s>", starlark.Tuple{key, value}.String())
+		return nil, t.failWithProposition(msg, "")
+	}
+	return nil, errUnhandled
+}
+
+func doesNotContainItem(t *T, args ...starlark.Value) (starlark.Value, error) {
+	key, value := args[0], args[1]
+	if actual, ok := t.actual.(starlark.Mapping); ok {
+		val, found, err := actual.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			ok, err := starlark.Compare(syntax.EQL, value, val)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				msg := fmt.Sprintf(
+					"does not contain item <%s>",
+					starlark.Tuple{key, value}.String(),
+				)
+				return nil, t.failWithProposition(msg, "")
+			}
+		}
+		return starlark.None, nil
+	}
+	return nil, errUnhandled
+}
+
+func hasLength(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		expected, err := starlark.AsInt32(args[0])
+		if err != nil {
+			return nil, errUnhandled
+		}
+		actualLength := actual.Len()
+		if actualLength != expected {
+			msg := fmt.Sprintf("has a length of %d. It is %d", expected, actualLength)
+			return nil, t.failWithProposition(msg, "")
+		}
+		return starlark.None, nil
+	}
+	return nil, errUnhandled
+}
+
+func startsWith(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		if prefix, ok := args[0].(starlark.String); ok {
+			if !strings.HasPrefix(actual.GoString(), prefix.GoString()) {
+				return nil, t.failComparingValues("starts with", prefix, "")
+			}
+			return starlark.None, nil
+		}
+	}
+	return nil, errUnhandled
+}
+
+func endsWith(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		if suffix, ok := args[0].(starlark.String); ok {
+			if !strings.HasSuffix(actual.GoString(), suffix.GoString()) {
+				return nil, t.failComparingValues("ends with", suffix, "")
+			}
+			return starlark.None, nil
+		}
+	}
+	return nil, errUnhandled
+}
+
+func newRegex(regex string) (*regexp.Regexp, error) {
+	if strings.Contains(regex, "\\C") {
+		// https://github.com/google/starlark-go/issues/241#issuecomment-529663462
+		return nil, errors.New("unsupported regex class \\C")
+	}
+	return regexp.Compile(regex)
+}
+
+func matches(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		if regex, ok := args[0].(starlark.String); ok {
+			r, err := newRegex("^" + regex.GoString())
+			if err != nil {
+				return nil, err
+			}
+			if !r.MatchString(actual.GoString()) {
+				msg := fmt.Sprintf("matches <%s>", regex)
+				return nil, t.failWithProposition(msg, "")
+			}
+			return starlark.None, nil
+		}
+	}
+	return nil, errUnhandled
+}
+
+func doesNotMatch(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		if regex, ok := args[0].(starlark.String); ok {
+			r, err := newRegex("^" + regex.GoString())
+			if err != nil {
+				return nil, err
+			}
+			if r.MatchString(actual.GoString()) {
+				msg := fmt.Sprintf("fails to match <%s>", regex)
+				return nil, t.failWithProposition(msg, "")
+			}
+			return starlark.None, nil
+		}
+	}
+	return nil, errUnhandled
+}
+
+func containsMatch(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		if regex, ok := args[0].(starlark.String); ok {
+			r, err := newRegex(regex.GoString())
+			if err != nil {
+				return nil, err
+			}
+			if !r.MatchString(actual.GoString()) {
+				msg := fmt.Sprintf("should have contained a match for <%s>", regex)
+				return nil, t.failWithProposition(msg, "")
+			}
+			return starlark.None, nil
+		}
+	}
+	return nil, errUnhandled
+}
+
+func doesNotContainMatch(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if actual, ok := t.actual.(starlark.String); ok {
+		if regex, ok := args[0].(starlark.String); ok {
+			r, err := newRegex(regex.GoString())
+			if err != nil {
+				return nil, err
+			}
+			if r.MatchString(actual.GoString()) {
+				msg := fmt.Sprintf("should not have contained a match for <%s>", regex)
+				return nil, t.failWithProposition(msg, "")
+			}
+			return starlark.None, nil
+		}
+	}
+	return nil, errUnhandled
+}
+
+func isOfType(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if expected, ok := args[0].(starlark.String); ok {
+		actualType := t.actual.Type()
+		if expected.GoString() == actualType {
+			return starlark.None, nil
+		}
+		msg := fmt.Sprintf("is of type <%s>", expected)
+		suffix := fmt.Sprintf(" However, it is of type <%q>", actualType)
+		return nil, t.failWithProposition(msg, suffix)
+	}
+	return nil, errUnhandled
+}
+
+func isNotOfType(t *T, args ...starlark.Value) (starlark.Value, error) {
+	if expected, ok := args[0].(starlark.String); ok {
+		actualType := t.actual.Type()
+		if expected.GoString() != actualType {
+			return starlark.None, nil
+		}
+		msg := fmt.Sprintf("is not of type <%s>", expected)
+		suffix := fmt.Sprintf(" However, it is of type <%q>", actualType)
+		return nil, t.failWithProposition(msg, suffix)
+	}
+	return nil, errUnhandled
+}
+
+func isZero(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		if actual != 0 {
+			return nil, t.failWithProposition("is zero", "")
+		}
+		return starlark.None, nil
+	case starlark.Int:
+		if actual.Truth() {
+			return nil, t.failWithProposition("is zero", "")
+		}
+		return starlark.None, nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func isNonZero(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		if actual == 0 {
+			return nil, t.failWithProposition("is non-zero", "")
+		}
+		return starlark.None, nil
+	case starlark.Int:
+		if !actual.Truth() {
+			return nil, t.failWithProposition("is non-zero", "")
+		}
+		return starlark.None, nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func isFloatNotFinite(f float64) bool { return math.IsInf(f, 0) || math.IsNaN(f) }
+
+func isFinite(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		if isFloatNotFinite(float64(actual)) {
+			return nil, t.failWithSubject("should have been finite")
+		}
+		return starlark.None, nil
+	case starlark.Int:
+		return starlark.None, nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func isNotFinite(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		if !isFloatNotFinite(float64(actual)) {
+			return nil, t.failWithSubject("should not have been finite")
+		}
+		return starlark.None, nil
+	case starlark.Int:
+		return nil, t.failWithSubject("should not have been finite")
+	default:
+		return nil, errUnhandled
+	}
+}
+
+var (
+	pInf = starlark.Float(math.Inf(+1))
+	nInf = starlark.Float(math.Inf(-1))
+)
+
+func isPositiveInfinity(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isEqualTo(t, pInf)
+}
+
+func isNegativeInfinity(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isEqualTo(t, nInf)
+}
+
+func isNotPositiveInfinity(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isNotEqualTo(t, pInf)
+}
+
+func isNotNegativeInfinity(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return isNotEqualTo(t, nInf)
+}
+
+var nan = starlark.Float(math.NaN())
+
+func isNaN(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		if !math.IsNaN(float64(actual)) {
+			return nil, t.failComparingValues("is equal to", nan, "")
+		}
+		return starlark.None, nil
+	case starlark.Int:
+		return nil, t.failComparingValues("is equal to", nan, "")
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func isNotNaN(t *T, args ...starlark.Value) (starlark.Value, error) {
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		if math.IsNaN(float64(actual)) {
+			return nil, t.failWithSubject("should not have been <nan>")
+		}
+		return starlark.None, nil
+	case starlark.Int:
+		return starlark.None, nil
+	default:
+		return nil, errUnhandled
+	}
+}
+
+func (t *T) setWithinTolerance(tolerance starlark.Value, within bool) (starlark.Value, error) {
+	wt := withinTolerance{
+		within:           within,
+		toleranceAsValue: tolerance,
+	}
+
+	switch delta := tolerance.(type) {
+	case starlark.Float:
+		f := float64(delta)
+		if math.IsNaN(f) {
+			return nil, newInvalidAssertion("tolerance cannot be <nan>")
+		}
+		if f < 0 {
+			return nil, newInvalidAssertion("tolerance cannot be negative")
+		}
+		if math.IsInf(f, +1) {
+			return nil, newInvalidAssertion("tolerance cannot be positive infinity")
+		}
+		wt.tolerance = new(big.Rat).SetFloat64(f)
+	case starlark.Int:
+		if delta.Sign() < 0 {
+			return nil, newInvalidAssertion("tolerance cannot be negative")
+		}
+		wt.tolerance = new(big.Rat).SetInt(delta.BigInt())
+	default:
+		return nil, errUnhandled
+	}
+
+	switch actual := t.actual.(type) {
+	case starlark.Float:
+		wt.actual = new(big.Rat).SetFloat64(float64(actual))
+	case starlark.Int:
+		wt.actual = new(big.Rat).SetInt(actual.BigInt())
+	default:
+		return nil, errUnhandled
+	}
+
+	if t.withinTolerance != nil {
+		return nil, newInvalidAssertion("tolerance cannot be overwritten")
+	}
+	t.withinTolerance = &wt
+	return t, nil
+}
+
+func isWithin(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.setWithinTolerance(args[0], true)
+}
+
+func isNotWithin(t *T, args ...starlark.Value) (starlark.Value, error) {
+	return t.setWithinTolerance(args[0], false)
+}
+
+func (t *T) withinToleranceOf(expected *big.Rat, expectedAsValue starlark.Value) (starlark.Value, error) {
+	if t.withinTolerance == nil {
+		// .of() called, .is_within()/.is_not_within() not called
+		return nil, errUnhandled
+	}
+
+	tolerablyEqual := false
+	if expected != nil && t.withinTolerance.actual != nil {
+		// tolerably_equal = abs(self._actual - expected) <= self._tolerance
+		diff := new(big.Rat).Sub(t.withinTolerance.actual, expected)
+		tolerablyEqual = new(big.Rat).Abs(diff).Cmp(t.withinTolerance.tolerance) < 1
+	}
+	// Otherwise, (*big.Rat).SetFloat64(float64) was given non-finite
+	// in which case Cmp must fail (i.e tolerablyEqual=false)
+
+	notWithin := ""
+	if !t.withinTolerance.within {
+		notWithin = "not "
+	}
+	if t.withinTolerance.within != tolerablyEqual {
+		msg := fmt.Sprintf("and <%s> should %shave been within <%s> of each other",
+			expectedAsValue, notWithin, t.withinTolerance.toleranceAsValue)
+		return nil, t.failWithSubject(msg)
+	}
+	return starlark.None, nil
+}
+
+func of(t *T, args ...starlark.Value) (starlark.Value, error) {
+	expected := args[0]
+	switch x := expected.(type) {
+	case starlark.Float:
+		r := new(big.Rat).SetFloat64(float64(x))
+		return t.withinToleranceOf(r, expected)
+	case starlark.Int:
+		r := new(big.Rat).SetInt(x.BigInt())
+		return t.withinToleranceOf(r, expected)
+	default:
+		return nil, errUnhandled
+	}
+}

--- a/lib/truth/attrs.go
+++ b/lib/truth/attrs.go
@@ -1,0 +1,230 @@
+package truth
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+type (
+	attr  func(t *T, args ...starlark.Value) (starlark.Value, error)
+	attrs map[string]attr
+)
+
+var (
+	methods0args = attrs{
+		"contains_no_duplicates":   containsNoDuplicates,
+		"in_order":                 inOrder,
+		"is_callable":              isCallable,
+		"is_empty":                 isEmpty,
+		"is_false":                 isFalse,
+		"is_falsy":                 isFalsy,
+		"is_finite":                isFinite,
+		"is_nan":                   isNaN,
+		"is_negative_infinity":     isNegativeInfinity,
+		"is_non_zero":              isNonZero,
+		"is_none":                  isNone,
+		"is_not_callable":          isNotCallable,
+		"is_not_empty":             isNotEmpty,
+		"is_not_finite":            isNotFinite,
+		"is_not_nan":               isNotNaN,
+		"is_not_negative_infinity": isNotNegativeInfinity,
+		"is_not_none":              isNotNone,
+		"is_not_positive_infinity": isNotPositiveInfinity,
+		"is_ordered":               isOrdered,
+		"is_positive_infinity":     isPositiveInfinity,
+		"is_strictly_ordered":      isStrictlyOrdered,
+		"is_true":                  isTrue,
+		"is_truthy":                isTruthy,
+		"is_zero":                  isZero,
+	}
+
+	methods1arg = attrs{
+		"contains":                         contains,
+		"contains_all_in":                  containsAllIn,
+		"contains_any_in":                  containsAnyIn,
+		"contains_exactly_elements_in":     containsExactlyElementsIn,
+		"contains_exactly_items_in":        containsExactlyItemsIn,
+		"contains_key":                     containsKey,
+		"contains_match":                   containsMatch,
+		"contains_none_in":                 containsNoneIn,
+		"does_not_contain":                 doesNotContain,
+		"does_not_contain_key":             doesNotContainKey,
+		"does_not_contain_match":           doesNotContainMatch,
+		"does_not_have_attribute":          doesNotHaveAttribute,
+		"does_not_match":                   doesNotMatch,
+		"ends_with":                        endsWith,
+		"has_attribute":                    hasAttribute,
+		"has_length":                       hasLength,
+		"has_size":                         hasSize,
+		"is_at_least":                      isAtLeast,
+		"is_at_most":                       isAtMost,
+		"is_equal_to":                      isEqualTo,
+		"is_greater_than":                  isGreaterThan,
+		"is_in":                            isIn,
+		"is_less_than":                     isLessThan,
+		"is_not_equal_to":                  isNotEqualTo,
+		"is_not_in":                        isNotIn,
+		"is_not_of_type":                   isNotOfType,
+		"is_not_within":                    isNotWithin,
+		"is_of_type":                       isOfType,
+		"is_ordered_according_to":          isOrderedAccordingTo,
+		"is_strictly_ordered_according_to": isStrictlyOrderedAccordingTo,
+		"is_within":                        isWithin,
+		"matches":                          matches,
+		"named":                            named,
+		"of":                               of,
+		"starts_with":                      startsWith,
+	}
+
+	methods2args = attrs{
+		"contains_item":         containsItem,
+		"does_not_contain_item": doesNotContainItem,
+	}
+
+	methodsNargs = attrs{
+		"contains_all_of":  containsAllOf,
+		"contains_any_of":  containsAnyOf,
+		"contains_exactly": containsExactly,
+		"contains_none_of": containsNoneOf,
+		"is_any_of":        isAnyOf,
+		"is_none_of":       isNoneOf,
+	}
+
+	methods = []attrs{
+		methodsNargs,
+		methods0args,
+		methods1arg,
+		methods2args,
+	}
+
+	attrNames = func() []string {
+		count := 0
+		for _, ms := range methods {
+			count += len(ms)
+		}
+		names := make([]string, 0, count)
+		for _, ms := range methods {
+			for name := range ms {
+				names = append(names, name)
+			}
+		}
+		sort.Strings(names)
+		return names
+	}()
+)
+
+func findAttr(name string) (attr, int) {
+	for i, ms := range methods[1:] {
+		if m, ok := ms[name]; ok {
+			return m, i
+		}
+	}
+	if m, ok := methodsNargs[name]; ok {
+		return m, -1
+	}
+	return nil, 0
+}
+
+// LocalThreadKeyForClose is used by Close() and internally to check subjects
+// are eventually resolved.
+var LocalThreadKeyForClose = Default
+
+var εCallFrame = starlark.CallFrame{Pos: syntax.Position{Line: -1, Col: -1}}
+
+// Close ensures that all created subjects were eventually resolved.
+// Otherwise it returns an error pinpointing the UnresolvedError position.
+// A subject is considered resolved what at least one proposition has been
+// executed on it. An unresolved or dangling assertion is almost certainly a
+// test author error.
+func Close(th *starlark.Thread) (err error) {
+	if c, ok := th.Local(LocalThreadKeyForClose).(starlark.CallFrame); ok && c != εCallFrame {
+		err = UnresolvedError(c.Pos.String())
+	}
+	return
+}
+
+// Asserted returns whether all assert.that(x)... call chains were properly terminated
+func Asserted(th *starlark.Thread) bool {
+	_, ok := th.Local(LocalThreadKeyForClose).(starlark.CallFrame)
+	return ok
+}
+
+func builtinAttr(t *T, name string) (starlark.Value, error) {
+	method, nArgs := findAttr(name)
+	if method == nil {
+		return nil, nil // no such method
+	}
+	impl := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if err := t.registerValues(thread); err != nil {
+			return nil, err
+		}
+		bName := b.Name()
+
+		var argz []starlark.Value
+		switch nArgs {
+		case -1:
+			if len(kwargs) > 0 {
+				return nil, fmt.Errorf("%s: unexpected keyword arguments", bName)
+			}
+			argz = []starlark.Value(args)
+		case 0:
+			if err := starlark.UnpackPositionalArgs(bName, args, kwargs, nArgs); err != nil {
+				return nil, err
+			}
+		case 1:
+			var arg1 starlark.Value
+			if err := starlark.UnpackPositionalArgs(bName, args, kwargs, nArgs, &arg1); err != nil {
+				return nil, err
+			}
+			argz = []starlark.Value{arg1}
+		case 2:
+			var arg1, arg2 starlark.Value
+			if err := starlark.UnpackPositionalArgs(bName, args, kwargs, nArgs, &arg1, &arg2); err != nil {
+				return nil, err
+			}
+			argz = []starlark.Value{arg1, arg2}
+		default:
+			err := fmt.Errorf("unexpected #args for %s.that(%s).%q(): %d", Default, t.actual.String(), name, nArgs)
+			return nil, err
+		}
+
+		providesInOrder := false ||
+			strings.HasPrefix(bName, "contains_all") ||
+			strings.HasPrefix(bName, "contains_exactly")
+
+		deferred := false
+		switch bName {
+		case "named":
+		case "is_within":
+		case "is_not_within":
+		default:
+			// Marks the current subject as having been adequately asserted.
+			defer thread.SetLocal(LocalThreadKeyForClose, εCallFrame)
+			deferred = true
+		}
+
+		ret, err := method(t, argz...)
+		switch err {
+		case nil:
+			if providesInOrder {
+				if tt, ok := ret.(*T); !ok {
+					panic("unreachable: call should return t for .in_order()")
+				} else if tt.forOrdering == nil {
+					panic("unreachable: call should prepare for .in_order()")
+				}
+			} else if deferred && ret != starlark.None {
+				panic(fmt.Sprintf("unreachable: call should return None, not: %T", ret))
+			}
+			return ret, nil
+		case errUnhandled:
+			return nil, t.unhandled(bName, argz...)
+		default:
+			return nil, err
+		}
+	}
+	return starlark.NewBuiltin(name, impl).BindReceiver(t), nil
+}

--- a/lib/truth/bools_test.go
+++ b/lib/truth/bools_test.go
@@ -1,0 +1,71 @@
+package truth
+
+import "testing"
+
+func TestTrue(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(True).is_true()`:  nil,
+		`that(True).is_false()`: fail("True", "is False"),
+	})
+}
+
+func TestFalse(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(False).is_false()`: nil,
+		`that(False).is_true()`:  fail("False", "is True"),
+	})
+}
+
+func TestTruthyThings(t *testing.T) {
+	values := []string{
+		`1`,
+		`True`,
+		`2.5`,
+		`"Hi"`,
+		`[3]`,
+		`{4: "four"}`,
+		`("my", "tuple")`,
+		`set([5])`,
+		`-1`,
+	}
+	m := make(map[string]error, 4*len(values))
+	for _, v := range values {
+		m[`that(`+v+`).is_truthy()`] = nil
+		m[`that(`+v+`).is_falsy()`] = fail(v, "is falsy")
+		m[`that(`+v+`).is_false()`] = fail(v, "is False")
+		if v != `True` {
+			m[`that(`+v+`).is_true()`] = fail(v, "is True",
+				" However, it is truthy. Did you mean to call .is_truthy() instead?")
+		}
+	}
+	testEach(t, m)
+}
+
+func TestFalsyThings(t *testing.T) {
+	values := []string{
+		`None`,
+		`False`,
+		`0`,
+		`0.0`,
+		`""`,
+		`()`, // tuple
+		`[]`,
+		`{}`,
+		`set()`,
+	}
+	m := make(map[string]error, 4*len(values))
+	for _, v := range values {
+		vv := v
+		if v == `set()` {
+			vv = `set([])`
+		}
+		m[`that(`+v+`).is_falsy()`] = nil
+		m[`that(`+v+`).is_truthy()`] = fail(vv, "is truthy")
+		m[`that(`+v+`).is_true()`] = fail(vv, "is True")
+		if v != `False` {
+			m[`that(`+v+`).is_false()`] = fail(vv, "is False",
+				" However, it is falsy. Did you mean to call .is_falsy() instead?")
+		}
+	}
+	testEach(t, m)
+}

--- a/lib/truth/cmp_test.go
+++ b/lib/truth/cmp_test.go
@@ -1,0 +1,35 @@
+package truth
+
+import "testing"
+
+func TestIsAtLeast(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(5).is_at_least(3)`: nil,
+		`that(5).is_at_least(5)`: nil,
+		`that(5).is_at_least(8)`: fail("5", "is at least <8>"),
+	})
+}
+
+func TestIsAtMost(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(5).is_at_most(5)`: nil,
+		`that(5).is_at_most(8)`: nil,
+		`that(5).is_at_most(3)`: fail("5", "is at most <3>"),
+	})
+}
+
+func TestIsGreaterThan(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(5).is_greater_than(3)`: nil,
+		`that(5).is_greater_than(5)`: fail("5", "is greater than <5>"),
+		`that(5).is_greater_than(8)`: fail("5", "is greater than <8>"),
+	})
+}
+
+func TestIsLessThan(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(5).is_less_than(8)`: nil,
+		`that(5).is_less_than(5)`: fail("5", "is less than <5>"),
+		`that(5).is_less_than(3)`: fail("5", "is less than <3>"),
+	})
+}

--- a/lib/truth/contains_test.go
+++ b/lib/truth/contains_test.go
@@ -1,0 +1,384 @@
+package truth
+
+import "testing"
+
+func TestContainsExactly(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_exactly(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		`that(` + ss + `).contains_exactly(3, 5, []).in_order()`: nil,
+		`that(` + ss + `).contains_exactly(3, 5, [])`:            nil,
+		`that(` + ss + `).contains_exactly([], 3, 5)`:            nil,
+		`that(` + ss + `).contains_exactly([], 3, 5).in_order()`: fail(ss,
+			"contains exactly these elements in order <([], 3, 5)>"),
+
+		s(`3, 5, [], 9`): fail(ss,
+			`contains exactly <(3, 5, [], 9)>. It is missing <9>`),
+		s(`9, 3, 5, [], 10`): fail(ss,
+			`contains exactly <(9, 3, 5, [], 10)>. It is missing <9, 10>`),
+		s(`3, 5`): fail(ss,
+			`contains exactly <(3, 5)>. It has unexpected items <[]>`),
+		s(`[], 3`): fail(ss,
+			`contains exactly <([], 3)>. It has unexpected items <5>`),
+		s(`3`): fail(ss,
+			`contains exactly <(3,)>. It has unexpected items <5, []>`),
+		s(`4, 4`): fail(ss,
+			`contains exactly <(4, 4)>. It is missing <4 [2 copies]> and has unexpected items <3, 5, []>`),
+		s(`3, 5, 9`): fail(ss,
+			`contains exactly <(3, 5, 9)>. It is missing <9> and has unexpected items <[]>`),
+		s(`(3, 5, [])`): fail(ss,
+			`contains exactly <((3, 5, []),)>. It is missing <(3, 5, [])> and has unexpected items <3, 5, []>`,
+			warnContainsExactlySingleIterable),
+		s(``): fail(ss, "is empty"),
+	})
+}
+
+func TestContainsExactlyDoesNotWarnIfSingleStringNotContained(t *testing.T) {
+	s := `.contains_exactly("abc")`
+	testEach(t, map[string]error{
+		`that(())` + s:      fail(`()`, `contains exactly <("abc",)>. It is missing <"abc">`),
+		`that([])` + s:      fail(`[]`, `contains exactly <("abc",)>. It is missing <"abc">`),
+		`that({})` + s:      errMustBeEqualNumberOfKVPairs(1),
+		`that("")` + s:      fail(`""`, `contains exactly <("abc",)>. It is missing <"abc">`),
+		`that(set([]))` + s: fail(`set([])`, `contains exactly <("abc",)>. It is missing <"abc">`),
+	})
+}
+
+func TestContainsExactlyEmptyContainer(t *testing.T) {
+	s := func(x string) string {
+		return `that(` + x + `).contains_exactly(3)`
+	}
+	testEach(t, map[string]error{
+		s(`()`): fail(`()`, `contains exactly <(3,)>. It is missing <3>`),
+		s(`[]`): fail(`[]`, `contains exactly <(3,)>. It is missing <3>`),
+		s(`{}`): errMustBeEqualNumberOfKVPairs(1),
+		s(`""`): fail(`""`, `contains exactly <(3,)>. It is missing <3>`),
+		//FIXME: Not true that <''> contains exactly <(3,)>. It is missing <[3]>. warnContainsExactlySingleIterable
+		s(`set([])`): fail(`set([])`, `contains exactly <(3,)>. It is missing <3>`),
+	})
+}
+
+func TestContainsExactlyNothing(t *testing.T) {
+	s := func(x string) string {
+		return `that(` + x + `).contains_exactly()`
+	}
+	testEach(t, map[string]error{
+		s(`()`):      nil,
+		s(`[]`):      nil,
+		s(`{}`):      nil,
+		s(`""`):      nil,
+		s(`set([])`): nil,
+	})
+}
+
+func TestContainsExactlyElementsIn(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_exactly_elements_in(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		`that(` + ss + `).contains_exactly_elements_in((3, 5, [])).in_order()`: nil,
+		`that(` + ss + `).contains_exactly_elements_in(([], 3, 5))`:            nil,
+		`that(` + ss + `).contains_exactly_elements_in(([], 3, 5)).in_order()`: fail(ss,
+			"contains exactly these elements in order <([], 3, 5)>"),
+
+		s(`(3, 5, [], 9)`):     fail(ss, `contains exactly <(3, 5, [], 9)>. It is missing <9>`),
+		s(`(9, 3, 5, [], 10)`): fail(ss, `contains exactly <(9, 3, 5, [], 10)>. It is missing <9, 10>`),
+		s(`(3, 5)`):            fail(ss, `contains exactly <(3, 5)>. It has unexpected items <[]>`),
+		s(`([], 3)`):           fail(ss, `contains exactly <([], 3)>. It has unexpected items <5>`),
+		s(`(3,)`):              fail(ss, `contains exactly <(3,)>. It has unexpected items <5, []>`),
+		s(`(4, 4)`):            fail(ss, `contains exactly <(4, 4)>. It is missing <4 [2 copies]> and has unexpected items <3, 5, []>`),
+		s(`(3, 5, 9)`):         fail(ss, `contains exactly <(3, 5, 9)>. It is missing <9> and has unexpected items <[]>`),
+		s(`()`):                fail(ss, `is empty`),
+	})
+}
+
+func TestContainsExactlyElementsInEmptyContainer(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(()).contains_exactly_elements_in(())`: nil,
+		`that(()).contains_exactly_elements_in((3,))`: fail(`()`,
+			`contains exactly <(3,)>. It is missing <3>`),
+	})
+}
+
+func TestContainsExactlyTargetingOrderedDict(t *testing.T) {
+	ss := `((2, "two"), (4, "four"))`
+	s := `that(` + ss + `).contains_exactly(`
+	testEach(t, map[string]error{
+		`that(` + ss + `).contains_exactly((2, "two"), (4, "four")).in_order()`: nil,
+		`that(` + ss + `).contains_exactly((2, "two"), (4, "four"))`:            nil,
+		`that(` + ss + `).contains_exactly((4, "four"), (2, "two"))`:            nil,
+		`that(` + ss + `).contains_exactly((4, "four"), (2, "two")).in_order()`: fail(ss,
+			`contains exactly these elements in order <((4, "four"), (2, "two"))>`),
+
+		s + `2, "two")`: fail(ss,
+			`contains exactly <(2, "two")>. It is missing <2, "two"> and has unexpected items <(2, "two"), (4, "four")>`),
+
+		s + `2, "two", 4, "for")`: fail(ss,
+			`contains exactly <(2, "two", 4, "for")>. It is missing <2, "two", 4, "for"> and has unexpected items <(2, "two"), (4, "four")>`),
+
+		s + `2, "two", 4, "four", 5, "five")`: fail(ss,
+			`contains exactly <(2, "two", 4, "four", 5, "five")>. It is missing <2, "two", 4, "four", 5, "five"> and has unexpected items <(2, "two"), (4, "four")>`),
+	})
+}
+
+func TestContainsExactlyPassingOddNumberOfArgs(t *testing.T) {
+	testEach(t, map[string]error{
+		`that({}).contains_exactly("key1", "value1", "key2")`: errMustBeEqualNumberOfKVPairs(3),
+	})
+}
+
+func TestContainsExactlyItemsIn(t *testing.T) {
+	s := func(x string) string {
+		return `that({2: "two", 4: "four"}).contains_exactly_items_in(` + x + `)`
+	}
+	ss := `items([(2, "two"), (4, "four")])`
+	testEach(t, map[string]error{
+		s(`{2: "two", 4: "four"}`): nil,
+
+		s(`{}`) + `.in_order()`: fail(ss, `is empty`),
+
+		s(`{4: "four", 2: "two"}`) + `.in_order()`: newInvalidAssertion("values of type dict are not ordered"),
+		// Starlark's dict is not ordered (uses insertion order)
+		s(`{2: "two", 4: "four"}`) + `.in_order()`: newInvalidAssertion("values of type dict are not ordered"),
+
+		s(`{2: "two"}`): fail(ss,
+			`contains exactly <((2, "two"),)>. It has unexpected items <(4, "four")>`,
+			warnContainsExactlySingleIterable),
+
+		s(`{2: "two", 4: "for"}`): fail(ss,
+			`contains exactly <((2, "two"), (4, "for"))>. It is missing <(4, "for")> and has unexpected items <(4, "four")>`),
+
+		s(`{2: "two", 4: "four", 5: "five"}`): fail(ss,
+			`contains exactly <((2, "two"), (4, "four"), (5, "five"))>. It is missing <(5, "five")>`),
+	})
+}
+
+func TestContains(t *testing.T) {
+	s := func(x string) string {
+		return `that((2, 5, [])).contains(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`2`):   nil,
+		s(`5`):   nil,
+		s(`[]`):  nil,
+		s(`3`):   newTruthAssertion(`<(2, 5, [])> should have contained 3.`),
+		s(`"2"`): newTruthAssertion(`<(2, 5, [])> should have contained "2".`),
+		s(`{}`):  newTruthAssertion(`<(2, 5, [])> should have contained {}.`),
+	})
+}
+
+func TestDoesNotContain(t *testing.T) {
+	s := func(x string) string {
+		return `that((2, 5, [])).does_not_contain(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`3`):   nil,
+		s(`"2"`): nil,
+		s(`{}`):  nil,
+		s(`2`):   newTruthAssertion(`<(2, 5, [])> should not have contained 2.`),
+		s(`5`):   newTruthAssertion(`<(2, 5, [])> should not have contained 5.`),
+		s(`[]`):  newTruthAssertion(`<(2, 5, [])> should not have contained [].`),
+	})
+}
+
+func TestContainsNoDuplicates(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).contains_no_duplicates()`
+	}
+	testEach(t, map[string]error{
+		s(`()`):           nil,
+		s(abc):            nil,
+		s(`(2,)`):         nil,
+		s(`(2, 5)`):       nil,
+		s(`{2: 2}`):       nil,
+		s(`set([2])`):     nil,
+		s(`"aaa"`):        newTruthAssertion(`<"aaa"> has the following duplicates: <"a" [3 copies]>.`),
+		s(`(3, 2, 5, 2)`): newTruthAssertion(`<(3, 2, 5, 2)> has the following duplicates: <2 [2 copies]>.`),
+		s(`"abcabc"`): newTruthAssertion(
+			`<"abcabc"> has the following duplicates: <"a" [2 copies], "b" [2 copies], "c" [2 copies]>.`),
+	})
+}
+
+func TestContainsAllIn(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_all_in(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`()`):                                nil,
+		`that(` + ss + `).contains_all_in(())`: nil,
+		`that(` + ss + `).contains_all_in(()).in_order()`:         nil,
+		`that(` + ss + `).contains_all_in((3,))`:                  nil,
+		`that(` + ss + `).contains_all_in((3,)).in_order()`:       nil,
+		`that(` + ss + `).contains_all_in((3, []))`:               nil,
+		`that(` + ss + `).contains_all_in((3, [])).in_order()`:    nil,
+		`that(` + ss + `).contains_all_in((3, 5, []))`:            nil,
+		`that(` + ss + `).contains_all_in((3, 5, [])).in_order()`: nil,
+		`that(` + ss + `).contains_all_in(([], 5, 3))`:            nil,
+		`that(` + ss + `).contains_all_in(([], 5, 3)).in_order()`: fail(ss,
+			`contains all elements in order <([], 5, 3)>`),
+		s(`(2, 3)`):    fail(ss, "contains all elements in <(2, 3)>. It is missing <2>"),
+		s(`(2, 3, 6)`): fail(ss, "contains all elements in <(2, 3, 6)>. It is missing <2, 6>"),
+	})
+}
+
+func TestContainsAllOf(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_all_of(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		`that(` + ss + `).contains_all_of()`:                    nil,
+		`that(` + ss + `).contains_all_of().in_order()`:         nil,
+		`that(` + ss + `).contains_all_of(3)`:                   nil,
+		`that(` + ss + `).contains_all_of(3).in_order()`:        nil,
+		`that(` + ss + `).contains_all_of(3, [])`:               nil,
+		`that(` + ss + `).contains_all_of(3, []).in_order()`:    nil,
+		`that(` + ss + `).contains_all_of(3, 5, [])`:            nil,
+		`that(` + ss + `).contains_all_of(3, 5, []).in_order()`: nil,
+		`that(` + ss + `).contains_all_of([], 3, 5)`:            nil,
+		`that(` + ss + `).contains_all_of([], 3, 5).in_order()`: fail(ss,
+			`contains all elements in order <([], 3, 5)>`),
+		s(`2, 3`):    fail(ss, "contains all of <(2, 3)>. It is missing <2>"),
+		s(`2, 3, 6`): fail(ss, "contains all of <(2, 3, 6)>. It is missing <2, 6>"),
+	})
+}
+
+func TestContainsWithStrings(t *testing.T) {
+	testEach(t, map[string]error{
+		`that("abcdefg").contains_all_of("a", "c", "e")`:            nil,
+		`that("abcdefg").contains_all_of("a", "c", "e").in_order()`: nil,
+		`that("abcdefg").contains_any_in(("a", "c", "e"))`:          nil,
+		`that("abcdefg").contains_none_of("x", "z", "y")`:           nil,
+	})
+}
+
+func TestContainsAllMixedHashableElements(t *testing.T) {
+	ss := `(3, [], 5, 8)`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_all_of(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		`that(` + ss + `).contains_all_of(3, [], 5, 8)`:            nil,
+		`that(` + ss + `).contains_all_of(3, [], 5, 8).in_order()`: nil,
+		`that(` + ss + `).contains_all_of(5, 3, 8, [])`:            nil,
+		`that(` + ss + `).contains_all_of(5, 3, 8, []).in_order()`: fail(ss,
+			`contains all elements in order <(5, 3, 8, [])>`),
+		s(`3, [], 8, 5, 9`):  fail(ss, "contains all of <(3, [], 8, 5, 9)>. It is missing <9>"),
+		s(`3, [], 8, 5, {}`): fail(ss, "contains all of <(3, [], 8, 5, {})>. It is missing <{}>"),
+		s(`8, 3, [], 9, 5`):  fail(ss, "contains all of <(8, 3, [], 9, 5)>. It is missing <9>"),
+	})
+}
+
+func TestContainsAnyIn(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_any_in(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`(3,)`):   nil,
+		s(`(7, 3)`): nil,
+		s(`()`):     fail(ss, "contains any element in <()>"),
+		s(`(2, 6)`): fail(ss, "contains any element in <(2, 6)>"),
+	})
+}
+
+func TestContainsAnyOf(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_any_of(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`3`):    nil,
+		s(`7, 3`): nil,
+		s(``):     fail(ss, "contains any of <()>"),
+		s(`2, 6`): fail(ss, "contains any of <(2, 6)>"),
+	})
+}
+
+func TestContainsNoneIn(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_none_in(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`()`):     nil,
+		s(`(2,)`):   nil,
+		s(`(2, 6)`): nil,
+		s(`(5,)`):   fail(ss, "contains no elements in <(5,)>. It contains <5>"),
+		s(`(2, 5)`): fail(ss, "contains no elements in <(2, 5)>. It contains <5>"),
+	})
+}
+
+func TestContainsNoneOf(t *testing.T) {
+	ss := `(3, 5, [])`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_none_of(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(``):     nil,
+		s(`2`):    nil,
+		s(`2, 6`): nil,
+		s(`5`):    fail(ss, "contains none of <(5,)>. It contains <5>"),
+		s(`2, 5`): fail(ss, "contains none of <(2, 5)>. It contains <5>"),
+	})
+}
+
+func TestContainsKey(t *testing.T) {
+	ss := `{2: "two", None: "None"}`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_key(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`2`):     nil,
+		s(`None`):  nil,
+		s(`3`):     fail(ss, `contains key <3>`),
+		s(`"two"`): fail(ss, `contains key <"two">`),
+	})
+}
+
+func TestDoesNotContainKey(t *testing.T) {
+	ss := `{2: "two", None: "None"}`
+	s := func(x string) string {
+		return `that(` + ss + `).does_not_contain_key(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`3`):     nil,
+		s(`"two"`): nil,
+		s(`2`):     fail(ss, `does not contain key <2>`),
+		s(`None`):  fail(ss, `does not contain key <None>`),
+	})
+}
+
+func TestContainsItem(t *testing.T) {
+	ss := `{2: "two", 4: "four", "too": "two"}`
+	s := func(x string) string {
+		return `that(` + ss + `).contains_item(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`2, "two"`):     nil,
+		s(`4, "four"`):    nil,
+		s(`"too", "two"`): nil,
+		s(`2, "to"`):      fail(ss, `contains item <(2, "to")>. However, it has a mapping from <2> to <"two">`),
+		s(`7, "two"`): fail(ss, `contains item <(7, "two")>.`+
+			` However, the following keys are mapped to <"two">: [2, "too"]`),
+		s(`7, "seven"`): fail(ss, `contains item <(7, "seven")>`),
+	})
+}
+
+func TestDoesNotContainItem(t *testing.T) {
+	ss := `{2: "two", 4: "four", "too": "two"}`
+	s := func(x string) string {
+		return `that(` + ss + `).does_not_contain_item(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`2, "to"`):    nil,
+		s(`7, "two"`):   nil,
+		s(`7, "seven"`): nil,
+		s(`2, "two"`):   fail(ss, `does not contain item <(2, "two")>`),
+		s(`4, "four"`):  fail(ss, `does not contain item <(4, "four")>`),
+	})
+}

--- a/lib/truth/doc.go
+++ b/lib/truth/doc.go
@@ -1,0 +1,210 @@
+// Package truth defines builtins and methods to express
+// test assertions within Starlark programs in the fashion of https://truth.dev
+//
+// This package is a Starlark port of PyTruth (2c3717ddad 2021-03-10) https://github.com/google/pytruth
+//
+// The Starlark:
+//
+//      assert.that(a).is_equal_to(b)
+//      assert.that(c).named("my value").is_true()
+//      assert.that(d).contains(a)
+//      assert.that(d).contains_all_of(a, b).in_order()
+//      assert.that(d).contains_any_of(a, b, c)
+//
+// is equivalent to the following Python:
+//
+//      from truth.truth import AssertThat
+//      AssertThat(a).IsEqualTo(b)
+//      AssertThat(c).Named("my value").IsTrue()
+//      AssertThat(d).Contains(a)
+//      AssertThat(d).ContainsAllOf(a, b).InOrder()
+//      AssertThat(d).ContainsAnyOf(a, b, c)
+//
+// Often, tests assert a relationship between a value produced by the test
+// (the "actual" value) and some reference value (the "expected" value). It is
+// strongly recommended that the actual value is made the subject of the assertion.
+// For example:
+//
+//      assert.that(actual).is_equal_to(expected)    # Recommended.
+//      assert.that(expected).is_equal_to(actual)    # Not recommended.
+//      assert.that(actual).is_in(expected_possibilities)     # Recommended.
+//      assert.that(expected_possibilities).contains(actual)  # Not recommended.
+//
+// Some assertions
+//
+//      assert.that(a).is_equal_to(b)
+//      assert.that(a).is_not_equal_to(b)
+//      assert.that(a).is_truthy()
+//      assert.that(a).is_falsy()
+//      assert.that(a).is_true()
+//      assert.that(a).is_false()
+//      assert.that(a).is_none()
+//      assert.that(a).is_not_none()
+//      assert.that(a).is_in(b)
+//      assert.that(a).is_any_of(b, c, d)
+//      assert.that(a).is_not_in(b)
+//      assert.that(a).is_none_of(b, c, d)
+//      assert.that(a).is_of_type(type(b))
+//      assert.that(a).is_not_of_type(type(b))
+//      assert.that(a).has_attribute(b)
+//      assert.that(a).does_not_have_attribute(b)
+//      assert.that(a).is_callable()
+//      assert.that(a).is_not_callable()
+//      assert.that(a).is_less_than(b)
+//      assert.that(a).is_greater_than(b)
+//      assert.that(a).is_at_most(b)
+//      assert.that(a).is_at_least(b)
+//
+// Truthiness
+//   Predicates `.is_true()` and `.is_false()` match *only* `True` and `False`.
+//   For `.is_truthy()` and `.is_falsy()`, `(starlark.Value).Truth() bool` is used.
+//
+//      assert.that(True).is_true()
+//      assert.that(False).is_false()
+//      assert.that(1).is_true()      # fails
+//      assert.that(0).is_false()     # fails
+//      assert.that(None).is_true()   # fails
+//      assert.that(None).is_false()  # fails
+//      assert.that(True).is_truthy()
+//      assert.that(False).is_falsy()
+//      assert.that(1).is_truthy()
+//      assert.that(0).is_falsy()
+//      assert.that(None).is_truthy() # fails
+//      assert.that(None).is_falsy()
+//
+// Strings
+//
+//      assert.that("abc").has_length(3)
+//      assert.that("abc").starts_with("a")
+//      assert.that("abc").ends_with("c")
+//      assert.that("abc").matches("a.+")                # prepends "^" to regexp
+//      assert.that("abc").does_not_match("b.+")         # prepends "^" to regexp
+//      assert.that("abc").contains_match("b.+")
+//      assert.that("abc").does_not_contain_match("c.+")
+//
+// Numbers
+//
+//      assert.that(a).is_zero()
+//      assert.that(a).is_non_zero()
+//      assert.that(a).is_positive_infinity()
+//      assert.that(a).is_not_positive_infinity()
+//      assert.that(a).is_negative_infinity()
+//      assert.that(a).is_not_negative_infinity()
+//      assert.that(a).is_finite()
+//      assert.that(a).is_not_finite()
+//      assert.that(a).is_nan()
+//      assert.that(a).is_not_nan()
+//      assert.that(a).is_within(delta).of(b)
+//      assert.that(a).is_not_within(delta).of(b)
+//
+// Lists, strings, and other iterables
+//   `cmp(x,y)` should return negative if x < y, zero if x == y and positive if x > y.
+//   *Ordered* means that the iterable's elements must increase (or decrease,
+//  depending on `cmp`) from beginning to end. Adjacent elements are allowed to be equal.
+//   *Strictly ordered* means that in addition, the elements must be unique
+//  (i.e. monotonically increasing or decreasing).
+//
+//      assert.that(a).has_size(n)
+//      assert.that(a).is_empty()
+//      assert.that(a).is_not_empty()
+//      assert.that(a).contains(b)
+//      assert.that(a).does_not_contain(b)
+//      assert.that(a).contains_all_of(b, c)
+//      assert.that(a).contains_all_in([b, c])
+//      assert.that(a).contains_any_of(b, c)
+//      assert.that(a).contains_any_in([b, c])
+//      assert.that(a).contains_exactly(b, c)
+//      assert.that(sorted(a)).contains_exactly_elements_in(sorted(b)).in_order()
+//      assert.that(a).contains_none_of(b, c)
+//      assert.that(a).contains_none_in([b, c])
+//      assert.that(a).contains_no_duplicates()
+//      assert.that(a).is_ordered()
+//      assert.that(a).is_ordered_according_to(cmp)
+//      assert.that(a).is_strictly_ordered()
+//      assert.that(a).is_strictly_ordered_according_to(cmp)
+//
+// Asserting order
+//   By default, `.contains_all...` and `.contains_exactly...` do not enforce that the
+//  order of the elements in the subject under test matches that of the expected
+//  value. To do that, append `.in_order()` to the returned predicate.
+//
+//      assert.that([2, 4, 6]).contains_all_of(6, 2)
+//      assert.that([2, 4, 6]).contains_all_of(6, 2).in_order()     # fails
+//      assert.that([2, 4, 6]).contains_all_of(2, 6).in_order()
+//      assert.that((1, 2, 3)).contains_all_in((1, 3)).in_order()
+//      assert.that([2, 4, 6]).contains_exactly(2, 6, 4)
+//      assert.that([2, 4, 6]).contains_exactly(2, 6, 4).in_order() # fails
+//      assert.that([2, 4, 6]).contains_exactly(2, 4, 6).in_order()
+//      assert.that((1, 2, 3)).contains_exactly_elements_in([1, 2, 3]).in_order()
+//
+//   When using `.in_order()`, ensure that both the subject under test and the expected
+//  value have a defined order, otherwise the result is undefined.
+//  For example, `assert.that(aList).contains_exactly_elements_in(aSet).in_order()`
+//  may or may not succeed, depending on how the `set` implements ordering.
+//  The builtin set datatype does not implement ordering.
+//  These assertions *may or may not* succeed:
+//
+//      assert.that((1, 2, 3)).contains_all_in(set([1, 3])).in_order()
+//      assert.that(set([3, 2, 1])).contains_exactly_elements_in((1, 2, 3)).in_order()
+//      assert.that({1:2, 3:4}).contains_all_in((1, 3)).in_order()
+//
+// Dictionaries, in addition to the table above
+//
+//      assert.that(d).contains_key(k)
+//      assert.that(d).does_not_contain_key(k)
+//      assert.that(d).contains_item(k, v)
+//      assert.that(d).does_not_contain_item(k, v)
+//      assert.that(d).contains_exactly(k1, v1, k2, v2)
+//      assert.that(d1).contains_exactly_items_in(d2)
+//      assert.that(d1.items()).contains_all_in(d2.items())
+//
+//
+// Notes (in no particular order):
+//
+//   `None` is not comparable (as in Python 3), so assertions involving `<` `>`
+//  `<=` `>=` on `None` such as `assert.that(a).is_greater_than(None)`
+//  fail with `InvalidAssertion` error.
+//  It is recommended to first check the `None`-ness of values with `.is_none()`
+//  or `.is_not_none()` before performing inequility assertions.
+//
+//   As in Python, `0`, `0.0` and `-0.0` all compare equal. The assertions
+//  `.is_zero()` and `.is_non_zero()` are provided for semantic convenience.
+//
+//   Starlark strings are not iterable (unlike Python's) but are iterated on as
+//  slices of utf-8 runes when needed in this implementation. This works:
+//      assert.that("abcdefg").contains_all_of("a", "c", "e").in_order()
+//      assert.that("abcdefg").is_strictly_ordered()
+//
+//   In `.contains...()` assertions a "duplicate values counter" is used that
+//  relies on the `(starlark.Value).String() string` reprensentation of values
+//  instead of `(starlark.Value).Hash() (uint32, error)` as some basic types
+//  are not hashable (list, dict, set).
+//  For this reason **it is recommended to only pass values of the main data types
+//  built in to the interpreter to functions of this package:**
+//  * NoneType
+//  * bool
+//  * int
+//  * float
+//  * string
+//  * list
+//  * tuple
+//  * dict
+//  * set
+//  * function
+//  * builtin_function_or_method
+//
+//   It is possible to incorrectly express assertions (see all but the last line in
+//  this block):
+//      assert.that(x)
+//      assert.that(x).named(z)
+//      assert.that(x).is_within(y)
+//      assert.that(x).is_not_within(y)
+//      assert.that(x).is_not_within(y).of(z)
+//   This is why each call to `.that(...)` first checks that no non-terminated
+//  assertions were previously executed in the current thread.
+//   A `Close(*starlark.Thread) error` function is also provided to ensure
+//  this property holds after the interpreter returns.
+//
+//   This library is threadsafe; you may execute multiple assertions in parallel.
+//
+package truth // import "go.starlark.net/lib/truth"

--- a/lib/truth/dupe_counter.go
+++ b/lib/truth/dupe_counter.go
@@ -1,0 +1,139 @@
+package truth
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+var _ fmt.Stringer = (*duplicateCounter)(nil)
+
+// duplicateCounter is a synchronized collection of counters for tracking duplicates.
+//
+// The count values may be modified only through Increment() and Decrement(),
+// which increment and decrement by 1 (only). If a count ever becomes 0, the item
+// is immediately expunged from the dictionary. Counts can never be negative;
+// attempting to Decrement an absent key has no effect.
+//
+// Order is preserved so that error messages containing expected values match.
+//
+// Supports counting values based on their (starlark.Value).String() representation.
+// TODO: track hashable objects in a hashmap. Use a slice and equality for non-hashables.
+type duplicateCounter struct {
+	m map[string]uint
+	s []string
+	d uint
+}
+
+func newDuplicateCounter() *duplicateCounter {
+	return &duplicateCounter{
+		m: make(map[string]uint),
+	}
+}
+
+// HasDupes indicates whether there are values that appears > 1 times.
+func (dc *duplicateCounter) HasDupes() bool { return dc.d != 0 }
+
+func (dc *duplicateCounter) Empty() bool { return len(dc.m) == 0 }
+
+func (dc *duplicateCounter) Len() int { return len(dc.m) }
+
+func (dc *duplicateCounter) Contains(v starlark.Value) bool {
+	return dc.contains(v.String())
+}
+
+func (dc *duplicateCounter) contains(v string) bool {
+	_, ok := dc.m[v]
+	return ok
+}
+
+// Increment increments a count by 1. Inserts the item if not present.
+func (dc *duplicateCounter) Increment(v starlark.Value) {
+	dc.increment(v.String())
+}
+
+func (dc *duplicateCounter) increment(v string) {
+	if _, ok := dc.m[v]; !ok {
+		dc.m[v] = 0
+		dc.s = append(dc.s, v)
+	}
+	dc.m[v]++
+	if dc.m[v] == 2 {
+		dc.d++
+	}
+}
+
+// Decrement decrements a count by 1. Expunges the item if the count is 0.
+// If the item is not present, has no effect.
+func (dc *duplicateCounter) Decrement(v starlark.Value) {
+	dc.decrement(v.String())
+}
+
+func (dc *duplicateCounter) decrement(v string) {
+	if count, ok := dc.m[v]; ok {
+		if count != 1 {
+			dc.m[v]--
+			if dc.m[v] == 1 {
+				dc.d--
+			}
+			return
+		}
+		delete(dc.m, v)
+		if sz := len(dc.s); sz != 1 {
+			s := make([]string, 0, len(dc.s)-1)
+			for _, vv := range dc.s {
+				if vv != v {
+					s = append(s, vv)
+				}
+			}
+			dc.s = s
+		} else {
+			dc.s = nil
+		}
+	}
+}
+
+// Returns the string representation of the duplicate counts.
+//
+// Items occurring more than once are accompanied by their count.
+// Otherwise the count is implied to be 1.
+//
+// For example, if the internal dict is `{2: 1, 3: 4, "abc": 1}`, this returns
+// the string `2, 3 [4 copies], "abc"`.
+func (dc *duplicateCounter) String() string {
+	var b strings.Builder
+	for i, vv := range dc.s {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+
+		b.WriteString(vv)
+		if count := dc.m[vv]; count != 1 {
+			b.WriteString(" [")
+			b.WriteString(fmt.Sprintf("%d", count))
+			b.WriteString(" copies]")
+		}
+	}
+	return b.String()
+}
+
+// Dupes shows only items whose count > 1.
+func (dc *duplicateCounter) Dupes() string {
+	var b strings.Builder
+	first := true
+	for _, vv := range dc.s {
+		if count := dc.m[vv]; count != 1 {
+			if !first {
+				b.WriteString(", ")
+			}
+			first = false
+
+			b.WriteString(vv)
+			b.WriteString(" [")
+			b.WriteString(fmt.Sprintf("%d", count))
+			b.WriteString(" copies]")
+		}
+	}
+	return b.String()
+}

--- a/lib/truth/dupe_counter_test.go
+++ b/lib/truth/dupe_counter_test.go
@@ -1,0 +1,130 @@
+package truth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+var (
+	a = starlark.String("a")
+	b = starlark.String("b")
+
+	alist     = starlark.NewList([]starlark.Value{a})
+	emptylist = starlark.NewList([]starlark.Value{})
+)
+
+func maker(t *testing.T) starlark.Value {
+	t.Helper()
+	d := starlark.NewDict(1)
+	err := d.SetKey(starlark.String("a"), starlark.NewList([]starlark.Value{
+		starlark.String("b"),
+		starlark.String("c"),
+	}))
+	require.NoError(t, err)
+	return d
+}
+
+func TestDupeCounterContains(t *testing.T) {
+	d := newDuplicateCounter() // {}
+	require.False(t, d.Contains(a))
+	require.False(t, d.Contains(b))
+
+	d.Increment(a) // {'a': 1}
+	require.True(t, d.Contains(a))
+	require.False(t, d.Contains(b))
+
+	d.Decrement(a) // {}
+	require.False(t, d.Contains(a))
+	require.False(t, d.Contains(b))
+}
+
+func TestDupeCounterLen(t *testing.T) {
+	d := newDuplicateCounter()
+	require.True(t, d.Empty())
+	d.Increment(a)
+	require.Equal(t, 1, d.Len())
+	d.Increment(alist)
+	require.Equal(t, 2, d.Len())
+}
+
+func TestDupeCounterEverything(t *testing.T) {
+	d := newDuplicateCounter() // {}
+	require.True(t, d.Empty())
+	require.Equal(t, ``, d.String())
+
+	d.Increment(a) // {'a': 1}
+	require.Equal(t, 1, d.Len())
+	require.Equal(t, `"a"`, d.String())
+
+	d.Increment(a) // {'a': 2}
+	require.Equal(t, 1, d.Len())
+	require.Equal(t, `"a" [2 copies]`, d.String())
+
+	d.Increment(b) // {'a': 2, 'b': 1}
+	require.Equal(t, 2, d.Len())
+	require.Equal(t, `"a" [2 copies], "b"`, d.String())
+
+	d.Decrement(a) // {'a': 1, 'b': 1}
+	require.Equal(t, 2, d.Len())
+	require.Equal(t, `"a", "b"`, d.String())
+
+	d.Decrement(a) // {'b': 1}
+	require.Equal(t, 1, d.Len())
+	require.Equal(t, `"b"`, d.String())
+
+	d.Increment(a) // {'b': 1, 'a': 1}
+	require.Equal(t, 2, d.Len())
+	require.Equal(t, `"b", "a"`, d.String())
+
+	d.Decrement(a) // {'b': 1}
+	require.Equal(t, 1, d.Len())
+	require.Equal(t, `"b"`, d.String())
+
+	d.Decrement(b) // {}
+	require.True(t, d.Empty())
+	require.Equal(t, ``, d.String())
+
+	d.Decrement(a) // {}
+	require.True(t, d.Empty())
+	require.Equal(t, ``, d.String())
+}
+
+func TestDupeCounterUnhashableKeys(t *testing.T) {
+	d := newDuplicateCounter() // {}
+	require.False(t, d.Contains(emptylist))
+
+	d.Increment(alist) // {['a']: 1}
+	require.True(t, d.Contains(alist))
+	require.Equal(t, 1, d.Len())
+	require.Equal(t, `["a"]`, d.String())
+
+	d.Decrement(alist) // {}
+	require.False(t, d.Contains(alist))
+	require.True(t, d.Empty())
+	require.Equal(t, ``, d.String())
+}
+
+func TestDupeCounterIncrementEquivalentDictionaries(t *testing.T) {
+	d := newDuplicateCounter()
+	d.Increment(maker(t))
+	d.Increment(maker(t))
+	d.Increment(maker(t))
+	d.Increment(maker(t))
+	require.Equal(t, 1, d.Len())
+	require.Equal(t, `{"a": ["b", "c"]} [4 copies]`, d.String())
+}
+
+func TestDupeCounterDecrementEquivalentDictionaries(t *testing.T) {
+	d := newDuplicateCounter()
+	d.Increment(maker(t))
+	d.Increment(maker(t))
+	require.Equal(t, 1, d.Len())
+	d.Decrement(maker(t))
+	require.Equal(t, 1, d.Len())
+	d.Decrement(maker(t))
+	require.True(t, d.Empty())
+	d.Decrement(maker(t))
+	require.True(t, d.Empty())
+}

--- a/lib/truth/equal_test.go
+++ b/lib/truth/equal_test.go
@@ -1,0 +1,180 @@
+package truth
+
+import "testing"
+
+func TestIsEqualTo(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(5).is_equal_to(5)`: nil,
+		`that(5).is_equal_to(3)`: fail("5", "is equal to <3>"),
+		`that({1:2,3:4}).is_equal_to([1,2,3,4])`: fail(`{1: 2, 3: 4}`,
+			"is equal to <[1, 2, 3, 4]>"),
+	})
+}
+
+func TestIsEqualToFailsOnFloatsAsWellAsWithFormattedRepresentations(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(0.3).is_equal_to(0.1+0.2)`: fail("0.3", "is equal to <0.30000000000000004>"),
+		`that(0.1+0.2).is_equal_to(0.3)`: fail("0.30000000000000004", "is equal to <0.3>"),
+	})
+}
+
+func TestIsNotEqualTo(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(5).is_not_equal_to(3)`: nil,
+		`that(5).is_not_equal_to(5)`: fail("5", "is not equal to <5>"),
+	})
+}
+
+func TestSequenceIsEqualToUsesContainsExactlyElementsInPlusInOrder(t *testing.T) {
+	testEach(t, map[string]error{
+		`that((3,5,[])).is_equal_to((3, 5, []))`: nil,
+		`that((3,5,[])).is_equal_to(([],3,5))`: fail("(3, 5, [])",
+			"contains exactly these elements in order <([], 3, 5)>"),
+		`that((3,5,[])).is_equal_to((3,5,[],9))`: fail("(3, 5, [])",
+			"contains exactly <(3, 5, [], 9)>. It is missing <9>"),
+		`that((3,5,[])).is_equal_to((9,3,5,[],10))`: fail("(3, 5, [])",
+			"contains exactly <(9, 3, 5, [], 10)>. It is missing <9, 10>"),
+		`that((3,5,[])).is_equal_to((3,5))`: fail("(3, 5, [])",
+			"contains exactly <(3, 5)>. It has unexpected items <[]>"),
+		`that((3,5,[])).is_equal_to(([],3))`: fail("(3, 5, [])",
+			"contains exactly <([], 3)>. It has unexpected items <5>"),
+		`that((3,5,[])).is_equal_to((3,))`: fail("(3, 5, [])",
+			"contains exactly <(3,)>. It has unexpected items <5, []>"),
+		`that((3,5,[])).is_equal_to((4,4,3,[],5))`: fail("(3, 5, [])",
+			"contains exactly <(4, 4, 3, [], 5)>. It is missing <4 [2 copies]>"),
+		`that((3,5,[])).is_equal_to((4,4))`: fail("(3, 5, [])",
+			"contains exactly <(4, 4)>. It is missing <4 [2 copies]> and has unexpected items <3, 5, []>"),
+		`that((3,5,[])).is_equal_to((3,5,9))`: fail("(3, 5, [])",
+			"contains exactly <(3, 5, 9)>. It is missing <9> and has unexpected items <[]>"),
+		`that((3,5,[])).is_equal_to(())`: fail("(3, 5, [])", "is empty"),
+	})
+}
+
+func TestSetIsEqualToUsesContainsExactlyElementsIn(t *testing.T) {
+	s := `that(set([3, 5, 8]))`
+	testEach(t, map[string]error{
+		s + `.is_equal_to(set([3, 5, 8]))`: nil,
+		s + `.is_equal_to(set([8, 3, 5]))`: nil,
+		s + `.is_equal_to(set([3, 5, 8, 9]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([3, 5, 8, 9])>. It is missing <9>"),
+		s + `.is_equal_to(set([9, 3, 5, 8, 10]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([9, 3, 5, 8, 10])>. It is missing <9, 10>"),
+		s + `.is_equal_to(set([3, 5]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([3, 5])>. It has unexpected items <8>"),
+		s + `.is_equal_to(set([8, 3]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([8, 3])>. It has unexpected items <5>"),
+		s + `.is_equal_to(set([3]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([3])>. It has unexpected items <5, 8>"),
+		s + `.is_equal_to(set([4]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([4])>. It is missing <4> and has unexpected items <3, 5, 8>"),
+		s + `.is_equal_to(set([3, 5, 9]))`: fail("set([3, 5, 8])",
+			"contains exactly <set([3, 5, 9])>. It is missing <9> and has unexpected items <8>"),
+		s + `.is_equal_to(set([]))`: fail("set([3, 5, 8])", "is empty"),
+	})
+}
+
+func TestSequenceIsEqualToComparedWithNonIterables(t *testing.T) {
+	testEach(t, map[string]error{
+		`that((3, 5, [])).is_equal_to(3)`: fail("(3, 5, [])", "is equal to <3>"),
+	})
+}
+
+func TestSetIsEqualToComparedWithNonIterables(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(set([3, 5, 8])).is_equal_to(3)`: fail("set([3, 5, 8])", "is equal to <3>"),
+	})
+}
+
+func TestOrderedDictIsEqualToUsesContainsExactlyItemsInPlusInOrder(t *testing.T) {
+	d1 := `((2, "two"), (4, "four"))`
+	d2 := `((2, "two"), (4, "four"))`
+	d3 := `((4, "four"), (2, "two"))`
+	d4 := `((2, "two"), (4, "for"))`
+	d5 := `((2, "two"), (4, "four"), (5, "five"))`
+	s := `that(` + d1 + `).is_equal_to(`
+	testEach(t, map[string]error{
+		s + d2 + `)`: nil,
+		s + d3 + `)`: fail(d1, "contains exactly these elements in order <"+d3+">"),
+
+		s + `((2, "two"),))`: fail(d1,
+			`contains exactly <((2, "two"),)>. It has unexpected items <(4, "four")>`),
+
+		s + d4 + `)`: fail(d1,
+			"contains exactly <"+d4+`>. It is missing <(4, "for")> and has unexpected items <(4, "four")>`),
+		s + d5 + `)`: fail(d1,
+			"contains exactly <"+d5+`>. It is missing <(5, "five")>`),
+	})
+}
+
+func TestDictIsEqualToUsesContainsExactlyItemsIn(t *testing.T) {
+	d := `{2: "two", 4: "four"}`
+	dd := `{2: "two", 4: "for"}`
+	ddd := `{2: "two", 4: "four", 5: "five"}`
+	dBis := `items([(2, "two"), (4, "four")])`
+	s := `that(` + d + `).is_equal_to(`
+	testEach(t, map[string]error{
+		s + d + `)`: nil,
+
+		s + `{2: "two"})`: fail(dBis,
+			`contains exactly <((2, "two"),)>. It has unexpected items <(4, "four")>`,
+			warnContainsExactlySingleIterable),
+
+		s + dd + `)`: fail(dBis,
+			`contains exactly <((2, "two"), (4, "for"))>. It is missing <(4, "for")> and has unexpected items <(4, "four")>`),
+		s + ddd + `)`: fail(dBis,
+			`contains exactly <((2, "two"), (4, "four"), (5, "five"))>. It is missing <(5, "five")>`),
+		s + `{})`: fail(`items([(2, "two"), (4, "four")])`, "is empty"),
+	})
+}
+
+func TestIsEqualToComparedWithNonDictionary(t *testing.T) {
+	ss := `{2: "two", 4: "four"}`
+	testEach(t, map[string]error{
+		`that(` + ss + `).is_equal_to(3)`: fail(ss, `is equal to <3>`),
+	})
+}
+
+func TestNamedMultilineString(t *testing.T) {
+	s := `that("line1\nline2").named("some-name")`
+	testEach(t, map[string]error{
+		s + `.is_equal_to("line1\nline2")`: nil,
+		s + `.is_equal_to("")`: newTruthAssertion(
+			`Not true that actual some-name is equal to <"">.`),
+		s + `.is_equal_to("line1\nline2\n")`: newTruthAssertion(
+			`Not true that actual some-name is equal to expected, found diff:
+*** Expected
+--- Actual
+***************
+*** 1,3 ****
+  line1
+  line2
+- 
+--- 1,2 ----
+.`),
+	})
+}
+
+func TestIsEqualToRaisesErrorWithVerboseDiff(t *testing.T) {
+	testEach(t, map[string]error{
+		`that("line1\nline2\nline3\nline4\nline5\n") \
+         .is_equal_to("line1\nline2\nline4\nline6\n")`: newTruthAssertion(
+			`Not true that actual is equal to expected, found diff:
+*** Expected
+--- Actual
+***************
+*** 1,5 ****
+  line1
+  line2
+  line4
+! line6
+  
+--- 1,6 ----
+  line1
+  line2
++ line3
+  line4
+! line5
+  
+.`),
+	})
+}

--- a/lib/truth/errors.go
+++ b/lib/truth/errors.go
@@ -1,0 +1,81 @@
+package truth
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+// InvalidAssertion signifies an invalid assertion was attempted
+// such as comparing with None.
+type InvalidAssertion string
+
+var _ error = InvalidAssertion("")
+
+func newInvalidAssertion(prop string) InvalidAssertion { return InvalidAssertion(prop) }
+func (e InvalidAssertion) Error() string               { return string(e) }
+
+// TruthAssertion signifies an assertion predicate was invalidated.
+type TruthAssertion string
+
+var _ error = TruthAssertion("")
+
+func newTruthAssertion(msg string) TruthAssertion { return TruthAssertion(msg) }
+func (e TruthAssertion) Error() string            { return string(e) }
+
+// unhandled internal & public errors
+
+const errUnhandled = unhandledError(0)
+
+type unhandledError int
+
+var _ error = errUnhandled
+
+func (e unhandledError) Error() string { return "unhandled" }
+
+// UnhandledError appears when an operation on an incompatible type is attempted.
+type UnhandledError struct {
+	name   string
+	actual starlark.Value
+	args   starlark.Tuple
+}
+
+var _ error = (*UnhandledError)(nil)
+
+func (t *T) unhandled(name string, args ...starlark.Value) *UnhandledError {
+	return &UnhandledError{
+		name:   name,
+		actual: t.actual,
+		args:   args,
+	}
+}
+
+func (e UnhandledError) Error() string {
+	var b strings.Builder
+	b.WriteString("Invalid assertion .")
+	b.WriteString(e.name)
+	b.WriteByte('(')
+	for i, arg := range e.args {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(arg.String())
+	}
+	b.WriteString(") on value of type ")
+	b.WriteString(e.actual.Type())
+	return b.String()
+}
+
+// UnresolvedError describes that an `assert.that(actual)` was called but never any of its `.truth_methods(subject)`.
+// At the exception of (as each by themselves this still require an assertion):
+// * `.named(name)`
+// * `.is_within(tolerance)`
+// * `.is_not_within(tolerance)`
+type UnresolvedError string
+
+var _ error = UnresolvedError("")
+
+func (e UnresolvedError) Error() string {
+	return fmt.Sprintf("%s: %s.that(...) is missing an assertion", string(e), Default)
+}

--- a/lib/truth/fail.go
+++ b/lib/truth/fail.go
@@ -1,0 +1,101 @@
+package truth
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+const warnContainsExactlySingleIterable = "" +
+	" Passing a single iterable to .contains_exactly(*expected) is often" +
+	" not the correct thing to do. Did you mean to call" +
+	" .contains_exactly_elements_in(some_iterable) instead?"
+
+func errMustBeEqualNumberOfKVPairs(count int) error {
+	return newInvalidAssertion(
+		fmt.Sprintf("There must be an equal number of key/value pairs"+
+			" (i.e., the number of key/value parameters (%d) must be even).", count))
+}
+
+func (t *T) failNone(check string, other starlark.Value) error {
+	if other == starlark.None {
+		msg := fmt.Sprintf("It is illegal to compare using .%s(None)", check)
+		return newInvalidAssertion(msg)
+	}
+	return nil
+}
+
+func (t *T) failIterable() (starlark.Iterable, error) {
+	itermap, ok := t.actual.(starlark.IterableMapping)
+	if ok {
+		iter := newTupleSlice(itermap.Items())
+		return iter, nil
+	}
+
+	iter, ok := t.actual.(starlark.Iterable)
+	if !ok {
+		msg := fmt.Sprintf("Cannot use %s as Iterable.", t.subject())
+		return nil, newInvalidAssertion(msg)
+	}
+	return iter, nil
+}
+
+func (t *T) failComparingValues(verb string, other starlark.Value, suffix string) error {
+	proposition := fmt.Sprintf("%s <%s>", verb, other.String())
+	return t.failWithProposition(proposition, suffix)
+}
+
+func (t *T) failWithProposition(proposition, suffix string) error {
+	msg := fmt.Sprintf("Not true that %s %s.%s", t.subject(), proposition, suffix)
+	return newTruthAssertion(msg)
+}
+
+func (t *T) failWithBadResults(
+	verb string, other starlark.Value,
+	failVerb string, actual fmt.Stringer,
+	suffix string,
+) error {
+	msg := fmt.Sprintf("%s <%s>. It %s <%s>",
+		verb, other.String(),
+		failVerb, actual.String())
+	return t.failWithProposition(msg, suffix)
+}
+
+func (t *T) failWithSubject(verb string) error {
+	msg := fmt.Sprintf("%s %s.", t.subject(), verb)
+	return newTruthAssertion(msg)
+}
+
+func (t *T) subject() string {
+	str := ""
+	switch actual := t.actual.(type) {
+	case starlark.String:
+		if strings.Contains(actual.GoString(), "\n") {
+			if t.name == "" {
+				return "actual"
+			}
+			return fmt.Sprintf("actual %s", t.name)
+		}
+	case starlark.Callable:
+		str = t.actual.String()
+	case starlark.Tuple:
+		if t.actualIsIterableFromString {
+			var b strings.Builder
+			b.WriteString(`<"`)
+			for _, v := range actual {
+				b.WriteString(v.(starlark.String).GoString())
+			}
+			b.WriteString(`">`)
+			str = b.String()
+		}
+	default:
+	}
+	if str == "" {
+		str = fmt.Sprintf("<%s>", t.actual.String())
+	}
+	if t.name == "" {
+		return str
+	}
+	return fmt.Sprintf("%s(%s)", t.name, str)
+}

--- a/lib/truth/func_test.go
+++ b/lib/truth/func_test.go
@@ -1,0 +1,58 @@
+package truth
+
+import "testing"
+
+func TestHasAttribute(t *testing.T) {
+	s := func(x string) string {
+		return `that("my str").has_attribute(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`"elems"`):    nil,
+		s(`"index"`):    nil,
+		s(`"isdigit"`):  nil,
+		s(`""`):         fail(`"my str"`, `has attribute <"">`),
+		s(`"ermagerd"`): fail(`"my str"`, `has attribute <"ermagerd">`),
+	})
+}
+
+func TestDoesNotHaveAttribute(t *testing.T) {
+	s := func(x string) string {
+		return `that({1: ()}).does_not_have_attribute(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`"other_attribute"`): nil,
+		s(`""`):                nil,
+		s(`"keys"`):            fail(`{1: ()}`, `does not have attribute <"keys">`),
+		s(`"values"`):          fail(`{1: ()}`, `does not have attribute <"values">`),
+		s(`"setdefault"`):      fail(`{1: ()}`, `does not have attribute <"setdefault">`),
+	})
+}
+
+func TestIsCallable(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_callable()`
+	}
+	testEach(t, map[string]error{
+		s(`lambda x: x`):    nil,
+		s(`"str".endswith`): nil,
+		s(`that`):           nil,
+		s(`None`):           fail(`None`, `is callable`),
+		s(abc):              fail(abc, `is callable`),
+	})
+}
+
+func TestIsNotCallable(t *testing.T) {
+	testEach(t, map[string]error{
+		`assert.that(assert.that).is_not_callable()`: fail(`built-in method assert of assert value`, `is not callable`),
+	}, asModule)
+	s := func(t string) string {
+		return `that(` + t + `).is_not_callable()`
+	}
+	testEach(t, map[string]error{
+		s(`None`):           nil,
+		s(abc):              nil,
+		s(`lambda x: x`):    fail(`function lambda`, `is not callable`),
+		s(`"str".endswith`): fail(`built-in method endswith of string value`, `is not callable`),
+		s(`that`):           fail(`built-in function that`, `is not callable`),
+	})
+}

--- a/lib/truth/is_in_test.go
+++ b/lib/truth/is_in_test.go
@@ -1,0 +1,36 @@
+package truth
+
+import "testing"
+
+func TestIsIn(t *testing.T) {
+	s := func(x string) string {
+		return `that(3).is_in(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		`that("a").is_in("abc")`: nil,
+		`that("d").is_in("abc")`: fail(`"d"`, `is equal to any of <"abc">`),
+		s(`(3,)`):                nil,
+		s(`(3, 5)`):              nil,
+		s(`(1, 3, 5)`):           nil,
+		s(`{3: "three"}`):        nil,
+		s(`set([3, 5])`):         nil,
+		s(`()`):                  fail(`3`, `is equal to any of <()>`),
+		s(`(2,)`):                fail(`3`, `is equal to any of <(2,)>`),
+	})
+}
+
+func TestIsNotIn(t *testing.T) {
+	s := func(x string) string {
+		return `that(3).is_not_in(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		`that("a").is_not_in("abc")`: fail(`"a"`, `is not in "abc". It was found at index 0`),
+		`that("d").is_not_in("abc")`: nil,
+		s(`(5,)`):                    nil,
+		s(`set([5])`):                nil,
+		s(`("3",)`):                  nil,
+		s(`(3,)`):                    fail(`3`, `is not in (3,). It was found at index 0`),
+		s(`(1, 3)`):                  fail(`3`, `is not in (1, 3). It was found at index 1`),
+		s(`set([3])`):                fail(`3`, `is not in set([3])`),
+	})
+}

--- a/lib/truth/is_of_test.go
+++ b/lib/truth/is_of_test.go
@@ -1,0 +1,28 @@
+package truth
+
+import "testing"
+
+func TestIsAnyOf(t *testing.T) {
+	s := func(x string) string {
+		return `that(3).is_any_of(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`3`):       nil,
+		s(`3, 5`):    nil,
+		s(`1, 3, 5`): nil,
+		s(``):        fail(`3`, `is equal to any of <()>`),
+		s(`2`):       fail(`3`, `is equal to any of <(2,)>`),
+	})
+}
+
+func TestIsNoneOf(t *testing.T) {
+	s := func(x string) string {
+		return `that(3).is_none_of(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`5`):    nil,
+		s(`"3"`):  nil,
+		s(`3`):    fail(`3`, `is not in (3,). It was found at index 0`),
+		s(`1, 3`): fail(`3`, `is not in (1, 3). It was found at index 1`),
+	})
+}

--- a/lib/truth/iteritems.go
+++ b/lib/truth/iteritems.go
@@ -1,0 +1,71 @@
+package truth
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+const tupleSliceType = "items"
+
+var _ starlark.Iterable = (tupleSlice)(nil)
+
+// tupleSlice is used to iterate on starlark.Dict's key-values, not its keys.
+// From starlark-go docs:
+// > If a type satisfies both Mapping and Iterable, the iterator yields
+// > the keys of the mapping.
+type tupleSlice []starlark.Tuple
+
+func newTupleSlice(ts []starlark.Tuple) tupleSlice { return tupleSlice(ts) }
+func (ts tupleSlice) String() string {
+	var b strings.Builder
+	b.WriteString(tupleSliceType)
+	b.WriteString("([")
+	for i, v := range ts {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(v.String())
+	}
+	b.WriteString("])")
+	return b.String()
+}
+func (ts tupleSlice) Type() string { return tupleSliceType }
+func (ts tupleSlice) Freeze() {
+	for _, v := range ts {
+		v.Freeze()
+	}
+}
+func (ts tupleSlice) Truth() starlark.Bool { return len(ts) > 0 }
+func (ts tupleSlice) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable type: %s", tupleSliceType)
+}
+
+func (ts tupleSlice) Values() []starlark.Value {
+	vs := make([]starlark.Value, 0, len(ts))
+	for _, v := range ts {
+		vs = append(vs, v)
+	}
+	return vs
+}
+
+func (ts tupleSlice) Iterate() starlark.Iterator { return newTupleSliceIterator(ts) }
+
+var _ starlark.Iterator = (*tupleSliceIterator)(nil)
+
+type tupleSliceIterator struct {
+	s tupleSlice
+	i int
+}
+
+func newTupleSliceIterator(ts tupleSlice) *tupleSliceIterator { return &tupleSliceIterator{s: ts} }
+func (tsi *tupleSliceIterator) Done()                         {}
+func (tsi *tupleSliceIterator) Next(v *starlark.Value) bool {
+	if tsi.i < len(tsi.s) {
+		*v = tsi.s[tsi.i]
+		tsi.i++
+		return true
+	}
+	return false
+}

--- a/lib/truth/module.go
+++ b/lib/truth/module.go
@@ -1,0 +1,60 @@
+package truth
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// Default is the default module constructor. It is merely the string "assert".
+const Default = "assert"
+
+type module struct{}
+
+var _ starlark.Value = (*module)(nil)
+var _ starlark.HasAttrs = (*module)(nil)
+
+// NewModule registers a Starlark module of https://truth.dev/
+func NewModule(predeclared starlark.StringDict) { predeclared[Default] = &module{} }
+
+func (m *module) String() string        { return Default }
+func (m *module) Type() string          { return Default }
+func (m *module) Freeze()               {}
+func (m *module) Truth() starlark.Bool  { return false }
+func (m *module) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable type: %s", Default) }
+func (m *module) AttrNames() []string   { return []string{"that"} }
+func (m *module) Attr(name string) (starlark.Value, error) {
+	if name != "that" {
+		return nil, nil // no such method
+	}
+	b := starlark.NewBuiltin(Default, That)
+	return b.BindReceiver(m), nil
+}
+
+// That implements the `.that(target)` builtin
+func That(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var target starlark.Value
+	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &target); err != nil {
+		return nil, err
+	}
+
+	if err := Close(thread); err != nil {
+		return nil, err
+	}
+	thread.SetLocal(LocalThreadKeyForClose, thread.CallFrame(1))
+
+	return newT(target), nil
+}
+
+var _ starlark.Value = (*T)(nil)
+var _ starlark.HasAttrs = (*T)(nil)
+
+func newT(target starlark.Value) *T { return &T{actual: target} }
+
+func (t *T) String() string                           { return fmt.Sprintf("%s.that(%s)", Default, t.actual.String()) }
+func (t *T) Type() string                             { return Default }
+func (t *T) Freeze()                                  { t.actual.Freeze() }
+func (t *T) Truth() starlark.Bool                     { return true }
+func (t *T) Hash() (uint32, error)                    { return 0, fmt.Errorf("unhashable: %s", t.Type()) }
+func (t *T) Attr(name string) (starlark.Value, error) { return builtinAttr(t, name) }
+func (t *T) AttrNames() []string                      { return attrNames }

--- a/lib/truth/none_test.go
+++ b/lib/truth/none_test.go
@@ -1,0 +1,109 @@
+package truth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCannotCompareToNone(t *testing.T) {
+	p := "It is illegal to compare using ."
+	testEach(t, map[string]error{
+		`that(5).is_at_least(None)`:     newInvalidAssertion(p + "is_at_least(None)"),
+		`that(5).is_at_most(None)`:      newInvalidAssertion(p + "is_at_most(None)"),
+		`that(5).is_greater_than(None)`: newInvalidAssertion(p + "is_greater_than(None)"),
+		`that(5).is_less_than(None)`:    newInvalidAssertion(p + "is_less_than(None)"),
+	})
+}
+
+func TestNone(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(None).is_none()`:      nil,
+		`that(None).is_not_none()`:  fail(`None`, `is not None`),
+		`that("abc").is_not_none()`: nil,
+		`that("abc").is_none()`:     fail(abc, `is None`),
+	})
+}
+
+func TestNoneSuccess(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(None).is_none()`:                 nil,
+		`that(None).is_falsy()`:                nil,
+		`that(None).is_equal_to(None)`:         nil,
+		`that(None).is_not_equal_to(0)`:        nil,
+		`that(None).is_not_equal_to(0.0)`:      nil,
+		`that(None).is_not_equal_to(False)`:    nil,
+		`that(None).is_not_equal_to("")`:       nil,
+		`that(None).is_not_equal_to(())`:       nil,
+		`that(None).is_not_equal_to([])`:       nil,
+		`that(None).is_not_equal_to({})`:       nil,
+		`that(None).is_not_equal_to(set([]))`:  nil,
+		`that(None).is_in((5, None, "six"))`:   nil,
+		`that(None).is_not_in((5, "six"))`:     nil,
+		`that(None).is_any_of(5, None, "six")`: nil,
+		`that(None).is_none_of()`:              nil,
+		`that(None).is_none_of(5, "six")`:      nil,
+		`that(None).is_of_type(type(None))`:    nil,
+		`that(None).is_not_of_type("int")`:     nil,
+		`that(None).is_not_callable()`:         nil,
+	})
+}
+
+func TestNoneFailure(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(None).is_not_none()`:                   fail(`None`, `is not None`),
+		`that(None).is_truthy()`:                     fail(`None`, `is truthy`),
+		`that(None).is_equal_to(0)`:                  fail(`None`, `is equal to <0>`),
+		`that(None).is_not_equal_to(None)`:           fail(`None`, `is not equal to <None>`),
+		`that(None).is_in((5, "six"))`:               fail(`None`, `is equal to any of <(5, "six")>`),
+		`that(None).is_not_in((5, None))`:            fail(`None`, `is not in (5, None). It was found at index 1`),
+		`that(None).is_any_of(5, "six")`:             fail(`None`, `is equal to any of <(5, "six")>`),
+		`that(None).is_none_of(5, None)`:             fail(`None`, `is not in (5, None). It was found at index 1`),
+		`that(None).is_of_type("int")`:               fail(`None`, `is of type <"int">`, ` However, it is of type <"NoneType">`),
+		`that(None).is_not_of_type(type(None))`:      fail(`None`, `is not of type <"NoneType">`, ` However, it is of type <"NoneType">`),
+		`that(None).has_attribute("test_attribute")`: fail(`None`, `has attribute <"test_attribute">`),
+		`that(None).is_callable()`:                   fail(`None`, `is callable`),
+
+		`that(None).is_true()`:  fail(`None`, `is True`),
+		`that(None).is_false()`: fail(`None`, `is False`, ` However, it is falsy. Did you mean to call .is_falsy() instead?`),
+	})
+}
+
+func TestInvalidOperationOnNone(t *testing.T) {
+	testEach(t, map[string]error{
+		// Iterable subject
+		`that(None).has_size(1)`:                               fmt.Errorf(`Invalid assertion .has_size(1) on value of type NoneType`),
+		`that(None).is_empty()`:                                fmt.Errorf(`Invalid assertion .is_empty() on value of type NoneType`),
+		`that(None).is_not_empty()`:                            fmt.Errorf(`Invalid assertion .is_not_empty() on value of type NoneType`),
+		`that(None).contains(None)`:                            fmt.Errorf(`Invalid assertion .contains(None) on value of type NoneType`),
+		`that(None).does_not_contain(5)`:                       fmt.Errorf(`Invalid assertion .does_not_contain(5) on value of type NoneType`),
+		`that(None).contains_no_duplicates()`:                  fmt.Errorf(`Invalid assertion .contains_no_duplicates() on value of type NoneType`),
+		`that(None).contains_all_in((None,))`:                  fmt.Errorf(`Invalid assertion .contains_all_in((None,)) on value of type NoneType`),
+		`that(None).contains_all_of(None)`:                     fmt.Errorf(`Invalid assertion .contains_all_of(None) on value of type NoneType`),
+		`that(None).contains_any_in((None,))`:                  fmt.Errorf(`Invalid assertion .contains_any_in((None,)) on value of type NoneType`),
+		`that(None).contains_any_of(None)`:                     fmt.Errorf(`Invalid assertion .contains_any_of(None) on value of type NoneType`),
+		`that(None).contains_exactly_elements_in([None])`:      newInvalidAssertion(`Cannot use <None> as Iterable.`),
+		`that(None).contains_none_in((5,))`:                    fmt.Errorf(`Invalid assertion .contains_none_in((5,)) on value of type NoneType`),
+		`that(None).contains_none_of(5)`:                       fmt.Errorf(`Invalid assertion .contains_none_of(5) on value of type NoneType`),
+		`that(None).is_ordered()`:                              fmt.Errorf(`Invalid assertion .is_ordered() on value of type NoneType`),
+		`that(None).is_ordered_according_to(someCmp)`:          fmt.Errorf(`Invalid assertion .is_ordered_according_to(<function lambda>) on value of type NoneType`),
+		`that(None).is_strictly_ordered()`:                     fmt.Errorf(`Invalid assertion .is_strictly_ordered() on value of type NoneType`),
+		`that(None).is_strictly_ordered_according_to(someCmp)`: fmt.Errorf(`Invalid assertion .is_strictly_ordered_according_to(<function lambda>) on value of type NoneType`),
+
+		// Dictionary subject
+		`that(None).contains_key("key")`:                         fmt.Errorf(`Invalid assertion .contains_key("key") on value of type NoneType`),
+		`that(None).does_not_contain_key("key")`:                 fmt.Errorf(`Invalid assertion .does_not_contain_key("key") on value of type NoneType`),
+		`that(None).contains_item("key", "value")`:               fmt.Errorf(`Invalid assertion .contains_item("key", "value") on value of type NoneType`),
+		`that(None).does_not_contain_item("key", "value")`:       fmt.Errorf(`Invalid assertion .does_not_contain_item("key", "value") on value of type NoneType`),
+		`that(None).contains_exactly("key", "value")`:            fmt.Errorf(`Invalid assertion .contains_exactly("key", "value") on value of type NoneType`),
+		`that(None).contains_exactly_items_in({"key": "value"})`: fmt.Errorf(`Invalid assertion .contains_exactly_items_in({"key": "value"}) on value of type NoneType`),
+
+		// String subject
+		`that(None).has_length(0)`:              fmt.Errorf(`Invalid assertion .has_length(0) on value of type NoneType`),
+		`that(None).starts_with("")`:            fmt.Errorf(`Invalid assertion .starts_with("") on value of type NoneType`),
+		`that(None).ends_with("")`:              fmt.Errorf(`Invalid assertion .ends_with("") on value of type NoneType`),
+		`that(None).matches("")`:                fmt.Errorf(`Invalid assertion .matches("") on value of type NoneType`),
+		`that(None).does_not_match("")`:         fmt.Errorf(`Invalid assertion .does_not_match("") on value of type NoneType`),
+		`that(None).contains_match("")`:         fmt.Errorf(`Invalid assertion .contains_match("") on value of type NoneType`),
+		`that(None).does_not_contain_match("")`: fmt.Errorf(`Invalid assertion .does_not_contain_match("") on value of type NoneType`),
+	})
+}

--- a/lib/truth/numbers_test.go
+++ b/lib/truth/numbers_test.go
@@ -1,0 +1,162 @@
+package truth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestZero(t *testing.T) {
+	zeros := []string{`0`, `0.0`, `-0.0`}
+	m := make(map[string]error, 42+3*2)
+
+	for i := 0; i < len(zeros); i++ {
+		m[fmt.Sprintf(`that(%s).is_zero()`, zeros[i])] = nil
+		m[fmt.Sprintf(`that(%s).is_non_zero()`, zeros[i])] =
+			fail(zeros[i], `is non-zero`)
+
+		for j := len(zeros) - 1; j >= 0; j-- {
+			m[fmt.Sprintf(`that(%s).is_equal_to(%s)`, zeros[i], zeros[j])] = nil
+			m[fmt.Sprintf(`that(%s).is_not_equal_to(%s)`, zeros[i], zeros[j])] =
+				fail(zeros[i], fmt.Sprintf(`is not equal to <%s>`, zeros[j]))
+		}
+	}
+
+	for _, zero := range zeros {
+		m[fmt.Sprintf(`that(%s).is_finite()`, zero)] = nil
+		m[fmt.Sprintf(`that(%s).is_not_finite()`, zero)] =
+			newTruthAssertion(fmt.Sprintf(`<%s> should not have been finite.`, zero))
+
+		m[fmt.Sprintf(`that(%s).is_not_nan()`, zero)] = nil
+		m[fmt.Sprintf(`that(%s).is_nan()`, zero)] =
+			fail(zero, `is equal to <nan>`)
+
+		m[fmt.Sprintf(`that(%s).is_not_positive_infinity()`, zero)] = nil
+		m[fmt.Sprintf(`that(%s).is_positive_infinity()`, zero)] =
+			fail(zero, fmt.Sprintf(`is equal to <+inf>`))
+
+		m[fmt.Sprintf(`that(%s).is_not_negative_infinity()`, zero)] = nil
+		m[fmt.Sprintf(`that(%s).is_negative_infinity()`, zero)] =
+			fail(zero, fmt.Sprintf(`is equal to <-inf>`))
+	}
+
+	testEach(t, m)
+}
+
+func TestNumericEdges(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(9).is_zero()`:                  fail(`9`, `is zero`),
+		`that(9).is_non_zero()`:              nil,
+		`that(9).is_finite()`:                nil,
+		`that(9).is_not_finite()`:            newTruthAssertion(`<9> should not have been finite.`),
+		`that(9).is_not_nan()`:               nil,
+		`that(9).is_nan()`:                   fail(`9`, `is equal to <nan>`),
+		`that(9).is_not_positive_infinity()`: nil,
+		`that(9).is_positive_infinity()`:     fail(`9`, `is equal to <+inf>`),
+		`that(9).is_not_negative_infinity()`: nil,
+		`that(9).is_negative_infinity()`:     fail(`9`, `is equal to <-inf>`),
+
+		`that(float("+inf")).is_zero()`:                  fail(`+inf`, `is zero`),
+		`that(float("+inf")).is_non_zero()`:              nil,
+		`that(float("+inf")).is_finite()`:                newTruthAssertion(`<+inf> should have been finite.`),
+		`that(float("+inf")).is_not_finite()`:            nil,
+		`that(float("+inf")).is_not_nan()`:               nil,
+		`that(float("+inf")).is_nan()`:                   fail(`+inf`, `is equal to <nan>`),
+		`that(float("+inf")).is_not_positive_infinity()`: fail(`+inf`, `is not equal to <+inf>`),
+		`that(float("+inf")).is_positive_infinity()`:     nil,
+		`that(float("+inf")).is_not_negative_infinity()`: nil,
+		`that(float("+inf")).is_negative_infinity()`:     fail(`+inf`, `is equal to <-inf>`),
+
+		`that(float("-inf")).is_zero()`:                  fail(`-inf`, `is zero`),
+		`that(float("-inf")).is_non_zero()`:              nil,
+		`that(float("-inf")).is_finite()`:                newTruthAssertion(`<-inf> should have been finite.`),
+		`that(float("-inf")).is_not_finite()`:            nil,
+		`that(float("-inf")).is_not_nan()`:               nil,
+		`that(float("-inf")).is_nan()`:                   fail(`-inf`, `is equal to <nan>`),
+		`that(float("-inf")).is_not_positive_infinity()`: nil,
+		`that(float("-inf")).is_positive_infinity()`:     fail(`-inf`, `is equal to <+inf>`),
+		`that(float("-inf")).is_not_negative_infinity()`: fail(`-inf`, `is not equal to <-inf>`),
+		`that(float("-inf")).is_negative_infinity()`:     nil,
+
+		`that(float("nan")).is_zero()`:                  fail(`nan`, `is zero`),
+		`that(float("nan")).is_non_zero()`:              nil,
+		`that(float("nan")).is_finite()`:                newTruthAssertion(`<nan> should have been finite.`),
+		`that(float("nan")).is_not_finite()`:            nil,
+		`that(float("nan")).is_not_nan()`:               newTruthAssertion(`<nan> should not have been <nan>.`),
+		`that(float("nan")).is_nan()`:                   nil,
+		`that(float("nan")).is_not_positive_infinity()`: nil,
+		`that(float("nan")).is_positive_infinity()`:     fail(`nan`, `is equal to <+inf>`),
+		`that(float("nan")).is_not_negative_infinity()`: nil,
+		`that(float("nan")).is_negative_infinity()`:     fail(`nan`, `is equal to <-inf>`),
+	})
+}
+
+func TestWithin(t *testing.T) {
+	testEach(t, map[string]error{
+		`
+fortytwo = that(5.0).is_within(0.1)
+fortytwo.of(4.9)
+fortytwo.of(5.0)
+fortytwo.of(5.1)
+`: nil,
+
+		`that(5.0).is_within(0.1).of(float("-inf"))`: newTruthAssertion(`<5.0> and <-inf> should have been within <0.1> of each other.`),
+		`that(5.0).is_within(0.1).of(4.8)`:           newTruthAssertion(`<5.0> and <4.8> should have been within <0.1> of each other.`),
+		`that(5.0).is_within(0.1).of(5.2)`:           newTruthAssertion(`<5.0> and <5.2> should have been within <0.1> of each other.`),
+		`that(5.0).is_within(0.1).of(float("+inf"))`: newTruthAssertion(`<5.0> and <+inf> should have been within <0.1> of each other.`),
+	})
+}
+
+func TestNotWithin(t *testing.T) {
+	testEach(t, map[string]error{
+		`
+fortytwo = that(5.0).is_not_within(0.1)
+fortytwo.of(float("-inf"))
+fortytwo.of(4.8)
+fortytwo.of(5.2)
+fortytwo.of(float("+inf"))
+`: nil,
+
+		`that(5.0).is_not_within(0.1).of(4.9)`: newTruthAssertion(`<5.0> and <4.9> should not have been within <0.1> of each other.`),
+		`that(5.0).is_not_within(0.1).of(5.0)`: newTruthAssertion(`<5.0> and <5.0> should not have been within <0.1> of each other.`),
+		`that(5.0).is_not_within(0.1).of(5.1)`: newTruthAssertion(`<5.0> and <5.1> should not have been within <0.1> of each other.`),
+	})
+}
+
+func TestWithinTolerance(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(0).is_within(-1).of(42)`:            newInvalidAssertion(`tolerance cannot be negative`),
+		`that(0).is_within(float("+inf")).of(42)`: newInvalidAssertion(`tolerance cannot be positive infinity`),
+		`that(0).is_within(float("-inf")).of(42)`: newInvalidAssertion(`tolerance cannot be negative`),
+		`that(0).is_within(float("nan")).of(42)`:  newInvalidAssertion(`tolerance cannot be <nan>`),
+
+		`that(0).is_not_within(-1).of(42)`:            newInvalidAssertion(`tolerance cannot be negative`),
+		`that(0).is_not_within(float("+inf")).of(42)`: newInvalidAssertion(`tolerance cannot be positive infinity`),
+		`that(0).is_not_within(float("-inf")).of(42)`: newInvalidAssertion(`tolerance cannot be negative`),
+		`that(0).is_not_within(float("nan")).of(42)`:  newInvalidAssertion(`tolerance cannot be <nan>`),
+	})
+}
+
+func TestTheOtherFloats(t *testing.T) {
+	others := []string{`2`, `float("+inf")`, `float("-inf")`, `float("nan")`}
+	reprs := []string{`2`, `+inf`, `-inf`, `nan`}
+	m := make(map[string]error)
+
+	for i := 0; i < len(others); i++ {
+		for j := len(others) - 1; j >= 0; j-- {
+			x, y := others[i], others[j]
+			rx, ry := reprs[i], reprs[j]
+
+			var expectA, expectB error
+			expectA = newTruthAssertion(fmt.Sprintf(`<%s> and <%s> should have been within <1> of each other.`, rx, ry))
+			if i == 0 && j == i {
+				expectA = nil
+				expectB = newTruthAssertion(`<2> and <2> should not have been within <1> of each other.`)
+			}
+
+			m[fmt.Sprintf(`that(%s).is_within(1).of(%s)`, x, y)] = expectA
+			m[fmt.Sprintf(`that(%s).is_not_within(1).of(%s)`, x, y)] = expectB
+		}
+	}
+
+	testEach(t, m)
+}

--- a/lib/truth/ordered_test.go
+++ b/lib/truth/ordered_test.go
@@ -1,0 +1,71 @@
+package truth
+
+import "testing"
+
+func TestIsOrdered(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_ordered()`
+	}
+	testEach(t, map[string]error{
+		s(`()`):        nil,
+		s(`(3,)`):      nil,
+		s(`(3, 5, 8)`): nil,
+		s(`(3, 5, 5)`): nil,
+		s(`"abcdef"`):  nil,
+		s(`"fedcba"`):  newTruthAssertion(`Not true that <"fedcba"> is ordered <("f", "e")>.`),
+		s(`{5: 4}`):    newInvalidAssertion("values of type dict are not ordered"),
+		s(`(5, 4)`):    newTruthAssertion(`Not true that <(5, 4)> is ordered <(5, 4)>.`),
+		s(`(3, 5, 4)`): newTruthAssertion(`Not true that <(3, 5, 4)> is ordered <(5, 4)>.`),
+	})
+}
+
+func TestIsOrderedAccordingTo(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_ordered_according_to(someCmp)`
+	}
+	testEach(t, map[string]error{
+		s(`()`):        nil,
+		s(`(3,)`):      nil,
+		s(`(8, 5, 3)`): nil,
+		s(`(5, 5, 3)`): nil,
+		s(`"fedcba"`):  nil,
+		s(`"abcdef"`):  newTruthAssertion(`Not true that <"abcdef"> is ordered <("a", "b")>.`),
+		s(`{5: 4}`):    newInvalidAssertion("values of type dict are not ordered"),
+		s(`(4, 5)`):    newTruthAssertion(`Not true that <(4, 5)> is ordered <(4, 5)>.`),
+		s(`(3, 5, 4)`): newTruthAssertion(`Not true that <(3, 5, 4)> is ordered <(3, 5)>.`),
+	})
+}
+
+func TestIsStrictlyOrdered(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_strictly_ordered()`
+	}
+	testEach(t, map[string]error{
+		s(`()`):        nil,
+		s(`(3,)`):      nil,
+		s(`(3, 5, 8)`): nil,
+		s(`"abcdef"`):  nil,
+		s(`"abcdee"`):  newTruthAssertion(`Not true that <"abcdee"> is strictly ordered <("e", "e")>.`),
+		s(`"fedcba"`):  newTruthAssertion(`Not true that <"fedcba"> is strictly ordered <("f", "e")>.`),
+		s(`{5: 4}`):    newInvalidAssertion("values of type dict are not ordered"),
+		s(`(5, 4)`):    newTruthAssertion(`Not true that <(5, 4)> is strictly ordered <(5, 4)>.`),
+		s(`(3, 5, 5)`): newTruthAssertion(`Not true that <(3, 5, 5)> is strictly ordered <(5, 5)>.`),
+	})
+}
+
+func TestIsStrictlyOrderedAccordingTo(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_strictly_ordered_according_to(someCmp)`
+	}
+	testEach(t, map[string]error{
+		s(`()`):        nil,
+		s(`(3,)`):      nil,
+		s(`(8, 5, 3)`): nil,
+		s(`"fedcba"`):  nil,
+		s(`"fedcbb"`):  newTruthAssertion(`Not true that <"fedcbb"> is strictly ordered <("b", "b")>.`),
+		s(`"abcdef"`):  newTruthAssertion(`Not true that <"abcdef"> is strictly ordered <("a", "b")>.`),
+		s(`{5: 4}`):    newInvalidAssertion("values of type dict are not ordered"),
+		s(`(4, 5)`):    newTruthAssertion(`Not true that <(4, 5)> is strictly ordered <(4, 5)>.`),
+		s(`(5, 5, 3)`): newTruthAssertion(`Not true that <(5, 5, 3)> is strictly ordered <(5, 5)>.`),
+	})
+}

--- a/lib/truth/size_test.go
+++ b/lib/truth/size_test.go
@@ -1,0 +1,50 @@
+package truth
+
+import "testing"
+
+func TestHasSize(t *testing.T) {
+	s := func(x string) string {
+		return `that((2, 5, 8)).has_size(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`3`):  nil,
+		s(`-1`): fail(`(2, 5, 8)`, `has a size of <-1>. It is <3>`),
+		s(`2`):  fail(`(2, 5, 8)`, `has a size of <2>. It is <3>`),
+	})
+}
+
+func TestIsEmpty(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_empty()`
+	}
+	testEach(t, map[string]error{
+		s(`()`):       nil,
+		s(`[]`):       nil,
+		s(`{}`):       nil,
+		s(`set([])`):  nil,
+		s(`""`):       nil,
+		s(`(3,)`):     fail(`(3,)`, `is empty`),
+		s(`[4]`):      fail(`[4]`, `is empty`),
+		s(`{5: 6}`):   fail(`{5: 6}`, `is empty`),
+		s(`set([7])`): fail(`set([7])`, `is empty`),
+		s(`"height"`): fail(`"height"`, `is empty`),
+	})
+}
+
+func TestIsNotEmpty(t *testing.T) {
+	s := func(t string) string {
+		return `that(` + t + `).is_not_empty()`
+	}
+	testEach(t, map[string]error{
+		s(`(3,)`):     nil,
+		s(`[4]`):      nil,
+		s(`{5: 6}`):   nil,
+		s(`set([7])`): nil,
+		s(`"height"`): nil,
+		s(`()`):       fail(`()`, `is not empty`),
+		s(`[]`):       fail(`[]`, `is not empty`),
+		s(`{}`):       fail(`{}`, `is not empty`),
+		s(`set([])`):  fail(`set([])`, `is not empty`),
+		s(`""`):       fail(`""`, `is not empty`),
+	})
+}

--- a/lib/truth/strings_test.go
+++ b/lib/truth/strings_test.go
@@ -1,0 +1,99 @@
+package truth
+
+import "testing"
+
+func TestHasLength(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).has_length(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`3`): nil,
+		s(`4`): fail(ss, `has a length of 4. It is 3`),
+		s(`2`): fail(ss, `has a length of 2. It is 3`),
+	})
+}
+
+func TestStartsWith(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).starts_with(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`""`):   nil,
+		s(`"a"`):  nil,
+		s(`"ab"`): nil,
+		s(abc):    nil,
+		s(`"b"`):  fail(ss, `starts with <"b">`),
+	})
+}
+
+func TestEndsWith(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).ends_with(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`""`):   nil,
+		s(`"c"`):  nil,
+		s(`"bc"`): nil,
+		s(abc):    nil,
+		s(`"b"`):  fail(ss, `ends with <"b">`),
+	})
+}
+
+func TestMatches(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).matches(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`"a"`):     nil,
+		s(`r".b"`):   nil,
+		s(`r"[Aa]"`): nil,
+		s(`"d"`):     fail(ss, `matches <"d">`),
+		s(`"b"`):     fail(ss, `matches <"b">`),
+	})
+}
+
+func TestDoesNotMatch(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).does_not_match(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`"b"`):     nil,
+		s(`"d"`):     nil,
+		s(`"a"`):     fail(ss, `fails to match <"a">`),
+		s(`r".b"`):   fail(ss, `fails to match <".b">`),
+		s(`r"[Aa]"`): fail(ss, `fails to match <"[Aa]">`),
+	})
+}
+
+func TestContainsMatch(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).contains_match(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`"a"`):     nil,
+		s(`r".b"`):   nil,
+		s(`r"[Aa]"`): nil,
+		s(`"b"`):     nil,
+		s(`"d"`):     fail(ss, `should have contained a match for <"d">`),
+	})
+}
+
+func TestDoesNotContainMatch(t *testing.T) {
+	ss := abc
+	s := func(x string) string {
+		return `that(` + ss + `).does_not_contain_match(` + x + `)`
+	}
+	testEach(t, map[string]error{
+		s(`"d"`):     nil,
+		s(`"a"`):     fail(ss, `should not have contained a match for <"a">`),
+		s(`"b"`):     fail(ss, `should not have contained a match for <"b">`),
+		s(`r".b"`):   fail(ss, `should not have contained a match for <".b">`),
+		s(`r"[Aa]"`): fail(ss, `should not have contained a match for <"[Aa]">`),
+	})
+}

--- a/lib/truth/t.go
+++ b/lib/truth/t.go
@@ -1,0 +1,76 @@
+package truth
+
+import (
+	"math/big"
+
+	"go.starlark.net/starlark"
+)
+
+// T wraps an assert target
+type T struct {
+	// Target in assert.that(target)
+	actual starlark.Value
+
+	// Readable optional prefix with .named(name)
+	name string
+
+	// True when actual was a String and was made into an iterable.
+	// Helps when pretty printing.
+	actualIsIterableFromString bool
+
+	// forOrdering is relevant to .in_order() assertions
+	forOrdering *forOrdering
+
+	// registered holds the compiled default compare function
+	registered *registeredValues
+
+	// withinTolerance is used to delta-compare numbers
+	withinTolerance *withinTolerance
+}
+
+type forOrdering struct {
+	inOrderError error
+}
+
+type withinTolerance struct {
+	within           bool
+	actual           *big.Rat
+	tolerance        *big.Rat
+	toleranceAsValue starlark.Value
+}
+
+func (t *T) turnActualIntoIterableFromString() {
+	s := t.actual.(starlark.String).GoString()
+	vs := make([]starlark.Value, 0, len(s))
+	for _, c := range s {
+		vs = append(vs, starlark.String(c))
+	}
+	t.actual = starlark.Tuple(vs)
+	t.actualIsIterableFromString = true
+}
+
+type registeredValues struct {
+	Cmp   starlark.Value
+	Apply func(f *starlark.Function, args starlark.Tuple) (starlark.Value, error)
+}
+
+const cmpSrc = `lambda a, b: int(a > b) - int(a < b)`
+
+func (t *T) registerValues(thread *starlark.Thread) error {
+	if t.registered == nil {
+		cmp, err := starlark.Eval(thread, "", cmpSrc, starlark.StringDict{})
+		if err != nil {
+			return err
+		}
+
+		apply := func(f *starlark.Function, args starlark.Tuple) (starlark.Value, error) {
+			return starlark.Call(thread, f, args, nil)
+		}
+
+		t.registered = &registeredValues{
+			Cmp:   cmp,
+			Apply: apply,
+		}
+	}
+	return nil
+}

--- a/lib/truth/truth_test.go
+++ b/lib/truth/truth_test.go
@@ -1,0 +1,152 @@
+package truth
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
+)
+
+type asWhat int
+
+const (
+	asFunc asWhat = iota
+	asModule
+)
+
+const abc = `"abc"` // Please linter
+
+func helper(t *testing.T, as asWhat, program string) (starlark.StringDict, error) {
+	t.Helper() // TODO: make this work (for failed test reports)
+
+	// Enabled so they can be tested
+	resolve.AllowFloat = true
+	resolve.AllowSet = true
+	resolve.AllowLambda = true
+
+	predeclared := starlark.StringDict{}
+	if as == asModule {
+		NewModule(predeclared)
+	} else {
+		starlark.Universe["that"] = starlark.NewBuiltin("that", That)
+	}
+
+	thread := &starlark.Thread{
+		Name: t.Name(),
+		Print: func(_ *starlark.Thread, msg string) {
+			t.Logf("--> %s", msg)
+		},
+		Load: func(_ *starlark.Thread, module string) (starlark.StringDict, error) {
+			return nil, errors.New("load() disabled")
+		},
+	}
+
+	script := strings.Join([]string{
+		`dfltCmp = ` + cmpSrc,
+		`someCmp = lambda a, b: dfltCmp(b, a)`,
+		program,
+	}, "\n")
+
+	d, err := starlark.ExecFile(thread, t.Name()+".star", script, predeclared)
+	if err != nil {
+		return nil, err
+	}
+	if err := Close(thread); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func testEach(t *testing.T, m map[string]error, asSlice ...asWhat) {
+	as := asFunc
+	for _, as = range asSlice {
+	}
+	for code, expectedErr := range m {
+		t.Run(code, func(t *testing.T) {
+			globals, err := helper(t, as, code)
+			delete(globals, "dfltCmp")
+			delete(globals, "someCmp")
+			delete(globals, "fortytwo")
+			require.Empty(t, globals)
+			if expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.EqualError(t, err, expectedErr.Error())
+				if _, ok := err.(UnhandledError); !ok {
+					require.True(t, errors.As(err, &expectedErr))
+					require.IsType(t, expectedErr, err)
+				}
+			}
+		})
+	}
+}
+
+func fail(value, expected string, suffixes ...string) error {
+	var suffix string
+	switch len(suffixes) {
+	case 0:
+	case 1:
+		suffix = suffixes[0]
+	default:
+		panic(`There must be only one suffix`)
+	}
+	msg := "Not true that <" + value + "> " + expected + "." + suffix
+	return newTruthAssertion(msg)
+}
+
+func TestClosedness(t *testing.T) {
+	testEach(t, map[string]error{
+		`
+fortytwo = that(True)
+that(False).is_false()
+`: UnresolvedError("TestClosedness/_fortytwo_=_that(True)_that(False).is_false()_.star:4:16"),
+		`
+fortytwo = that(True)
+fortytwo.is_true()
+that(False).is_false()
+`: nil,
+	})
+	testEach(t, map[string]error{
+		`assert.that(True)`:           UnresolvedError("TestClosedness/assert.that(True).star:3:12"),
+		`assert.that(True).is_true()`: nil,
+
+		`assert.that(True).named("eh")`:           UnresolvedError(`TestClosedness/assert.that(True).named("eh").star:3:12`),
+		`assert.that(True).named("eh").is_true()`: nil,
+
+		`assert.that(10).is_within(0.1)`:            UnresolvedError("TestClosedness/assert.that(10).is_within(0.1).star:3:12"),
+		`assert.that(10).is_within(0.1).of(10)`:     nil,
+		`assert.that(10).is_not_within(0.1)`:        UnresolvedError("TestClosedness/assert.that(10).is_not_within(0.1).star:3:12"),
+		`assert.that(10).is_not_within(0.1).of(42)`: nil,
+	}, asModule)
+}
+
+func TestAsValue(t *testing.T) {
+	testEach(t, map[string]error{
+		`
+fortytwo = that(42)
+fortytwo.is_equal_to(42.0)
+fortytwo.is_not_callable()
+fortytwo.is_at_least(42)
+`: nil,
+
+		`
+fortytwo = that([1,2,3])
+fortytwo.contains(2)
+fortytwo.contains_exactly(1,2,3)
+fortytwo.contains_exactly(1,2,3).in_order()
+fortytwo.contains_all_of(2,3).in_order()
+`: nil,
+	})
+}
+
+func TestImpossibleInOrder(t *testing.T) {
+	testEach(t, map[string]error{
+		`that([1,2,3]).is_ordered()`: nil,
+		`that([1,2,3]).in_order()`:   fmt.Errorf(`Invalid assertion .in_order() on value of type list`),
+	})
+}

--- a/lib/truth/type_test.go
+++ b/lib/truth/type_test.go
@@ -1,0 +1,40 @@
+package truth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsOfType(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(None).is_of_type("NoneType")`:            nil,
+		`that("").is_of_type("string")`:                nil,
+		`that(0).is_of_type("int")`:                    nil,
+		`that(0.0).is_of_type("float")`:                nil,
+		`that(set([])).is_of_type("set")`:              nil,
+		`that(someCmp).is_of_type(type(lambda _: 42))`: nil,
+		`that([]).is_of_type("list")`:                  nil,
+		`that(()).is_of_type("tuple")`:                 nil,
+		`that({}).is_of_type("dict")`:                  nil,
+		`that({}).is_of_type("int")`:                   fail(`{}`, `is of type <"int">`, ` However, it is of type <"dict">`),
+		`that({}).is_of_type(type({}))`:                nil,
+		`that({}).is_of_type({})`:                      fmt.Errorf(`Invalid assertion .is_of_type({}) on value of type dict`),
+	})
+}
+
+func TestIsNotOfType(t *testing.T) {
+	testEach(t, map[string]error{
+		`that(None).is_not_of_type("int")`:    nil,
+		`that("").is_not_of_type("int")`:      nil,
+		`that(0).is_not_of_type("dict")`:      nil,
+		`that(0.0).is_not_of_type("int")`:     nil,
+		`that(set([])).is_not_of_type("int")`: nil,
+		`that(someCmp).is_not_of_type("int")`: nil,
+		`that([]).is_not_of_type("int")`:      nil,
+		`that(()).is_not_of_type("int")`:      nil,
+		`that({}).is_not_of_type("int")`:      nil,
+		`that({}).is_not_of_type("dict")`:     fail(`{}`, `is not of type <"dict">`, ` However, it is of type <"dict">`),
+		`that({}).is_not_of_type(type([{}]))`: nil,
+		`that([]).is_not_of_type({})`:         fmt.Errorf(`Invalid assertion .is_not_of_type({}) on value of type list`),
+	})
+}

--- a/lib/truth/unicodes_test.go
+++ b/lib/truth/unicodes_test.go
@@ -1,0 +1,41 @@
+package truth
+
+import "testing"
+
+func TestContainsExactlyHandlesStringsAsCodepoints(t *testing.T) {
+	const (
+		// multiple bytes codepoint
+		u1 = `Й`
+		// more multiple bytes codepoint
+		u2 = `😿`
+		// concats
+		full  = `"abc` + u1 + u2 + `"`
+		tuple = `("a", "` + u1 + `", "c")`
+		elput = `("c", "` + u1 + `", "a")`
+	)
+	testEach(t, map[string]error{
+		`that("abc").contains_exactly("abc")`: fail(abc,
+			`contains exactly <("abc",)>. It is missing <"abc"> and has unexpected items <"a", "b", "c">`),
+
+		`that("abc").contains_exactly("a", "b", "c")`:            nil,
+		`that("abc").contains_exactly("a", "b", "c").in_order()`: nil,
+		`that("abc").contains_exactly("c", "b", "a")`:            nil,
+		`that("abc").contains_exactly("c", "b", "a").in_order()`: fail(abc,
+			`contains exactly these elements in order <("c", "b", "a")>`),
+
+		`that("abc").contains_exactly("a", "bc")`: fail(abc,
+			`contains exactly <("a", "bc")>. It is missing <"bc"> and has unexpected items <"b", "c">`),
+
+		`that(` + tuple + `).contains_exactly` + tuple + ``:            nil,
+		`that(` + tuple + `).contains_exactly` + elput + ``:            nil,
+		`that(` + tuple + `).contains_exactly` + tuple + `.in_order()`: nil,
+		`that(` + tuple + `).contains_exactly` + elput + `.in_order()`: fail(tuple,
+			`contains exactly these elements in order <`+elput+`>`),
+
+		`that(` + full + `).contains_exactly("a", "` + u1 + `")`: fail(full,
+			`contains exactly <("a", "`+u1+`")>. It has unexpected items <"b", "c", "`+u2+`">`),
+
+		`that(` + full + `).contains_exactly("a` + u1 + `")`: fail(full,
+			`contains exactly <("a`+u1+`",)>. It is missing <"a`+u1+`"> and has unexpected items <"a", "b", "c", "`+u1+`", "`+u2+`">`),
+	})
+}


### PR DESCRIPTION
Hi there,
I've just finished porting https://github.com/google/pytruth to Starlark for use in https://github.com/FuzzyMonkeyCo/monkey which requires expressive assertions.

I understand these are the points that should require discussion (some/all are mentioned in the package docs):
* starlark strings aren't iterable but are sometimes turned into rune tuples in this lib for convenience on the user of the lib
* duplicate counter compares string serialization of values instead of hash. (pytruth works around this)

Please share your thoughts and take some time to do a bit of reviewing :)