### PR TITLE
Add support of timestamps in nanoseconds

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -20,6 +20,7 @@ var Module = &starlarkstruct.Module{
 		"time":              starlark.NewBuiltin("time", newTime),
 		"parse_time":        starlark.NewBuiltin("parse_time", parseTime),
 		"from_timestamp":    starlark.NewBuiltin("from_timestamp", fromTimestamp),
+		"from_timestamp_ns": starlark.NewBuiltin("from_timestamp_ns", fromTimestampNanos),
 
 		"nanosecond":  Duration(time.Nanosecond),
 		"microsecond": Duration(time.Microsecond),
@@ -89,14 +90,24 @@ func parseTime(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	return Time(t), nil
 }
 
-// Parses the given timestamp string corresponding to
-// the total amount of seconds since January 1, 1970 UTC.
+// Converts the given timestamp corresponding to the total amount of seconds
+// since January 1, 1970 UTC into an object of type Time.
 func fromTimestamp(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var x int64
 	if err := starlark.UnpackPositionalArgs("from_timestamp", args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
 	return Time(time.Unix(x, 0)), nil
+}
+
+// Converts the given timestamp corresponding to the total amount of nanoseconds
+// since January 1, 1970 UTC into an object of type Time.
+func fromTimestampNanos(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x int64
+	if err := starlark.UnpackPositionalArgs("from_timestamp_ns", args, kwargs, 1, &x); err != nil {
+		return nil, err
+	}
+	return Time(time.Unix(x/1e9, x%1e9)), nil
 }
 
 // Generates the current time current time.

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -18,27 +18,22 @@ import (
 // Module time is a Starlark module of time-related functions and constants.
 // The module defines the following functions:
 //
-//     from_timestamp(sec, nsec) - Converts the given Unix time corresponding to the total amount of seconds
-//                                 and nonoseconds since January 1, 1970 UTC into an object of type Time.
-//                                 The total amount of nonoseconds is optional.
-//                                 It is valid to pass nonoseconds outside the range [0, 999999999].
-//                                 Not all sec values have a corresponding time value. One such
-//                                 value is 1<<63-1 (the largest int64 value).
+//     from_timestamp(sec, nsec) - Converts the given Unix time corresponding to the number of seconds
+//                                 and (optionally) nanoseconds since January 1, 1970 UTC into an object
+//                                 of type Time. For more details, refer to https://pkg.go.dev/time#Unix.
 //
-//     is_valid_timezone(loc) - Indicates whether the given name of location is valid or not.
-//                              Returns true if it is valid, false otherwise.
+//     is_valid_timezone(loc) - Reports whether loc is a valid time zone name.
 //
-//     now() - Returns the current local time.
+//     now() - Returns the current local time. Applications may replace this function by a deterministic one.
 //
-//     parse_duration(d) - Parses the given duration string.
-//                         A duration string is a possibly signed sequence of decimal numbers,
-//                         each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
-//                         Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+//     parse_duration(d) - Parses the given duration string. For more details, refer to
+//                         https://pkg.go.dev/time#ParseDuration.
 //
 //     parseTime(x, format, location) - Parses the given time string using a specific time format and location.
 //                                      The expected arguments are a time string (mandatory), a time format
-//                                      (optional, set to RFC3339 by default) and a name of location
-//                                      (optional set to UTC by default).
+//                                      (optional, set to RFC3339 by default, e.g. "2021-03-22T23:20:50.52Z")
+//                                      and a name of location (optional, set to UTC by default). For more details,
+//                                      refer to https://pkg.go.dev/time#Parse and https://pkg.go.dev/time#ParseInLocation.
 //
 //     time(year, month, day, hour, minute, second, nanosecond, location) - Returns the Time corresponding to
 //	                                                                        yyyy-mm-dd hh:mm:ss + nsec nanoseconds
@@ -47,12 +42,12 @@ import (
 //                                                                          are optional.
 // The module also defines the following constants:
 //
-// nanosecond - A duration representing one nanosecond.
-// microsecond - A duration representing one microsecond.
-// millisecond - A duration representing one millisecond.
-// second - A duration representing one second.
-// minute - A duration representing one minute.
-// hour - A duration representing one hour.
+//     nanosecond - A duration representing one nanosecond.
+//     microsecond - A duration representing one microsecond.
+//     millisecond - A duration representing one millisecond.
+//     second - A duration representing one second.
+//     minute - A duration representing one minute.
+//     hour - A duration representing one hour.
 //
 var Module = &starlarkstruct.Module{
 	Name: "time",

--- a/starlark/testdata/time.star
+++ b/starlark/testdata/time.star
@@ -4,6 +4,7 @@ load('assert.star', 'assert')
 load('time.star', 'time')
 
 assert.eq(time.parse_time("2020-06-26T17:38:36Z"), time.from_timestamp(1593193116))
+assert.eq(time.parse_time("2020-06-26T17:38:36.123456789", format="2006-01-02T15:04:05.999999999"), time.from_timestamp_ns(1593193116123456789))
 
 assert.eq(time.parse_time("1970-01-01T00:00:00Z").unix, 0)
 assert.eq(time.parse_time("1970-01-01T00:00:00Z").unix_nano, 0)

--- a/starlark/testdata/time.star
+++ b/starlark/testdata/time.star
@@ -3,6 +3,8 @@
 load('assert.star', 'assert')
 load('time.star', 'time')
 
+assert.true(time.now() > time.parse_time("2021-03-20T00:00:00Z"))
+
 assert.eq(time.parse_time("2020-06-26T17:38:36Z"), time.from_timestamp(1593193116))
 assert.eq(time.parse_time("2020-06-26T17:38:36.123456789", format="2006-01-02T15:04:05.999999999"), time.from_timestamp_ns(1593193116123456789))
 

--- a/starlark/testdata/time.star
+++ b/starlark/testdata/time.star
@@ -6,7 +6,7 @@ load('time.star', 'time')
 assert.true(time.now() > time.parse_time("2021-03-20T00:00:00Z"))
 
 assert.eq(time.parse_time("2020-06-26T17:38:36Z"), time.from_timestamp(1593193116))
-assert.eq(time.parse_time("2020-06-26T17:38:36.123456789", format="2006-01-02T15:04:05.999999999"), time.from_timestamp_ns(1593193116123456789))
+assert.eq(time.parse_time("2020-06-26T17:38:36.123456789", format="2006-01-02T15:04:05.999999999"), time.from_timestamp(1593193116, 123456789))
 
 assert.eq(time.parse_time("1970-01-01T00:00:00Z").unix, 0)
 assert.eq(time.parse_time("1970-01-01T00:00:00Z").unix_nano, 0)


### PR DESCRIPTION
fixes #364 

## Motivation

For many real life use cases, it is important to be a able to support timestamps expressed in nanoseconds.

## Modifications:

* Overloads the function `from_timestamp` to be able to set nanoseconds.
* Fixes the documentation of the built in function `from_timestamp` 
* Improves the documentation (not related to this issue)
* Adds a test for the function `now` since it was not covered by any tests (not related to this issue)