### PR TITLE
Add dict|dict and dict|=dict

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -902,6 +902,20 @@ fail.
 A dictionary used in a Boolean context is considered true if it is
 non-empty.
 
+The binary `|` operation may be applied to two dictionaries.
+It yields a new dictionary whose set of keys is the union of the sets
+of keys of the two operands. The corresponding values are taken from
+the operands, where the value taken from the right operand takes
+precedence if both contain a given key.  Iterating over the keys in
+the resulting dictionary first yields all keys in the left operand in
+insertion order, then all keys in the right operand that were not
+present in the left operand, again in insertion order.
+
+There is also an augmented assignment version of the `|` operation.
+For two dictionaries `x` and `y`, the statement `x |= y` behaves
+similar to `x = x | y`, but updates `x` in place rather than assigning
+a new dictionary to it.
+
 Dictionaries may be compared for equality using `==` and `!=`.  Two
 dictionaries compare equal if they contain the same number of items
 and each key/value item (k, v) found in one dictionary is also present
@@ -2014,6 +2028,9 @@ Sets
       int & int                 # bitwise intersection (AND)
       set & set                 # set intersection
       set ^ set                 # set symmetric difference
+
+Dict
+      dict | dict               # ordered union
 ```
 
 The operands of the arithmetic operators `+`, `-`, `*`, `//`, and
@@ -2052,10 +2069,14 @@ For sets, it yields a new set containing the intersection of the
 elements of the operand sets, preserving the element order of the left
 operand.
 
-The `|` operator likewise computes bitwise or set unions.
+The `|` operator likewise computes bitwise, set, or dict unions.
 The result of `set | set` is a new set whose elements are the
 union of the operands, preserving the order of the elements of the
 operands, left before right.
+Similarly, the result of `dict | dict` is a new dict whose entries are
+the union of the operands, preserving the order in which keys first
+appear, but using the value from the right operand for each key
+common to both dicts.
 
 The `^` operator accepts operands of either `int` or `set` type.
 For integers, it yields the bitwise XOR (exclusive OR) of its operands.

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1031,6 +1031,12 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			if y, ok := y.(Int); ok {
 				return x.Or(y), nil
 			}
+
+		case *Dict: // union
+			if y, ok := y.(*Dict); ok {
+				return x.Union(y), nil
+			}
+
 		case *Set: // union
 			if y, ok := y.(*Set); ok {
 				iter := Iterate(y)

--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -12,6 +12,8 @@ import (
 // hashtable is used to represent Starlark dict and set values.
 // It is a hash table whose key/value entries form a doubly-linked list
 // in the order the entries were inserted.
+//
+// Initialized instances of hashtable must not be copied.
 type hashtable struct {
 	table     []bucket  // len is zero or a power of two
 	bucket0   [1]bucket // inline allocation for small maps.
@@ -20,7 +22,16 @@ type hashtable struct {
 	head      *entry  // insertion order doubly-linked list; may be nil
 	tailLink  **entry // address of nil link at end of list (perhaps &head)
 	frozen    bool
+
+	_ noCopy // triggers vet copylock check on this type.
 }
+
+// noCopy is zero-sized type that triggers vet's copylock check.
+// See https://github.com/golang/go/issues/8005#issuecomment-190753527.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
 
 const bucketSize = 8
 
@@ -70,11 +81,8 @@ func (ht *hashtable) freeze() {
 }
 
 func (ht *hashtable) insert(k, v Value) error {
-	if ht.frozen {
-		return fmt.Errorf("cannot insert into frozen hash table")
-	}
-	if ht.itercount > 0 {
-		return fmt.Errorf("cannot insert into hash table during iteration")
+	if err := ht.checkMutable("insert into"); err != nil {
+		return err
 	}
 	if ht.table == nil {
 		ht.init(1)
@@ -230,11 +238,8 @@ func (ht *hashtable) keys() []Value {
 }
 
 func (ht *hashtable) delete(k Value) (v Value, found bool, err error) {
-	if ht.frozen {
-		return nil, false, fmt.Errorf("cannot delete from frozen hash table")
-	}
-	if ht.itercount > 0 {
-		return nil, false, fmt.Errorf("cannot delete from hash table during iteration")
+	if err := ht.checkMutable("delete from"); err != nil {
+		return nil, false, err
 	}
 	if ht.table == nil {
 		return None, false, nil // empty
@@ -277,12 +282,21 @@ func (ht *hashtable) delete(k Value) (v Value, found bool, err error) {
 	return None, false, nil // not found
 }
 
-func (ht *hashtable) clear() error {
+// checkMutable reports an error if the hash table should not be mutated.
+// verb+" dict" should describe the operation.
+func (ht *hashtable) checkMutable(verb string) error {
 	if ht.frozen {
-		return fmt.Errorf("cannot clear frozen hash table")
+		return fmt.Errorf("cannot %s frozen hash table", verb)
 	}
 	if ht.itercount > 0 {
-		return fmt.Errorf("cannot clear hash table during iteration")
+		return fmt.Errorf("cannot %s hash table during iteration", verb)
+	}
+	return nil
+}
+
+func (ht *hashtable) clear() error {
+	if err := ht.checkMutable("clear"); err != nil {
+		return err
 	}
 	if ht.table != nil {
 		for i := range ht.table {
@@ -292,6 +306,15 @@ func (ht *hashtable) clear() error {
 	ht.head = nil
 	ht.tailLink = &ht.head
 	ht.len = 0
+	return nil
+}
+
+func (ht *hashtable) addAll(other *hashtable) error {
+	for e := other.head; e != nil; e = e.next {
+		if err := ht.insert(e.key, e.value); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -795,6 +795,14 @@ func (d *Dict) Freeze()                                         { d.ht.freeze() 
 func (d *Dict) Truth() Bool                                     { return d.Len() > 0 }
 func (d *Dict) Hash() (uint32, error)                           { return 0, fmt.Errorf("unhashable type: dict") }
 
+func (x *Dict) Union(y *Dict) *Dict {
+	z := new(Dict)
+	z.ht.init(x.Len()) // a lower bound
+	z.ht.addAll(&x.ht) // can't fail
+	z.ht.addAll(&y.ht) // can't fail
+	return z
+}
+
 func (d *Dict) Attr(name string) (Value, error) { return builtinAttr(d, name, dictMethods) }
 func (d *Dict) AttrNames() []string             { return builtinAttrNames(dictMethods) }
 


### PR DESCRIPTION
This change adds support for the `x | y` operation (ordered union) in dictionaries and the in-place `x |= y` statement, in which the resulting value of x aliases the original, which is mutated.

Spec change:  https://github.com/bazelbuild/starlark/pull/215
Java change: https://github.com/bazelbuild/bazel/pull/14540