### PR TITLE
avoid cross-package references in tests

### DIFF
--- a/internal/chunkedfile/chunkedfile.go
+++ b/internal/chunkedfile/chunkedfile.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -61,7 +62,13 @@ func Read(filename string, report Reporter) (chunks []Chunk) {
 		return
 	}
 	linenum := 1
-	for i, chunk := range strings.Split(string(data), "\n---\n") {
+
+	eol := "\n"
+	if runtime.GOOS == "windows" {
+		eol = "\r\n"
+	}
+
+	for i, chunk := range strings.Split(string(data), eol+"---"+eol) {
 		if debug {
 			fmt.Printf("chunk %d at line %d: %s\n", i, linenum, chunk)
 		}

--- a/internal/test.sh
+++ b/internal/test.sh
@@ -10,8 +10,9 @@ set -eu
 cp go.mod go.mod.orig
 cp go.sum go.sum.orig
 go mod tidy
-diff go.mod.orig go.mod
-diff go.sum.orig go.sum
+# Use -w to ignore differences in OS newlines.
+diff -w  go.mod.orig go.mod
+diff -w go.sum.orig go.sum
 rm go.mod.orig go.sum.orig
 
 # Run tests

--- a/starlarktest/assert.go
+++ b/starlarktest/assert.go
@@ -2,7 +2,7 @@ package starlarktest
 
 // assertStar contains the logical data file assert.star.
 // TODO(adonovan): move it back into an actual file,
-// when use fs.Embed is more than two releases old.
+// when fs.Embed is more than two releases old.
 const assertStar = `
 # Predeclared built-ins for this module:
 #

--- a/starlarktest/assert.go
+++ b/starlarktest/assert.go
@@ -1,3 +1,9 @@
+package starlarktest
+
+// assertStar contains the logical data file assert.star.
+// TODO(adonovan): move it back into an actual file,
+// when use fs.Embed is more than two releases old.
+const assertStar = `
 # Predeclared built-ins for this module:
 #
 # error(msg): report an error in Go's test framework without halting execution.
@@ -49,3 +55,4 @@ assert = module(
     contains = _contains,
     fails = _fails,
 )
+`


### PR DESCRIPTION
The previous implementation of DataFile (which abstracts different build systems' ways of locating test data files) constructed file names of data files using $GOPATH; also, it used a cross-package reference to locate the assert.star file. This doesn't work under Go modules. Now, DataFile looks only in the current directory, and the assert.star file is moved into a constant section of the executable.

Also, fix tests historically broken on Mac/Windows due to diff and CR LF differences.