### PR TITLE
Add GitHub action for testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Starlark Go Tests
+on: [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.16.x, 1.17.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Tests
+        shell: bash
+        run: 'internal/test.sh'

--- a/internal/test.sh
+++ b/internal/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copyright 2021 The Bazel Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -eu
+
+# Confirm that go.mod and go.sum are tidy
+cp go.mod go.mod.orig
+cp go.sum go.sum.orig
+go mod tidy
+diff go.mod.orig go.mod
+diff go.sum.orig go.sum
+rm go.mod.orig go.sum.orig
+
+# Run tests
+go test ./...


### PR DESCRIPTION
It runs all tests and confirms go.mod and go.sum are tidy, just like
the Travis CI test.

The action runs with Go 1.16 and 1.17 on darwin, linux, and windows.