### PR TITLE
starlark: remove allocs on Dict ranges for dictsEqual and write

### DIFF
--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -60,3 +60,11 @@ def bench_mix(b):
             if i:
                 x += 1
             a = [x for x in range(i)]
+
+largedict = {str(v): v for v in range(1000)}
+
+def bench_dict_equal(b):
+    "Benchmark of dict equality operation."
+    for _ in range(b.n):
+        if largedict != largedict:
+            fail("invalid comparison")

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -816,8 +816,8 @@ func dictsEqual(x, y *Dict, depth int) (bool, error) {
 	if x.Len() != y.Len() {
 		return false, nil
 	}
-	for _, xitem := range x.Items() {
-		key, xval := xitem[0], xitem[1]
+	for e := x.ht.head; e != nil; e = e.next {
+		key, xval := e.key, e.value
 
 		if yval, found, _ := y.Get(key); !found {
 			return false, nil
@@ -1185,8 +1185,8 @@ func writeValue(out *strings.Builder, x Value, path []Value) {
 			out.WriteString("...") // dict contains itself
 		} else {
 			sep := ""
-			for _, item := range x.Items() {
-				k, v := item[0], item[1]
+			for e := x.ht.head; e != nil; e = e.next {
+				k, v := e.key, e.value
 				out.WriteString(sep)
 				writeValue(out, k, path)
 				out.WriteString(": ")


### PR DESCRIPTION
Drops Items() range in favour of looking through the hashtable list
directly. This avoids an allocation, added a benchmark to verify.

Old:
Benchmark/bench_dict_equal-4               18782             61652 ns/op           57344 B/op          2 allocs/op

New:
Benchmark/bench_dict_equal-4               29802             39585 ns/op               0 B/op          0 allocs/op