### PR TITLE
Add build tag to disable small int optimization on 64bit posix systems

### DIFF
--- a/starlark/int_generic.go
+++ b/starlark/int_generic.go
@@ -1,4 +1,4 @@
-//+build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!solaris darwin,arm64 !amd64,!arm64,!mips64x,!ppc64x
+//+build starlark_int_generic !linux,!darwin,!dragonfly,!freebsd,!netbsd,!solaris darwin,arm64 !amd64,!arm64,!mips64x,!ppc64x
 
 package starlark
 

--- a/starlark/int_posix64.go
+++ b/starlark/int_posix64.go
@@ -1,5 +1,6 @@
 //+build linux darwin dragonfly freebsd netbsd solaris
 //+build amd64 arm64,!darwin mips64x ppc64x
+//+build !starlark_int_generic
 
 package starlark
 
@@ -71,7 +72,7 @@ var smallints = reserveAddresses(1 << 32)
 func reserveAddresses(len int) uintptr {
 	b, err := unix.Mmap(-1, 0, len, unix.PROT_READ, unix.MAP_PRIVATE|unix.MAP_ANON)
 	if err != nil {
-		log.Fatalf("mmap: %v", err)
+		log.Fatalf("mmap: %v (check ulimit or use the starlark_int_generic build tag)", err)
 	}
 	return uintptr(unsafe.Pointer(&b[0]))
 }


### PR DESCRIPTION
Adds a new build tag, starlark_int_generic, to disable the small
integer optimization on posix systems running on 64bit architecture.

This allows starlark to be used on systems with ulimits set.

Also updates the mmap error to be more helpful.

Fixes #394
