### PR TITLE
Add a OnMaxSteps optional handler to Thread (#410)

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -47,9 +47,8 @@ type Thread struct {
 	// See example_test.go for some example implementations of Load.
 	Load func(thread *Thread, module string) (StringDict, error)
 
-	// OnMaxSteps is a way to hook the behavior that will happen when
-	// maxSteps, settable via SetMaxExecutionSteps, is reached. The default
-	// behavior is to call thread.Cancel("too many steps").
+	// OnMaxSteps is called when the thread reaches the limit set by SetMaxExecutionSteps.
+	// The default behavior is to call thread.Cancel("too many steps").
 	OnMaxSteps func(thread *Thread)
 
 	// steps counts abstract computation steps executed by this thread.

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -47,6 +47,11 @@ type Thread struct {
 	// See example_test.go for some example implementations of Load.
 	Load func(thread *Thread, module string) (StringDict, error)
 
+	// OnMaxSteps is a way to hook the behavior that will happen when
+	// maxSteps, settable via SetMaxExecutionSteps, is reached. The default
+	// behavior is to call thread.Cancel("too many steps").
+	OnMaxSteps func(thread *Thread)
+
 	// steps counts abstract computation steps executed by this thread.
 	steps, maxSteps uint64
 
@@ -74,7 +79,8 @@ func (thread *Thread) ExecutionSteps() uint64 {
 // SetMaxExecutionSteps sets a limit on the number of Starlark
 // computation steps that may be executed by this thread. If the
 // thread's step counter exceeds this limit, the interpreter calls
-// thread.Cancel("too many steps").
+// the optional OnMaxSteps function or the default behavior
+// of calling thread.Cancel("too many steps").
 func (thread *Thread) SetMaxExecutionSteps(max uint64) {
 	thread.maxSteps = max
 }

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -89,7 +89,11 @@ loop:
 	for {
 		thread.steps++
 		if thread.steps >= thread.maxSteps {
-			thread.Cancel("too many steps")
+			if thread.OnMaxSteps != nil {
+				thread.OnMaxSteps(thread)
+			} else {
+				thread.Cancel("too many steps")
+			}
 		}
 		if reason := atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&thread.cancelReason))); reason != nil {
 			err = fmt.Errorf("Starlark computation cancelled: %s", *(*string)(reason))


### PR DESCRIPTION
This hook gives someone the ability to intercept and potentially
change the behavior when maxSteps is reached. The default behavior
of canceling is preserved.