### PR TITLE
struct: Add SetField method for mutable fields

### DIFF
--- a/starlarkstruct/struct_test.go
+++ b/starlarkstruct/struct_test.go
@@ -7,6 +7,7 @@ package starlarkstruct_test
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -67,3 +68,29 @@ func (sym *symbol) CallInternal(thread *starlark.Thread, args starlark.Tuple, kw
 	}
 	return starlarkstruct.FromKeywords(sym, kwargs), nil
 }
+
+func benchmarkAttrSmall(b *testing.B, size int) {
+	var keys []string
+	m := make(starlark.StringDict)
+	for i := 0; i < size; i++ {
+		key := strconv.Itoa(i)
+		m[key] = starlark.Bool(true)
+		keys = append(keys, key)
+	}
+	s := starlarkstruct.FromStringDict(starlarkstruct.Default, m)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := keys[i%len(keys)]
+		_, err := s.Attr(key)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAttr_4(b *testing.B)   { benchmarkAttrSmall(b, 4) }
+func BenchmarkAttr_8(b *testing.B)   { benchmarkAttrSmall(b, 8) }
+func BenchmarkAttr_16(b *testing.B)  { benchmarkAttrSmall(b, 16) }
+func BenchmarkAttr_32(b *testing.B)  { benchmarkAttrSmall(b, 32) }
+func BenchmarkAttr_64(b *testing.B)  { benchmarkAttrSmall(b, 64) }
+func BenchmarkAttr_128(b *testing.B) { benchmarkAttrSmall(b, 128) }

--- a/starlarkstruct/testdata/struct.star
+++ b/starlarkstruct/testdata/struct.star
@@ -14,7 +14,7 @@ assert.eq(type(s), "struct")
 assert.eq(str(s), 'struct(host = "localhost", port = 80)')
 assert.eq(s.host, "localhost")
 assert.eq(s.port, 80)
-assert.fails(lambda : s.protocol, "struct has no .protocol attribute")
+assert.fails(lambda: s.protocol, "struct has no .protocol attribute")
 assert.eq(dir(s), ["host", "port"])
 
 # Use gensym to create "branded" struct types.
@@ -31,7 +31,7 @@ assert.eq(http, hostport(host = "localhost", port = 80))
 assert.ne(http, hostport(host = "localhost", port = 443))
 assert.eq(http.host, "localhost")
 assert.eq(http.port, 80)
-assert.fails(lambda : http.protocol, "hostport struct has no .protocol attribute")
+assert.fails(lambda: http.protocol, "hostport struct has no .protocol attribute")
 
 person = gensym(name = "person")
 bob = person(name = "bob", age = 50)
@@ -58,6 +58,15 @@ assert.eq(getattr(alice, "city"), "NYC")
 assert.eq(bob + bob, bob)
 assert.eq(bob + alice, person(age = 50, city = "NYC", name = "alice"))
 assert.eq(alice + bob, person(age = 50, city = "NYC", name = "bob"))  # not commutative! a misfeature
-assert.fails(lambda : alice + 1, "struct \\+ int")
+assert.fails(lambda: alice + 1, "struct \\+ int")
 assert.eq(http + http, http)
-assert.fails(lambda : http + bob, "different constructors: hostport \\+ person")
+assert.fails(lambda: http + bob, "different constructors: hostport \\+ person")
+
+# setfield
+alice.city = "LA"
+assert.eq(getattr(alice, "city"), "LA")
+
+def set_fail():
+    alice.unknown = "unknown"
+
+assert.fails(set_fail, "unknown")


### PR DESCRIPTION
Modifies the struct definition to implement `starlark.SetField`. It changes the storage of fields from an `[]entries` to a `starlark.StringDict`, I've added a benchmark on `Attr`. On setting non-existing fields the new method errors with NoSuchAttrError.

This makes the struct mutable, fields can be edited after creation but no new fields can be added. A frozen struct behaves similar to before. Couldn't see if this violates the starlark spec? If so please feel free to close.