### PR TITLE
struct: store members as starlark.StringDict for faster access

### DIFF
--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -14,17 +14,15 @@ package starlarkstruct // import "go.starlark.net/starlarkstruct"
 //    them using more specific types such as String, Int, *Depset, and
 //    *File, as such types give no way to represent missing fields.
 // 2) the efficiency gain of direct struct field access is rather
-//    marginal: finding the index of a field by binary searching on the
-//    sorted list of field names is quite fast compared to the other
-//    overheads.
+//    marginal: finding the index of a field by map access is O(1)
+//    and is quite fast compared to the other overheads.
 // 3) the gains in compactness and spatial locality are also rather
-//    marginal: the array behind the []entry slice is (due to field name
+//    marginal: the map behind the field members is (due to field name
 //    strings) only a factor of 2 larger than the corresponding Go struct
 //    would be, and, like the Go struct, requires only a single allocation.
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"go.starlark.net/starlark"
@@ -53,17 +51,16 @@ func FromKeywords(constructor starlark.Value, kwargs []starlark.Tuple) *Struct {
 	if constructor == nil {
 		panic("nil constructor")
 	}
-	s := &Struct{
-		constructor: constructor,
-		entries:     make(entries, 0, len(kwargs)),
-	}
+	members := make(starlark.StringDict, len(kwargs))
 	for _, kwarg := range kwargs {
 		k := string(kwarg[0].(starlark.String))
 		v := kwarg[1]
-		s.entries = append(s.entries, entry{k, v})
+		members[k] = v
 	}
-	sort.Sort(s.entries)
-	return s
+	return &Struct{
+		constructor: constructor,
+		members:     members,
+	}
 }
 
 // FromStringDict returns a new struct instance whose elements are those of d.
@@ -72,15 +69,14 @@ func FromStringDict(constructor starlark.Value, d starlark.StringDict) *Struct {
 	if constructor == nil {
 		panic("nil constructor")
 	}
-	s := &Struct{
-		constructor: constructor,
-		entries:     make(entries, 0, len(d)),
-	}
+	members := make(starlark.StringDict, len(d))
 	for k, v := range d {
-		s.entries = append(s.entries, entry{k, v})
+		members[k] = v
 	}
-	sort.Sort(s.entries)
-	return s
+	return &Struct{
+		constructor: constructor,
+		members:     members,
+	}
 }
 
 // Struct is an immutable Starlark type that maps field names to values.
