### PR TITLE
fix overflow bug in finiteFloatToInt

### DIFF
--- a/starlark/int.go
+++ b/starlark/int.go
@@ -421,10 +421,15 @@ func NumberToInt(x Value) (Int, error) {
 	return zero, fmt.Errorf("cannot convert %s to int", x.Type())
 }
 
+// maxint64f is the largest float value that converts to int64 without overflow.
+// float64(MaxInt64) is numerically equal to MaxInt64+1.
+// See https://github.com/google/starlark-go/issues/375.
+var maxint64f = Float(math.Nextafter(math.MaxInt64, 0))
+
 // finiteFloatToInt converts f to an Int, truncating towards zero.
 // f must be finite.
 func finiteFloatToInt(f Float) Int {
-	if math.MinInt64 <= f && f <= math.MaxInt64 {
+	if math.MinInt64 <= f && f <= maxint64f {
 		// small values
 		return MakeInt64(int64(f))
 	}

--- a/starlark/testdata/float.star
+++ b/starlark/testdata/float.star
@@ -55,6 +55,10 @@ assert.eq(float(p53+6), p53+6)
 assert.eq(float(p53+7), p53+8) #
 assert.eq(float(p53+8), p53+8)
 
+# Regression test for https://github.com/google/starlark-go/issues/375.
+maxint64 = (1<<63)-1
+assert.eq(int(float(maxint64)), 9223372036854775808)
+
 assert.true(float(p53+1) != p53+1) # comparisons are exact
 assert.eq(float(p53+1) - (p53+1), 0) # arithmetic entails rounding
 

--- a/starlarktest/starlarktest.go
+++ b/starlarktest/starlarktest.go
@@ -67,6 +67,10 @@ func LoadAssertModule() (starlark.StringDict, error) {
 			"module":  starlark.NewBuiltin("module", starlarkstruct.MakeModule),
 			"_freeze": starlark.NewBuiltin("freeze", freeze),
 		}
+		// TODO(adonovan): embed the file using embed.FS when we can rely on go1.16,
+		// and stop using DataFile. Otherwise this reaches from the application's working
+		// directory into the starlarktest package's directory, which is not compatible
+		// with modules.
 		filename := DataFile("starlarktest", "assert.star")
 		thread := new(starlark.Thread)
 		assert, assertErr = starlark.ExecFile(thread, filename, nil, predeclared)


### PR DESCRIPTION
Fixes https://github.com/google/starlark-go/issues/375