### PR TITLE
rename math.abs to math.fabs (fixes #362) and introduce `Universe["abs"]`

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3027,8 +3027,8 @@ application-specific dialect) without breaking existing programs.
 
 ### abs
 
-`abs(x)` returns the absolute value of the same type.
-Execution terminates if `x` is not a real number.
+`abs(x)` returns the absolute value of its argument `x`, which must be an int or float.
+The result has the same type as `x`.
 
 ### any
 

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3025,6 +3025,11 @@ application-specific dialect) without breaking existing programs.
 
 `True` and `False` are the two values of type `bool`.
 
+### abs
+
+`abs(x)` returns the absolute value of the same type.
+Execution terminates if `x` is not a real number.
+
 ### any
 
 `any(x)` returns `True` if any element of the iterable sequence x has a truth value of true.

--- a/lib/math/math.go
+++ b/lib/math/math.go
@@ -17,9 +17,9 @@ import (
 // Module math is a Starlark module of math-related functions and constants.
 // The module defines the following functions:
 //
-//     abs(x) - Returns the absolute value of x.
 //     ceil(x) - Returns the ceiling of x, the smallest integer greater than or equal to x.
 //     copysign(x, y) - Returns a value with the magnitude of x and the sign of y.
+//     fabs(x) - Returns the absolute value of x as float.
 //     floor(x) - Returns the floor of x, the largest integer less than or equal to x.
 //     mod(x, y) - Returns the floating-point remainder of x/y. The magnitude of the result is less than y and its sign agrees with that of x.
 //     pow(x, y) - Returns x**y, the base-x exponential of y.
@@ -67,9 +67,9 @@ import (
 var Module = &starlarkstruct.Module{
 	Name: "math",
 	Members: starlark.StringDict{
-		"abs":       newUnaryBuiltin("abs", math.Abs),
 		"ceil":      newUnaryBuiltin("ceil", math.Ceil),
 		"copysign":  newBinaryBuiltin("copysign", math.Copysign),
+		"fabs":      newUnaryBuiltin("fabs", math.Abs),
 		"floor":     newUnaryBuiltin("floor", math.Floor),
 		"mod":       newBinaryBuiltin("round", math.Mod),
 		"pow":       newBinaryBuiltin("pow", math.Pow),

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -174,9 +174,9 @@ func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 		if x.Sign() >= 0 {
 			return x, nil
 		}
-		return x.Unary(syntax.MINUS)
+		return zero.Sub(x), nil
 	default:
-		return nil, fmt.Errorf("must be real number, not %s", x.Type())
+		return nil, fmt.Errorf("got %s, want int or float", x.Type())
 	}
 }
 

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -39,6 +39,7 @@ func init() {
 		"None":      None,
 		"True":      True,
 		"False":     False,
+		"abs":       NewBuiltin("abs", abs),
 		"any":       NewBuiltin("any", any),
 		"all":       NewBuiltin("all", all),
 		"bool":      NewBuiltin("bool", bool_),
@@ -159,6 +160,25 @@ func builtinAttrNames(methods map[string]*Builtin) []string {
 }
 
 // ---- built-in functions ----
+
+// https://github.com/google/starlark-go/blob/master/doc/spec.md#abs
+func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+	var x Value
+	if err := UnpackPositionalArgs("abs", args, kwargs, 1, &x); err != nil {
+		return nil, err
+	}
+	switch x := x.(type) {
+	case Float:
+		return Float(math.Abs(float64(x))), nil
+	case Int:
+		if x.Sign() >= 0 {
+			return x, nil
+		}
+		return x.Unary(syntax.MINUS)
+	default:
+		return nil, fmt.Errorf("must be real number, not %s", x.Type())
+	}
+}
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#all
 func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {

--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -18,6 +18,24 @@ none = None
 _1 = none and none[0]      # rhs is not evaluated
 _2 = (not none) or none[0] # rhs is not evaluated
 
+# abs
+assert.eq(abs(2.0), 2.0)
+assert.eq(abs(0.0), 0.0)
+assert.eq(abs(-2.0), 2.0)
+assert.eq(abs(2), 2)
+assert.eq(abs(0), 0)
+assert.eq(abs(-2), 2)
+assert.eq(abs(float("inf")), float("inf"))
+assert.eq(abs(float("-inf")), float("inf"))
+assert.eq(abs(float("nan")), float("nan"))
+assert.fails(lambda: abs("0"), "must be real number, not string")
+def abs_bigint():
+	maxint32 = (1 << 31) - 1
+	assert.eq(abs(+123 * maxint32), +123 * maxint32)
+	assert.eq(abs(-123 * maxint32), +123 * maxint32)
+
+abs_bigint()
+
 # any, all
 assert.true(all([]))
 assert.true(all([1, True, "foo"]))

--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -28,13 +28,10 @@ assert.eq(abs(-2), 2)
 assert.eq(abs(float("inf")), float("inf"))
 assert.eq(abs(float("-inf")), float("inf"))
 assert.eq(abs(float("nan")), float("nan"))
-assert.fails(lambda: abs("0"), "must be real number, not string")
-def abs_bigint():
-	maxint32 = (1 << 31) - 1
-	assert.eq(abs(+123 * maxint32), +123 * maxint32)
-	assert.eq(abs(-123 * maxint32), +123 * maxint32)
-
-abs_bigint()
+assert.fails(lambda: abs("0"), "got string, want int or float")
+maxint32 = (1 << 31) - 1
+assert.eq(abs(+123 * maxint32), +123 * maxint32)
+assert.eq(abs(-123 * maxint32), +123 * maxint32)
 
 # any, all
 assert.true(all([]))

--- a/starlark/testdata/math.star
+++ b/starlark/testdata/math.star
@@ -4,7 +4,7 @@ load('math.star', 'math')
 load('assert.star', 'assert')
 
 def near(got, want, threshold):
-  return math.abs(got-want) < threshold 
+  return math.fabs(got-want) < threshold
 
 inf, nan = float("inf"), float("nan")
 
@@ -28,17 +28,17 @@ assert.eq(math.ceil(-1), -1.0)
 assert.eq(math.ceil(-10), -10.0)
 assert.eq(math.ceil(-inf), -inf)
 assert.fails(lambda: math.ceil("0"), "got string, want float or int")
-# abs
-assert.eq(math.abs(2.0), 2.0)
-assert.eq(math.abs(0.0), 0.0)
-assert.eq(math.abs(-2.0), 2.0)
-assert.eq(math.abs(2), 2)
-assert.eq(math.abs(0), 0)
-assert.eq(math.abs(-2), 2)
-assert.eq(math.abs(inf), inf)
-assert.eq(math.abs(-inf), inf)
-assert.eq(math.abs(nan), nan)
-assert.fails(lambda: math.abs("0"), "got string, want float or int")
+# fabs
+assert.eq(math.fabs(2.0), 2.0)
+assert.eq(math.fabs(0.0), 0.0)
+assert.eq(math.fabs(-2.0), 2.0)
+assert.eq(math.fabs(2), 2)
+assert.eq(math.fabs(0), 0)
+assert.eq(math.fabs(-2), 2)
+assert.eq(math.fabs(inf), inf)
+assert.eq(math.fabs(-inf), inf)
+assert.eq(math.fabs(nan), nan)
+assert.fails(lambda: math.fabs("0"), "got string, want float or int")
 # floor
 assert.eq(math.floor(0.0), 0.0)
 assert.eq(math.floor(0.4), 0.0)


### PR DESCRIPTION
I get two failures that I could not figure out myself. Ideas?
```
--- FAIL: TestExecFile (0.14s)
    starlarktest.go:117: Traceback (most recent call last):
          /home/pete/wefwefwef/go/src/go.starlark.net/starlark/testdata/builtins.star:27:10: in <toplevel>
          /home/pete/wefwefwef/go/src/go.starlark.net/starlarktest/assert.star:14:14: in _eq
        Error: 1 != 2
    starlarktest.go:117: Traceback (most recent call last):
          /home/pete/wefwefwef/go/src/go.starlark.net/starlark/testdata/builtins.star:37:11: in <toplevel>
          /home/pete/wefwefwef/go/src/go.starlark.net/starlark/testdata/builtins.star:35:11: in abs_bigint
          /home/pete/wefwefwef/go/src/go.starlark.net/starlarktest/assert.star:14:14: in _eq
        Error: 264140488580 != -264140488581
FAIL
```