@@ -100,23 +96,13 @@ func FromStringDict(constructor starlark.Value, d starlark.StringDict) *Struct {
 // Use Attr to access its fields and AttrNames to enumerate them.
 type Struct struct {
 	constructor starlark.Value
-	entries     entries // sorted by name
+	members     starlark.StringDict
+	frozen      bool
 }
 
 // Default is the default constructor for structs.
 // It is merely the string "struct".
 const Default = starlark.String("struct")
-
-type entries []entry
-
-func (a entries) Len() int           { return len(a) }
-func (a entries) Less(i, j int) bool { return a[i].name < a[j].name }
-func (a entries) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-
-type entry struct {
-	name  string
-	value starlark.Value
-}
 
 var (
 	_ starlark.HasAttrs  = (*Struct)(nil)
@@ -125,8 +111,8 @@ var (
 
 // ToStringDict adds a name/value entry to d for each field of the struct.
 func (s *Struct) ToStringDict(d starlark.StringDict) {
-	for _, e := range s.entries {
-		d[e.name] = e.value
+	for key, val := range s.members {
+		d[key] = val
 	}
 }
 
@@ -140,13 +126,14 @@ func (s *Struct) String() string {
 		buf.WriteString(s.constructor.String())
 	}
 	buf.WriteByte('(')
-	for i, e := range s.entries {
+	for i, k := range s.members.Keys() {
+		v := s.members[k]
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(e.name)
+		buf.WriteString(k)
 		buf.WriteString(" = ")
-		buf.WriteString(e.value.String())
+		buf.WriteString(v.String())
 	}
 	buf.WriteByte(')')
 	return buf.String()
@@ -160,10 +147,10 @@ func (s *Struct) Truth() starlark.Bool { return true } // even when empty
 func (s *Struct) Hash() (uint32, error) {
 	// Same algorithm as Tuple.hash, but with different primes.
 	var x, m uint32 = 8731, 9839
-	for _, e := range s.entries {
-		namehash, _ := starlark.String(e.name).Hash()
+	for _, k := range s.members.Keys() {
+		namehash, _ := starlark.String(k).Hash()
 		x = x ^ 3*namehash
-		y, err := e.value.Hash()
+		y, err := s.members[k].Hash()
 		if err != nil {
 			return 0, err
 		}
@@ -173,9 +160,11 @@ func (s *Struct) Hash() (uint32, error) {
 	return x, nil
 }
 func (s *Struct) Freeze() {
-	for _, e := range s.entries {
-		e.value.Freeze()
+	if s.frozen {
+		return
 	}
+	s.members.Freeze()
+	s.frozen = true
 }
 
 func (x *Struct) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
@@ -193,11 +182,11 @@ func (x *Struct) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (
 		}
 
 		z := make(starlark.StringDict, x.len()+y.len())
-		for _, e := range x.entries {
-			z[e.name] = e.value
+		for k, v := range x.members {
+			z[k] = v
 		}
-		for _, e := range y.entries {
-			z[e.name] = e.value
+		for k, v := range y.members {
+			z[k] = v
 		}
 
 		return FromStringDict(x.constructor, z), nil
@@ -207,23 +196,9 @@ func (x *Struct) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (
 
 // Attr returns the value of the specified field.
 func (s *Struct) Attr(name string) (starlark.Value, error) {
-	// Binary search the entries.
-	// This implementation is a specialization of
-	// sort.Search that avoids dynamic dispatch.
-	n := len(s.entries)
-	i, j := 0, n
-	for i < j {
-		h := int(uint(i+j) >> 1)
-		if s.entries[h].name < name {
-			i = h + 1
-		} else {
-			j = h
-		}
+	if v, ok := s.members[name]; ok {
+		return v, nil
 	}
-	if i < n && s.entries[i].name == name {
-		return s.entries[i].value, nil
-	}
-
 	var ctor string
 	if s.constructor != Default {
 		ctor = s.constructor.String() + " "
@@ -232,16 +207,10 @@ func (s *Struct) Attr(name string) (starlark.Value, error) {
 		fmt.Sprintf("%sstruct has no .%s attribute", ctor, name))
 }
 
-func (s *Struct) len() int { return len(s.entries) }
+func (s *Struct) len() int { return len(s.members) }
 
 // AttrNames returns a new sorted list of the struct fields.
-func (s *Struct) AttrNames() []string {
-	names := make([]string, len(s.entries))
-	for i, e := range s.entries {
-		names[i] = e.name
-	}
-	return names
-}
+func (s *Struct) AttrNames() []string { return s.members.Keys() }
 
 func (x *Struct) CompareSameType(op syntax.Token, y_ starlark.Value, depth int) (bool, error) {
 	y := y_.(*Struct)
@@ -268,10 +237,13 @@ func structsEqual(x, y *Struct, depth int) (bool, error) {
 		return false, nil
 	}
 
-	for i, n := 0, x.len(); i < n; i++ {
-		if x.entries[i].name != y.entries[i].name {
+	for k, xv := range x.members {
+		yv, ok := y.members[k]
+		if !ok {
 			return false, nil
-		} else if eq, err := starlark.EqualDepth(x.entries[i].value, y.entries[i].value, depth-1); err != nil {
+		}
+
+		if eq, err := starlark.EqualDepth(xv, yv, depth-1); err != nil {
 			return false, err
 		} else if !eq {
 			return false, nil

--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -95,7 +95,6 @@ func FromStringDict(constructor starlark.Value, d starlark.StringDict) *Struct {
 type Struct struct {
 	constructor starlark.Value
 	members     starlark.StringDict
-	frozen      bool
 }
 
 // Default is the default constructor for structs.
@@ -157,13 +156,7 @@ func (s *Struct) Hash() (uint32, error) {
 	}
 	return x, nil
 }
-func (s *Struct) Freeze() {
-	if s.frozen {
-		return
-	}
-	s.members.Freeze()
-	s.frozen = true
-}
+func (s *Struct) Freeze() { s.members.Freeze() }
 
 func (x *Struct) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
 	if y, ok := y.(*Struct); ok && op == syntax.PLUS {

--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -242,18 +242,12 @@ func structsEqual(x, y *Struct, depth int) (bool, error) {
 		}
 	}
 	for k, xv := range x.members {
-		yv, ok := y.members[k]
-		if !ok {
+		if yv, ok := y.members[k]; !ok {
 			setErr(k, errNotEqual)
-			continue
-		}
-
-		if eq, err := starlark.EqualDepth(xv, yv, depth-1); err != nil {
+		} else if eq, err := starlark.EqualDepth(xv, yv, depth-1); err != nil {
 			setErr(k, err)
-			continue
 		} else if !eq {
 			setErr(k, errNotEqual)
-			continue
 		}
 	}
 	if err != nil {

--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -16,10 +16,8 @@ package starlarkstruct // import "go.starlark.net/starlarkstruct"
 // 2) the efficiency gain of direct struct field access is rather
 //    marginal: finding the index of a field by map access is O(1)
 //    and is quite fast compared to the other overheads.
-// 3) the gains in compactness and spatial locality are also rather
-//    marginal: the map behind the field members is (due to field name
-//    strings) only a factor of 2 larger than the corresponding Go struct
-//    would be, and, like the Go struct, requires only a single allocation.
+// Such an implementation is likely to be more compact than
+// the current map-based representation, though.
 
 import (
 	"fmt"
@@ -237,7 +235,8 @@ func structsEqual(x, y *Struct, depth int) (bool, error) {
 		return false, nil
 	}
 
-	for k, xv := range x.members {
+	for _, k := range x.members.Keys() {
+		xv := x.members[k]
 		yv, ok := y.members[k]
 		if !ok {
 			return false, nil

--- a/starlarkstruct/struct_test.go
+++ b/starlarkstruct/struct_test.go
@@ -7,6 +7,7 @@ package starlarkstruct_test
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -67,3 +68,29 @@ func (sym *symbol) CallInternal(thread *starlark.Thread, args starlark.Tuple, kw
 	}
 	return starlarkstruct.FromKeywords(sym, kwargs), nil
 }
+
+func benchmarkAttrSmall(b *testing.B, size int) {
+	var keys []string
+	m := make(starlark.StringDict)
+	for i := 0; i < size; i++ {
+		key := strconv.Itoa(i)
+		m[key] = starlark.Bool(true)
+		keys = append(keys, key)
+	}
+	s := starlarkstruct.FromStringDict(starlarkstruct.Default, m)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := keys[i%len(keys)]
+		_, err := s.Attr(key)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAttr_4(b *testing.B)   { benchmarkAttrSmall(b, 4) }
+func BenchmarkAttr_8(b *testing.B)   { benchmarkAttrSmall(b, 8) }
+func BenchmarkAttr_16(b *testing.B)  { benchmarkAttrSmall(b, 16) }
+func BenchmarkAttr_32(b *testing.B)  { benchmarkAttrSmall(b, 32) }
+func BenchmarkAttr_64(b *testing.B)  { benchmarkAttrSmall(b, 64) }
+func BenchmarkAttr_128(b *testing.B) { benchmarkAttrSmall(b, 128) }

--- a/starlarkstruct/struct_test.go
+++ b/starlarkstruct/struct_test.go
@@ -13,6 +13,7 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/starlarktest"
+	"go.starlark.net/syntax"
 )
 
 func Test(t *testing.T) {
@@ -94,3 +95,27 @@ func BenchmarkAttr_16(b *testing.B)  { benchmarkAttrSmall(b, 16) }
 func BenchmarkAttr_32(b *testing.B)  { benchmarkAttrSmall(b, 32) }
 func BenchmarkAttr_64(b *testing.B)  { benchmarkAttrSmall(b, 64) }
 func BenchmarkAttr_128(b *testing.B) { benchmarkAttrSmall(b, 128) }
+
+func benchmarkEqual(b *testing.B, size int) {
+	m := make(starlark.StringDict)
+	for i := 0; i < size; i++ {
+		key := strconv.Itoa(i)
+		m[key] = starlark.Bool(true)
+	}
+	x := starlarkstruct.FromStringDict(starlarkstruct.Default, m)
+	y := starlarkstruct.FromStringDict(starlarkstruct.Default, m)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := x.CompareSameType(syntax.EQL, y, 40)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEqual_4(b *testing.B)   { benchmarkEqual(b, 4) }
+func BenchmarkEqual_8(b *testing.B)   { benchmarkEqual(b, 8) }
+func BenchmarkEqual_16(b *testing.B)  { benchmarkEqual(b, 16) }
+func BenchmarkEqual_32(b *testing.B)  { benchmarkEqual(b, 32) }
+func BenchmarkEqual_64(b *testing.B)  { benchmarkEqual(b, 64) }
+func BenchmarkEqual_128(b *testing.B) { benchmarkEqual(b, 128) }


### PR DESCRIPTION
Wraps starlark.StringDict for storing fields.
Improves the performance on the `Attr` method for accessing fields.

I added a benchmark to check the happy path for access to a fields value.

OLD:
BenchmarkAttr_4-4       44931932                24.03 ns/op
BenchmarkAttr_8-4       39342510                28.64 ns/op
BenchmarkAttr_16-4      33596271                32.18 ns/op
BenchmarkAttr_32-4      30505212                37.62 ns/op
BenchmarkAttr_64-4      24424558                43.33 ns/op
BenchmarkAttr_128-4     17947136                64.29 ns/op

NEW:
BenchmarkAttr_4-4       48772784                21.45 ns/op
BenchmarkAttr_8-4       34554286                30.95 ns/op
BenchmarkAttr_16-4      56185027                19.59 ns/op
BenchmarkAttr_32-4      58317289                19.60 ns/op
BenchmarkAttr_64-4      58073444                20.30 ns/op
BenchmarkAttr_128-4     52069291                21.30 ns/op