### PR TITLE
Fix build instructions for Go 1.18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Build the code:
 ```shell
 # check out the code and dependencies,
 # and install interpreter in $GOPATH/bin
-$ go get -u go.starlark.net/cmd/starlark
+$ go install go.starlark.net/cmd/starlark@latest
 ```
 
 Run the interpreter:


### PR DESCRIPTION
Reference: https://golang.org/doc/go-get-install-deprecation

I’m unable to run the REPL by following the build instructions in the `README.md`, but using `go install` instead of `go get` works for me:
```console
$ podman run --pull always -it --rm docker.io/library/golang:latest
root@445c025009b7:/go# go version
go version go1.18.4 linux/amd64
root@445c025009b7:/go# starlark
bash: starlark: command not found
root@445c025009b7:/go# go get -u go.starlark.net/cmd/starlark
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
root@445c025009b7:/go# go install go.starlark.net/cmd/starlark@latest
go: downloading go.starlark.net v0.0.0-20220714194419-4cadf0a12139
go: downloading github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
go: downloading golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
root@445c025009b7:/go# starlark
Welcome to Starlark (go.starlark.net)
>>> ^D

```