### PR TITLE
starlark: set internal iteration use hashtable linked lists

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1066,12 +1066,9 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // intersection
 			if y, ok := y.(*Set); ok {
-				var set *Set
-				if xl, yl := x.Len(), y.Len(); xl > yl {
+				set := new(Set)
+				if x.Len() > y.Len() {
 					x, y = y, x // opt: range over smaller set
-					set = NewSet(xl)
-				} else {
-					set = NewSet(yl)
 				}
 				for xe := x.ht.head; xe != nil; xe = xe.next {
 					// Has, Insert cannot fail here.
@@ -1091,7 +1088,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // symmetric difference
 			if y, ok := y.(*Set); ok {
-				set := NewSet(x.Len() + y.Len())
+				set := new(Set)
 				for xe := x.ht.head; xe != nil; xe = xe.next {
 					if found, _ := y.Has(xe.key); !found {
 						set.Insert(xe.key)

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1066,14 +1066,17 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // intersection
 			if y, ok := y.(*Set); ok {
-				set := new(Set)
-				if x.Len() > y.Len() {
+				var set *Set
+				if xl, yl := x.Len(), y.Len(); xl > yl {
 					x, y = y, x // opt: range over smaller set
+					set = NewSet(xl)
+				} else {
+					set = NewSet(yl)
 				}
-				for _, xelem := range x.elems() {
+				for xe := x.ht.head; xe != nil; xe = xe.next {
 					// Has, Insert cannot fail here.
-					if found, _ := y.Has(xelem); found {
-						set.Insert(xelem)
+					if found, _ := y.Has(xe.key); found {
+						set.Insert(xe.key)
 					}
 				}
 				return set, nil
@@ -1088,15 +1091,15 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // symmetric difference
 			if y, ok := y.(*Set); ok {
-				set := new(Set)
-				for _, xelem := range x.elems() {
-					if found, _ := y.Has(xelem); !found {
-						set.Insert(xelem)
+				set := NewSet(x.Len() + y.Len())
+				for xe := x.ht.head; xe != nil; xe = xe.next {
+					if found, _ := y.Has(xe.key); !found {
+						set.Insert(xe.key)
 					}
 				}
-				for _, yelem := range y.elems() {
-					if found, _ := x.Has(yelem); !found {
-						set.Insert(yelem)
+				for ye := y.ht.head; ye != nil; ye = ye.next {
+					if found, _ := x.Has(ye.key); !found {
+						set.Insert(ye.key)
 					}
 				}
 				return set, nil

--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -66,16 +66,9 @@ func (ht *hashtable) init(size int) {
 func (ht *hashtable) freeze() {
 	if !ht.frozen {
 		ht.frozen = true
-		for i := range ht.table {
-			for p := &ht.table[i]; p != nil; p = p.next {
-				for i := range p.entries {
-					e := &p.entries[i]
-					if e.hash != 0 {
-						e.key.Freeze()
-						e.value.Freeze()
-					}
-				}
-			}
+		for e := ht.head; e != nil; e = e.next {
+			e.key.Freeze()
+			e.value.Freeze()
 		}
 	}
 }

--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -1,4 +1,5 @@
 # Benchmarks of Starlark execution
+# option:set
 
 def bench_range_construction(b):
     for _ in range(b.n):
@@ -67,6 +68,14 @@ def bench_dict_equal(b):
     "Benchmark of dict equality operation."
     for _ in range(b.n):
         if largedict != largedict:
+            fail("invalid comparison")
+
+largeset = set([v for v in range(1000)])
+
+def bench_set_equal(b):
+    "Benchmark of set union operation."
+    for _ in range(b.n):
+        if largeset != largeset:
             fail("invalid comparison")
 
 flat = { "int": 1, "float": 0.2, "string": "string", "list": [], "bool": True, "nil": None, "tuple": (1, 2, 3) }

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -7,35 +7,35 @@
 // Starlark values are represented by the Value interface.
 // The following built-in Value types are known to the evaluator:
 //
-//      NoneType        -- NoneType
-//      Bool            -- bool
-//      Bytes           -- bytes
-//      Int             -- int
-//      Float           -- float
-//      String          -- string
-//      *List           -- list
-//      Tuple           -- tuple
-//      *Dict           -- dict
-//      *Set            -- set
-//      *Function       -- function (implemented in Starlark)
-//      *Builtin        -- builtin_function_or_method (function or method implemented in Go)
+//	NoneType        -- NoneType
+//	Bool            -- bool
+//	Bytes           -- bytes
+//	Int             -- int
+//	Float           -- float
+//	String          -- string
+//	*List           -- list
+//	Tuple           -- tuple
+//	*Dict           -- dict
+//	*Set            -- set
+//	*Function       -- function (implemented in Starlark)
+//	*Builtin        -- builtin_function_or_method (function or method implemented in Go)
 //
 // Client applications may define new data types that satisfy at least
 // the Value interface.  Such types may provide additional operations by
 // implementing any of these optional interfaces:
 //
-//      Callable        -- value is callable like a function
-//      Comparable      -- value defines its own comparison operations
-//      Iterable        -- value is iterable using 'for' loops
-//      Sequence        -- value is iterable sequence of known length
-//      Indexable       -- value is sequence with efficient random access
-//      Mapping         -- value maps from keys to values, like a dictionary
-//      HasBinary       -- value defines binary operations such as * and +
-//      HasAttrs        -- value has readable fields or methods x.f
-//      HasSetField     -- value has settable fields x.f
-//      HasSetIndex     -- value supports element update using x[i]=y
-//      HasSetKey       -- value supports map update using x[k]=v
-//      HasUnary        -- value defines unary operations such as + and -
+//	Callable        -- value is callable like a function
+//	Comparable      -- value defines its own comparison operations
+//	Iterable        -- value is iterable using 'for' loops
+//	Sequence        -- value is iterable sequence of known length
+//	Indexable       -- value is sequence with efficient random access
+//	Mapping         -- value maps from keys to values, like a dictionary
+//	HasBinary       -- value defines binary operations such as * and +
+//	HasAttrs        -- value has readable fields or methods x.f
+//	HasSetField     -- value has settable fields x.f
+//	HasSetIndex     -- value supports element update using x[i]=y
+//	HasSetKey       -- value supports map update using x[k]=v
+//	HasUnary        -- value defines unary operations such as + and -
 //
 // Client applications may also define domain-specific functions in Go
 // and make them available to Starlark programs.  Use NewBuiltin to
@@ -63,7 +63,6 @@
 // through Starlark code and into callbacks.  When evaluation fails it
 // returns an EvalError from which the application may obtain a
 // backtrace of active Starlark calls.
-//
 package starlark // import "go.starlark.net/starlark"
 
 // This file defines the data types of Starlark and their basic operations.
@@ -229,13 +228,12 @@ var (
 //
 // Example usage:
 //
-// 	iter := iterable.Iterator()
+//	iter := iterable.Iterator()
 //	defer iter.Done()
 //	var x Value
 //	for iter.Next(&x) {
 //		...
 //	}
-//
 type Iterator interface {
 	// If the iterator is exhausted, Next returns false.
 	// Otherwise it sets *p to the current element of the sequence,
@@ -276,7 +274,7 @@ type HasSetKey interface {
 var _ HasSetKey = (*Dict)(nil)
 
 // A HasBinary value may be used as either operand of these binary operators:
-//     +   -   *   /   //   %   in   not in   |   &   ^   <<   >>
+// +   -   *   /   //   %   in   not in   |   &   ^   <<   >>
 //
 // The Side argument indicates whether the receiver is the left or right operand.
 //
@@ -296,7 +294,7 @@ const (
 )
 
 // A HasUnary value may be used as the operand of these unary operators:
-//     +   -   ~
+// +   -   ~
 //
 // An implementation may decline to handle an operation by returning (nil, nil).
 // For this reason, clients should always call the standalone Unary(op, x)
@@ -782,13 +780,12 @@ func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kw
 // In the example below, the value of f is the string.index
 // built-in method bound to the receiver value "abc":
 //
-//     f = "abc".index; f("a"); f("b")
+//	f = "abc".index; f("a"); f("b")
 //
 // In the common case, the receiver is bound only during the call,
 // but this still results in the creation of a temporary method closure:
 //
-//     "abc".index("a")
-//
+//	"abc".index("a")
 func (b *Builtin) BindReceiver(recv Value) *Builtin {
 	return &Builtin{name: b.name, fn: b.fn, recv: recv}
 }
@@ -1127,7 +1124,7 @@ func setsEqual(x, y *Set, depth int) (bool, error) {
 }
 
 func (s *Set) Union(iter Iterator) (Value, error) {
-	set := NewSet(s.Len())
+	set := new(Set)
 	for e := s.ht.head; e != nil; e = e.next {
 		set.Insert(e.key) // can't fail
 	}


### PR DESCRIPTION
Removes allocations on Set operations. Added a single benchmark testing
 equality, should improve other set operations too.

Old:
Benchmark/bench_set_equal-8                35050             34043 ns/op           16384 B/op          1 allocs/op

New:
Benchmark/bench_set_equal-8                41312             28884 ns/op               0 B/op          0 allocs/op