### PR TITLE
Bump go version to 1.19

### DIFF
--- a/docs/update.go
+++ b/docs/update.go
@@ -1,4 +1,5 @@
-//+build ignore
+//go:build ignore
+// +build ignore
 
 // The update command creates/updates the <html><head> elements of
 // each subpackage beneath docs so that "go get" requests redirect
@@ -6,9 +7,8 @@
 //
 // Usage:
 //
-//   $ cd $GOPATH/src/go.starlark.net
-//   $ go run docs/update.go
-//
+//	$ cd $GOPATH/src/go.starlark.net
+//	$ go run docs/update.go
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,15 @@ module go.starlark.net
 go 1.19
 
 require (
-	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	github.com/google/go-cmp v0.5.1 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0
+)
+
+require (
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/google/go-cmp v0.5.1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.starlark.net
 
-go 1.13
+go 1.19
 
 require (
 	github.com/chzyer/logex v1.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,7 +43,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=

--- a/internal/chunkedfile/chunkedfile.go
+++ b/internal/chunkedfile/chunkedfile.go
@@ -13,10 +13,10 @@
 //
 // Example:
 //
-//      x = 1 / 0 ### "division by zero"
-//      ---
-//      x = 1
-//      print(x + "") ### "int + string not supported"
+//	x = 1 / 0 ### "division by zero"
+//	---
+//	x = 1
+//	print(x + "") ### "int + string not supported"
 //
 // A client test feeds each chunk of text into the program under test,
 // then calls chunk.GotError for each error that actually occurred.  Any

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -23,7 +23,6 @@
 //
 // Operands, logically uint32s, are encoded using little-endian 7-bit
 // varints, the top bit indicating that more bytes follow.
-//
 package compile // import "go.starlark.net/internal/compile"
 
 import (

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -25,29 +25,30 @@ import (
 
 // Module json is a Starlark module of JSON-related functions.
 //
-//   json = module(
-//      encode,
-//      decode,
-//      indent,
-//   )
+//	json = module(
+//	   encode,
+//	   decode,
+//	   indent,
+//	)
 //
 // def encode(x):
 //
 // The encode function accepts one required positional argument,
 // which it converts to JSON by cases:
-// - A Starlark value that implements Go's standard json.Marshal
-//   interface defines its own JSON encoding.
-// - None, True, and False are converted to null, true, and false, respectively.
-// - Starlark int values, no matter how large, are encoded as decimal integers.
-//   Some decoders may not be able to decode very large integers.
-// - Starlark float values are encoded using decimal point notation,
-//   even if the value is an integer.
-//   It is an error to encode a non-finite floating-point value.
-// - Starlark strings are encoded as JSON strings, using UTF-16 escapes.
-// - a Starlark IterableMapping (e.g. dict) is encoded as a JSON object.
-//   It is an error if any key is not a string.
-// - any other Starlark Iterable (e.g. list, tuple) is encoded as a JSON array.
-// - a Starlark HasAttrs (e.g. struct) is encoded as a JSON object.
+//   - A Starlark value that implements Go's standard json.Marshal
+//     interface defines its own JSON encoding.
+//   - None, True, and False are converted to null, true, and false, respectively.
+//   - Starlark int values, no matter how large, are encoded as decimal integers.
+//     Some decoders may not be able to decode very large integers.
+//   - Starlark float values are encoded using decimal point notation,
+//     even if the value is an integer.
+//     It is an error to encode a non-finite floating-point value.
+//   - Starlark strings are encoded as JSON strings, using UTF-16 escapes.
+//   - a Starlark IterableMapping (e.g. dict) is encoded as a JSON object.
+//     It is an error if any key is not a string.
+//   - any other Starlark Iterable (e.g. list, tuple) is encoded as a JSON array.
+//   - a Starlark HasAttrs (e.g. struct) is encoded as a JSON object.
+//
 // It an application-defined type matches more than one the cases describe above,
 // (e.g. it implements both Iterable and HasFields), the first case takes precedence.
 // Encoding any other value yields an error.
@@ -56,10 +57,11 @@ import (
 //
 // The decode function accepts one positional parameter, a JSON string.
 // It returns the Starlark value that the string denotes.
-// - Numbers are parsed as int or float, depending on whether they
-//   contain a decimal point.
-// - JSON objects are parsed as new unfrozen Starlark dicts.
-// - JSON arrays are parsed as new unfrozen Starlark lists.
+//   - Numbers are parsed as int or float, depending on whether they
+//     contain a decimal point.
+//   - JSON objects are parsed as new unfrozen Starlark dicts.
+//   - JSON arrays are parsed as new unfrozen Starlark lists.
+//
 // Decoding fails if x is not a valid JSON string.
 //
 // def indent(str, *, prefix="", indent="\t"):
@@ -69,7 +71,6 @@ import (
 // It accepts one required positional parameter, the JSON string,
 // and two optional keyword-only string parameters, prefix and indent,
 // that specify a prefix of each new line, and the unit of indentation.
-//
 var Module = &starlarkstruct.Module{
 	Name: "json",
 	Members: starlark.StringDict{

--- a/lib/math/math.go
+++ b/lib/math/math.go
@@ -17,53 +17,52 @@ import (
 // Module math is a Starlark module of math-related functions and constants.
 // The module defines the following functions:
 //
-//     ceil(x) - Returns the ceiling of x, the smallest integer greater than or equal to x.
-//     copysign(x, y) - Returns a value with the magnitude of x and the sign of y.
-//     fabs(x) - Returns the absolute value of x as float.
-//     floor(x) - Returns the floor of x, the largest integer less than or equal to x.
-//     mod(x, y) - Returns the floating-point remainder of x/y. The magnitude of the result is less than y and its sign agrees with that of x.
-//     pow(x, y) - Returns x**y, the base-x exponential of y.
-//     remainder(x, y) - Returns the IEEE 754 floating-point remainder of x/y.
-//     round(x) - Returns the nearest integer, rounding half away from zero.
+//	ceil(x) - Returns the ceiling of x, the smallest integer greater than or equal to x.
+//	copysign(x, y) - Returns a value with the magnitude of x and the sign of y.
+//	fabs(x) - Returns the absolute value of x as float.
+//	floor(x) - Returns the floor of x, the largest integer less than or equal to x.
+//	mod(x, y) - Returns the floating-point remainder of x/y. The magnitude of the result is less than y and its sign agrees with that of x.
+//	pow(x, y) - Returns x**y, the base-x exponential of y.
+//	remainder(x, y) - Returns the IEEE 754 floating-point remainder of x/y.
+//	round(x) - Returns the nearest integer, rounding half away from zero.
 //
-//     exp(x) - Returns e raised to the power x, where e = 2.718281… is the base of natural logarithms.
-//     sqrt(x) - Returns the square root of x.
+//	exp(x) - Returns e raised to the power x, where e = 2.718281… is the base of natural logarithms.
+//	sqrt(x) - Returns the square root of x.
 //
-//     acos(x) - Returns the arc cosine of x, in radians.
-//     asin(x) - Returns the arc sine of x, in radians.
-//     atan(x) - Returns the arc tangent of x, in radians.
-//     atan2(y, x) - Returns atan(y / x), in radians.
-//                   The result is between -pi and pi.
-//                   The vector in the plane from the origin to point (x, y) makes this angle with the positive X axis.
-//                   The point of atan2() is that the signs of both inputs are known to it, so it can compute the correct
-//                   quadrant for the angle.
-//                   For example, atan(1) and atan2(1, 1) are both pi/4, but atan2(-1, -1) is -3*pi/4.
-//     cos(x) - Returns the cosine of x, in radians.
-//     hypot(x, y) - Returns the Euclidean norm, sqrt(x*x + y*y). This is the length of the vector from the origin to point (x, y).
-//     sin(x) - Returns the sine of x, in radians.
-//     tan(x) - Returns the tangent of x, in radians.
+//	acos(x) - Returns the arc cosine of x, in radians.
+//	asin(x) - Returns the arc sine of x, in radians.
+//	atan(x) - Returns the arc tangent of x, in radians.
+//	atan2(y, x) - Returns atan(y / x), in radians.
+//	              The result is between -pi and pi.
+//	              The vector in the plane from the origin to point (x, y) makes this angle with the positive X axis.
+//	              The point of atan2() is that the signs of both inputs are known to it, so it can compute the correct
+//	              quadrant for the angle.
+//	              For example, atan(1) and atan2(1, 1) are both pi/4, but atan2(-1, -1) is -3*pi/4.
+//	cos(x) - Returns the cosine of x, in radians.
+//	hypot(x, y) - Returns the Euclidean norm, sqrt(x*x + y*y). This is the length of the vector from the origin to point (x, y).
+//	sin(x) - Returns the sine of x, in radians.
+//	tan(x) - Returns the tangent of x, in radians.
 //
-//     degrees(x) - Converts angle x from radians to degrees.
-//     radians(x) - Converts angle x from degrees to radians.
+//	degrees(x) - Converts angle x from radians to degrees.
+//	radians(x) - Converts angle x from degrees to radians.
 //
-//     acosh(x) - Returns the inverse hyperbolic cosine of x.
-//     asinh(x) - Returns the inverse hyperbolic sine of x.
-//     atanh(x) - Returns the inverse hyperbolic tangent of x.
-//     cosh(x) - Returns the hyperbolic cosine of x.
-//     sinh(x) - Returns the hyperbolic sine of x.
-//     tanh(x) - Returns the hyperbolic tangent of x.
+//	acosh(x) - Returns the inverse hyperbolic cosine of x.
+//	asinh(x) - Returns the inverse hyperbolic sine of x.
+//	atanh(x) - Returns the inverse hyperbolic tangent of x.
+//	cosh(x) - Returns the hyperbolic cosine of x.
+//	sinh(x) - Returns the hyperbolic sine of x.
+//	tanh(x) - Returns the hyperbolic tangent of x.
 //
-//     log(x, base) - Returns the logarithm of x in the given base, or natural logarithm by default.
+//	log(x, base) - Returns the logarithm of x in the given base, or natural logarithm by default.
 //
-//     gamma(x) - Returns the Gamma function of x.
+//	gamma(x) - Returns the Gamma function of x.
 //
 // All functions accept both int and float values as arguments.
 //
 // The module also defines approximations of the following constants:
 //
-//     e - The base of natural logarithms, approximately 2.71828.
-//     pi - The ratio of a circle's circumference to its diameter, approximately 3.14159.
-//
+//	e - The base of natural logarithms, approximately 2.71828.
+//	pi - The ratio of a circle's circumference to its diameter, approximately 3.14159.
 var Module = &starlarkstruct.Module{
 	Name: "math",
 	Members: starlark.StringDict{
@@ -146,7 +145,8 @@ func newBinaryBuiltin(name string, fn func(float64, float64) float64) *starlark.
 	})
 }
 
-//  log wraps the Log function
+//	log wraps the Log function
+//
 // as a Starlark built-in that accepts int or float arguments.
 func log(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -9,21 +9,21 @@
 //
 // This package defines several types of Starlark value:
 //
-//      Message                 -- a protocol message
-//      RepeatedField           -- a repeated field of a message, like a list
+//	Message                 -- a protocol message
+//	RepeatedField           -- a repeated field of a message, like a list
 //
-//      FileDescriptor          -- information about a .proto file
-//      FieldDescriptor         -- information about a message field (or extension field)
-//      MessageDescriptor       -- information about the type of a message
-//      EnumDescriptor          -- information about an enumerated type
-//      EnumValueDescriptor     -- a value of an enumerated type
+//	FileDescriptor          -- information about a .proto file
+//	FieldDescriptor         -- information about a message field (or extension field)
+//	MessageDescriptor       -- information about the type of a message
+//	EnumDescriptor          -- information about an enumerated type
+//	EnumValueDescriptor     -- a value of an enumerated type
 //
 // A Message value is a wrapper around a protocol message instance.
 // Starlark programs may access and update Messages using dot notation:
 //
-//      x = msg.field
-//      msg.field = x + 1
-//      msg.field += 1
+//	x = msg.field
+//	msg.field = x + 1
+//	msg.field += 1
 //
 // Assignments to message fields perform dynamic checks on the type and
 // range of the value to ensure that the message is at all times valid.
@@ -35,31 +35,30 @@
 // performs a dynamic check to ensure that the RepeatedField holds
 // only elements of the correct type.
 //
-//      type(msg.uint32s)       # "proto.repeated<uint32>"
-//      msg.uint32s[0] = 1
-//      msg.uint32s[0] = -1     # error: invalid uint32: -1
+//	type(msg.uint32s)       # "proto.repeated<uint32>"
+//	msg.uint32s[0] = 1
+//	msg.uint32s[0] = -1     # error: invalid uint32: -1
 //
 // Any iterable may be assigned to a repeated field of a message.  If
 // the iterable is itself a value of type RepeatedField, the message
 // field holds a reference to it.
 //
-//      msg2.uint32s = msg.uint32s      # both messages share one RepeatedField
-//      msg.uint32s[0] = 123
-//      print(msg2.uint32s[0])          # "123"
+//	msg2.uint32s = msg.uint32s      # both messages share one RepeatedField
+//	msg.uint32s[0] = 123
+//	print(msg2.uint32s[0])          # "123"
 //
 // The RepeatedFields' element types must match.
 // It is not enough for the values to be merely valid:
 //
-//      msg.uint32s = [1, 2, 3]         # makes a copy
-//      msg.uint64s = msg.uint32s       # error: repeated field has wrong type
-//      msg.uint64s = list(msg.uint32s) # ok; makes a copy
+//	msg.uint32s = [1, 2, 3]         # makes a copy
+//	msg.uint64s = msg.uint32s       # error: repeated field has wrong type
+//	msg.uint64s = list(msg.uint32s) # ok; makes a copy
 //
 // For all other iterables, a new RepeatedField is constructed from the
 // elements of the iterable.
 //
-//      msg.uints32s = [1, 2, 3]
-//      print(type(msg.uints32s))       # "proto.repeated<uint32>"
-//
+//	msg.uints32s = [1, 2, 3]
+//	print(type(msg.uints32s))       # "proto.repeated<uint32>"
 //
 // To construct a Message from encoded binary or text data, call
 // Unmarshal or UnmarshalText.  These two functions are exposed to
@@ -75,7 +74,6 @@
 //
 // See proto_test.go for an example of how to use the 'proto'
 // module in an application that embeds Starlark.
-//
 package proto
 
 // TODO(adonovan): Go and Starlark API improvements:
@@ -111,8 +109,8 @@ import (
 // for a Starlark thread to use this package.
 //
 // For example:
-//	SetPool(thread, protoregistry.GlobalFiles)
 //
+//	SetPool(thread, protoregistry.GlobalFiles)
 func SetPool(thread *starlark.Thread, pool DescriptorPool) {
 	thread.SetLocal(contextKey, pool)
 }
@@ -305,10 +303,9 @@ func getFieldStarlark(thread *starlark.Thread, fn *starlark.Builtin, args starla
 // When a message descriptor is called, it returns a new instance of the
 // protocol message it describes.
 //
-//      Message(msg)            -- return a shallow copy of an existing message
-//      Message(k=v, ...)       -- return a new message with the specified fields
-//      Message(dict(...))      -- return a new message with the specified fields
-//
+//	Message(msg)            -- return a shallow copy of an existing message
+//	Message(k=v, ...)       -- return a new message with the specified fields
+//	Message(dict(...))      -- return a new message with the specified fields
 func (d MessageDescriptor) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	dest := &Message{
 		msg:    newMessage(d.Desc),
@@ -1180,11 +1177,10 @@ func enumValueOf(enum protoreflect.EnumDescriptor, x starlark.Value) (protorefle
 //
 // An EnumValueDescriptor has the following fields:
 //
-//      index   -- int, index of this value within the enum sequence
-//      name    -- string, name of this enum value
-//      number  -- int, numeric value of this enum value
-//      type    -- EnumDescriptor, the enum type to which this value belongs
-//
+//	index   -- int, index of this value within the enum sequence
+//	name    -- string, name of this enum value
+//	number  -- int, numeric value of this enum value
+//	type    -- EnumDescriptor, the enum type to which this value belongs
 type EnumValueDescriptor struct {
 	Desc protoreflect.EnumValueDescriptor
 }

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -18,37 +18,37 @@ import (
 // Module time is a Starlark module of time-related functions and constants.
 // The module defines the following functions:
 //
-//     from_timestamp(sec, nsec) - Converts the given Unix time corresponding to the number of seconds
-//                                 and (optionally) nanoseconds since January 1, 1970 UTC into an object
-//                                 of type Time. For more details, refer to https://pkg.go.dev/time#Unix.
+//	    from_timestamp(sec, nsec) - Converts the given Unix time corresponding to the number of seconds
+//	                                and (optionally) nanoseconds since January 1, 1970 UTC into an object
+//	                                of type Time. For more details, refer to https://pkg.go.dev/time#Unix.
 //
-//     is_valid_timezone(loc) - Reports whether loc is a valid time zone name.
+//	    is_valid_timezone(loc) - Reports whether loc is a valid time zone name.
 //
-//     now() - Returns the current local time. Applications may replace this function by a deterministic one.
+//	    now() - Returns the current local time. Applications may replace this function by a deterministic one.
 //
-//     parse_duration(d) - Parses the given duration string. For more details, refer to
-//                         https://pkg.go.dev/time#ParseDuration.
+//	    parse_duration(d) - Parses the given duration string. For more details, refer to
+//	                        https://pkg.go.dev/time#ParseDuration.
 //
-//     parseTime(x, format, location) - Parses the given time string using a specific time format and location.
-//                                      The expected arguments are a time string (mandatory), a time format
-//                                      (optional, set to RFC3339 by default, e.g. "2021-03-22T23:20:50.52Z")
-//                                      and a name of location (optional, set to UTC by default). For more details,
-//                                      refer to https://pkg.go.dev/time#Parse and https://pkg.go.dev/time#ParseInLocation.
+//	    parseTime(x, format, location) - Parses the given time string using a specific time format and location.
+//	                                     The expected arguments are a time string (mandatory), a time format
+//	                                     (optional, set to RFC3339 by default, e.g. "2021-03-22T23:20:50.52Z")
+//	                                     and a name of location (optional, set to UTC by default). For more details,
+//	                                     refer to https://pkg.go.dev/time#Parse and https://pkg.go.dev/time#ParseInLocation.
 //
-//     time(year, month, day, hour, minute, second, nanosecond, location) - Returns the Time corresponding to
-//	                                                                        yyyy-mm-dd hh:mm:ss + nsec nanoseconds
-//                                                                          in the appropriate zone for that time
-//                                                                          in the given location. All the parameters
-//                                                                          are optional.
+//	    time(year, month, day, hour, minute, second, nanosecond, location) - Returns the Time corresponding to
+//		                                                                        yyyy-mm-dd hh:mm:ss + nsec nanoseconds
+//	                                                                         in the appropriate zone for that time
+//	                                                                         in the given location. All the parameters
+//	                                                                         are optional.
+//
 // The module also defines the following constants:
 //
-//     nanosecond - A duration representing one nanosecond.
-//     microsecond - A duration representing one microsecond.
-//     millisecond - A duration representing one millisecond.
-//     second - A duration representing one second.
-//     minute - A duration representing one minute.
-//     hour - A duration representing one hour.
-//
+//	nanosecond - A duration representing one nanosecond.
+//	microsecond - A duration representing one microsecond.
+//	millisecond - A duration representing one millisecond.
+//	second - A duration representing one second.
+//	minute - A duration representing one minute.
+//	hour - A duration representing one hour.
 var Module = &starlarkstruct.Module{
 	Name: "time",
 	Members: starlark.StringDict{
@@ -223,14 +223,15 @@ func (d Duration) CompareSameType(op syntax.Token, v starlark.Value, depth int) 
 
 // Binary implements binary operators, which satisfies the starlark.HasBinary
 // interface. operators:
-//    duration + duration = duration
-//    duration + time = time
-//    duration - duration = duration
-//    duration / duration = float
-//    duration / int = duration
-//    duration / float = duration
-//    duration // duration = int
-//    duration * int = duration
+//
+//	duration + duration = duration
+//	duration + time = time
+//	duration - duration = duration
+//	duration / duration = float
+//	duration / int = duration
+//	duration / float = duration
+//	duration // duration = int
+//	duration * int = duration
 func (d Duration) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
 	x := time.Duration(d)
 
@@ -330,6 +331,7 @@ func newTime(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, 
 }
 
 // String returns the time formatted using the format string
+//
 //	"2006-01-02 15:04:05.999999999 -0700 MST".
 func (t Time) String() string { return time.Time(t).String() }
 
@@ -408,9 +410,10 @@ func (t Time) CompareSameType(op syntax.Token, yV starlark.Value, depth int) (bo
 
 // Binary implements binary operators, which satisfies the starlark.HasBinary
 // interface
-//    time + duration = time
-//    time - duration = time
-//    time - time = duration
+//
+//	time + duration = time
+//	time - duration = time
+//	time - time = duration
 func (t Time) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
 	x := time.Time(t)
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -33,7 +33,6 @@ var interrupted = make(chan os.Signal, 1)
 // variable named "context" to a context.Context that is cancelled by a
 // SIGINT (Control-C). Client-supplied global functions may use this
 // context to make long-running operations interruptable.
-//
 func REPL(thread *starlark.Thread, globals starlark.StringDict) {
 	signal.Notify(interrupted, os.Interrupt)
 	defer signal.Stop(interrupted)

--- a/starlark/bench_test.go
+++ b/starlark/bench_test.go
@@ -60,9 +60,9 @@ func BenchmarkStarlark(b *testing.B) {
 // It provides b.n, the number of iterations that must be executed by the function,
 // which is typically of the form:
 //
-//   def bench_foo(b):
-//      for _ in range(b.n):
-//         ...work...
+//	def bench_foo(b):
+//	   for _ in range(b.n):
+//	      ...work...
 //
 // It also provides stop, start, and restart methods to stop the clock in case
 // there is significant set-up work that should not count against the measured

--- a/starlark/profile.go
+++ b/starlark/profile.go
@@ -363,19 +363,19 @@ func profile(w io.Writer) {
 // monotonic system clock, which there is no portable way to access.
 // Should that function ever go away, these alternatives exist:
 //
-// 	// POSIX only. REALTIME not MONOTONIC. 17ns.
-// 	var tv syscall.Timeval
-// 	syscall.Gettimeofday(&tv) // can't fail
-// 	return tv.Nano()
+//		// POSIX only. REALTIME not MONOTONIC. 17ns.
+//		var tv syscall.Timeval
+//		syscall.Gettimeofday(&tv) // can't fail
+//		return tv.Nano()
 //
-// 	// Portable. REALTIME not MONOTONIC. 46ns.
-// 	return time.Now().Nanoseconds()
+//		// Portable. REALTIME not MONOTONIC. 46ns.
+//		return time.Now().Nanoseconds()
 //
-//      // POSIX only. Adds a dependency.
-//	import "golang.org/x/sys/unix"
-//	var ts unix.Timespec
-// 	unix.ClockGettime(CLOCK_MONOTONIC, &ts) // can't fail
-//	return unix.TimespecToNsec(ts)
+//	     // POSIX only. Adds a dependency.
+//		import "golang.org/x/sys/unix"
+//		var ts unix.Timespec
+//		unix.ClockGettime(CLOCK_MONOTONIC, &ts) // can't fail
+//		return unix.TimespecToNsec(ts)
 //
 //go:linkname nanotime runtime.nanotime
 func nanotime() int64

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -44,23 +44,23 @@ type Unpacker interface {
 //
 // Examples:
 //
-//      var (
-//          a Value
-//          b = MakeInt(42)
-//          c Value = starlark.None
-//      )
+//	var (
+//	    a Value
+//	    b = MakeInt(42)
+//	    c Value = starlark.None
+//	)
 //
-//      // 1. mixed parameters, like def f(a, b=42, c=None).
-//      err := UnpackArgs("f", args, kwargs, "a", &a, "b?", &b, "c?", &c)
+//	// 1. mixed parameters, like def f(a, b=42, c=None).
+//	err := UnpackArgs("f", args, kwargs, "a", &a, "b?", &b, "c?", &c)
 //
-//      // 2. keyword parameters only, like def f(*, a, b, c=None).
-//      if len(args) > 0 {
-//              return fmt.Errorf("f: unexpected positional arguments")
-//      }
-//      err := UnpackArgs("f", args, kwargs, "a", &a, "b?", &b, "c?", &c)
+//	// 2. keyword parameters only, like def f(*, a, b, c=None).
+//	if len(args) > 0 {
+//	        return fmt.Errorf("f: unexpected positional arguments")
+//	}
+//	err := UnpackArgs("f", args, kwargs, "a", &a, "b?", &b, "c?", &c)
 //
-//      // 3. positional parameters only, like def f(a, b=42, c=None, /) in Python 3.8.
-//      err := UnpackPositionalArgs("f", args, kwargs, 1, &a, &b, &c)
+//	// 3. positional parameters only, like def f(a, b=42, c=None, /) in Python 3.8.
+//	err := UnpackPositionalArgs("f", args, kwargs, 1, &a, &b, &c)
 //
 // More complex forms such as def f(a, b=42, *args, c, d=123, **kwargs)
 // require additional logic, but their need in built-ins is exceedingly rare.
@@ -79,17 +79,16 @@ type Unpacker interface {
 // for the zero values of variables of type *List, *Dict, Callable, or
 // Iterable. For example:
 //
-//      // def myfunc(d=None, e=[], f={})
-//      var (
-//          d Value
-//          e *List
-//          f *Dict
-//      )
-//      err := UnpackArgs("myfunc", args, kwargs, "d?", &d, "e?", &e, "f?", &f)
-//      if d == nil { d = None; }
-//      if e == nil { e = new(List); }
-//      if f == nil { f = new(Dict); }
-//
+//	// def myfunc(d=None, e=[], f={})
+//	var (
+//	    d Value
+//	    e *List
+//	    f *Dict
+//	)
+//	err := UnpackArgs("myfunc", args, kwargs, "d?", &d, "e?", &e, "f?", &f)
+//	if d == nil { d = None; }
+//	if e == nil { e = new(List); }
+//	if f == nil { f = new(Dict); }
 func UnpackArgs(fnname string, args Tuple, kwargs []Tuple, pairs ...interface{}) error {
 	nparams := len(pairs) / 2
 	var defined intset

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -7,35 +7,35 @@
 // Starlark values are represented by the Value interface.
 // The following built-in Value types are known to the evaluator:
 //
-//      NoneType        -- NoneType
-//      Bool            -- bool
-//      Bytes           -- bytes
-//      Int             -- int
-//      Float           -- float
-//      String          -- string
-//      *List           -- list
-//      Tuple           -- tuple
-//      *Dict           -- dict
-//      *Set            -- set
-//      *Function       -- function (implemented in Starlark)
-//      *Builtin        -- builtin_function_or_method (function or method implemented in Go)
+//	NoneType        -- NoneType
+//	Bool            -- bool
+//	Bytes           -- bytes
+//	Int             -- int
+//	Float           -- float
+//	String          -- string
+//	*List           -- list
+//	Tuple           -- tuple
+//	*Dict           -- dict
+//	*Set            -- set
+//	*Function       -- function (implemented in Starlark)
+//	*Builtin        -- builtin_function_or_method (function or method implemented in Go)
 //
 // Client applications may define new data types that satisfy at least
 // the Value interface.  Such types may provide additional operations by
 // implementing any of these optional interfaces:
 //
-//      Callable        -- value is callable like a function
-//      Comparable      -- value defines its own comparison operations
-//      Iterable        -- value is iterable using 'for' loops
-//      Sequence        -- value is iterable sequence of known length
-//      Indexable       -- value is sequence with efficient random access
-//      Mapping         -- value maps from keys to values, like a dictionary
-//      HasBinary       -- value defines binary operations such as * and +
-//      HasAttrs        -- value has readable fields or methods x.f
-//      HasSetField     -- value has settable fields x.f
-//      HasSetIndex     -- value supports element update using x[i]=y
-//      HasSetKey       -- value supports map update using x[k]=v
-//      HasUnary        -- value defines unary operations such as + and -
+//	Callable        -- value is callable like a function
+//	Comparable      -- value defines its own comparison operations
+//	Iterable        -- value is iterable using 'for' loops
+//	Sequence        -- value is iterable sequence of known length
+//	Indexable       -- value is sequence with efficient random access
+//	Mapping         -- value maps from keys to values, like a dictionary
+//	HasBinary       -- value defines binary operations such as * and +
+//	HasAttrs        -- value has readable fields or methods x.f
+//	HasSetField     -- value has settable fields x.f
+//	HasSetIndex     -- value supports element update using x[i]=y
+//	HasSetKey       -- value supports map update using x[k]=v
+//	HasUnary        -- value defines unary operations such as + and -
 //
 // Client applications may also define domain-specific functions in Go
 // and make them available to Starlark programs.  Use NewBuiltin to
@@ -63,7 +63,6 @@
 // through Starlark code and into callbacks.  When evaluation fails it
 // returns an EvalError from which the application may obtain a
 // backtrace of active Starlark calls.
-//
 package starlark // import "go.starlark.net/starlark"
 
 // This file defines the data types of Starlark and their basic operations.
@@ -229,13 +228,12 @@ var (
 //
 // Example usage:
 //
-// 	iter := iterable.Iterator()
+//	iter := iterable.Iterator()
 //	defer iter.Done()
 //	var x Value
 //	for iter.Next(&x) {
 //		...
 //	}
-//
 type Iterator interface {
 	// If the iterator is exhausted, Next returns false.
 	// Otherwise it sets *p to the current element of the sequence,
@@ -276,7 +274,7 @@ type HasSetKey interface {
 var _ HasSetKey = (*Dict)(nil)
 
 // A HasBinary value may be used as either operand of these binary operators:
-//     +   -   *   /   //   %   in   not in   |   &   ^   <<   >>
+//   - -   *   /   //   %   in   not in   |   &   ^   <<   >>
 //
 // The Side argument indicates whether the receiver is the left or right operand.
 //
@@ -296,7 +294,7 @@ const (
 )
 
 // A HasUnary value may be used as the operand of these unary operators:
-//     +   -   ~
+//   - -   ~
 //
 // An implementation may decline to handle an operation by returning (nil, nil).
 // For this reason, clients should always call the standalone Unary(op, x)
@@ -754,13 +752,12 @@ func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kw
 // In the example below, the value of f is the string.index
 // built-in method bound to the receiver value "abc":
 //
-//     f = "abc".index; f("a"); f("b")
+//	f = "abc".index; f("a"); f("b")
 //
 // In the common case, the receiver is bound only during the call,
 // but this still results in the creation of a temporary method closure:
 //
-//     "abc".index("a")
-//
+//	"abc".index("a")
 func (b *Builtin) BindReceiver(recv Value) *Builtin {
 	return &Builtin{name: b.name, fn: b.fn, recv: recv}
 }

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -274,7 +274,7 @@ type HasSetKey interface {
 var _ HasSetKey = (*Dict)(nil)
 
 // A HasBinary value may be used as either operand of these binary operators:
-//   - -   *   /   //   %   in   not in   |   &   ^   <<   >>
+//   +   -   *   /   //   %   in   not in   |   &   ^   <<   >>
 //
 // The Side argument indicates whether the receiver is the left or right operand.
 //
@@ -294,7 +294,7 @@ const (
 )
 
 // A HasUnary value may be used as the operand of these unary operators:
-//   - -   ~
+//   +   -   ~
 //
 // An implementation may decline to handle an operation by returning (nil, nil).
 // For this reason, clients should always call the standalone Unary(op, x)

--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -4,7 +4,6 @@
 
 // Package starlarkstruct defines the Starlark types 'struct' and
 // 'module', both optional language extensions.
-//
 package starlarkstruct // import "go.starlark.net/starlarkstruct"
 
 // It is tempting to introduce a variant of Struct that is a wrapper
@@ -36,10 +35,9 @@ import (
 //
 // An application can add 'struct' to the Starlark environment like so:
 //
-// 	globals := starlark.StringDict{
-// 		"struct":  starlark.NewBuiltin("struct", starlarkstruct.Make),
-// 	}
-//
+//	globals := starlark.StringDict{
+//		"struct":  starlark.NewBuiltin("struct", starlarkstruct.Make),
+//	}
 func Make(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) > 0 {
 		return nil, fmt.Errorf("struct: unexpected positional arguments")

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -275,10 +275,11 @@ func (p *parser) parseSimpleStmt(stmts []Stmt, consumeNL bool) []Stmt {
 }
 
 // small_stmt = RETURN expr?
-//            | PASS | BREAK | CONTINUE
-//            | LOAD ...
-//            | expr ('=' | '+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=') expr   // assign
-//            | expr
+//
+//	| PASS | BREAK | CONTINUE
+//	| LOAD ...
+//	| expr ('=' | '+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=') expr   // assign
+//	| expr
 func (p *parser) parseSmallStmt() Stmt {
 	switch p.tok {
 	case RETURN:
@@ -415,21 +416,23 @@ func (p *parser) consume(t Token) Position {
 }
 
 // params = (param COMMA)* param COMMA?
-//        |
+//
+//	|
 //
 // param = IDENT
-//       | IDENT EQ test
-//       | STAR
-//       | STAR IDENT
-//       | STARSTAR IDENT
+//
+//	| IDENT EQ test
+//	| STAR
+//	| STAR IDENT
+//	| STARSTAR IDENT
 //
 // parseParams parses a parameter list.  The resulting expressions are of the form:
 //
-//      *Ident                                          x
-//      *Binary{Op: EQ, X: *Ident, Y: Expr}             x=y
-//      *Unary{Op: STAR}                                *
-//      *Unary{Op: STAR, X: *Ident}                     *args
-//      *Unary{Op: STARSTAR, X: *Ident}                 **kwargs
+//	*Ident                                          x
+//	*Binary{Op: EQ, X: *Ident, Y: Expr}             x=y
+//	*Unary{Op: STAR}                                *
+//	*Unary{Op: STAR, X: *Ident}                     *args
+//	*Unary{Op: STARSTAR, X: *Ident}                 **kwargs
 func (p *parser) parseParams() []Expr {
 	var params []Expr
 	for p.tok != RPAREN && p.tok != COLON && p.tok != EOF {
@@ -651,9 +654,10 @@ func init() {
 }
 
 // primary_with_suffix = primary
-//                     | primary '.' IDENT
-//                     | primary slice_suffix
-//                     | primary call_suffix
+//
+//	| primary '.' IDENT
+//	| primary slice_suffix
+//	| primary call_suffix
 func (p *parser) parsePrimaryWithSuffix() Expr {
 	x := p.parsePrimary()
 	for {
@@ -770,12 +774,13 @@ func (p *parser) parseArgs() []Expr {
 	return args
 }
 
-//  primary = IDENT
-//          | INT | FLOAT | STRING | BYTES
-//          | '[' ...                    // list literal or comprehension
-//          | '{' ...                    // dict literal or comprehension
-//          | '(' ...                    // tuple or parenthesized expression
-//          | ('-'|'+'|'~') primary_with_suffix
+// primary = IDENT
+//
+//	| INT | FLOAT | STRING | BYTES
+//	| '[' ...                    // list literal or comprehension
+//	| '{' ...                    // dict literal or comprehension
+//	| '(' ...                    // tuple or parenthesized expression
+//	| ('-'|'+'|'~') primary_with_suffix
 func (p *parser) parsePrimary() Expr {
 	switch p.tok {
 	case IDENT:
@@ -836,9 +841,10 @@ func (p *parser) parsePrimary() Expr {
 }
 
 // list = '[' ']'
-//      | '[' expr ']'
-//      | '[' expr expr_list ']'
-//      | '[' expr (FOR loop_variables IN expr)+ ']'
+//
+//	| '[' expr ']'
+//	| '[' expr expr_list ']'
+//	| '[' expr (FOR loop_variables IN expr)+ ']'
 func (p *parser) parseList() Expr {
 	lbrack := p.nextToken()
 	if p.tok == RBRACK {
@@ -865,8 +871,9 @@ func (p *parser) parseList() Expr {
 }
 
 // dict = '{' '}'
-//      | '{' dict_entry_list '}'
-//      | '{' dict_entry FOR loop_variables IN expr '}'
+//
+//	| '{' dict_entry_list '}'
+//	| '{' dict_entry FOR loop_variables IN expr '}'
 func (p *parser) parseDict() Expr {
 	lbrace := p.nextToken()
 	if p.tok == RBRACE {
@@ -904,8 +911,9 @@ func (p *parser) parseDictEntry() *DictEntry {
 }
 
 // comp_suffix = FOR loopvars IN expr comp_suffix
-//             | IF expr comp_suffix
-//             | ']'  or  ')'                              (end)
+//
+//	| IF expr comp_suffix
+//	| ']'  or  ')'                              (end)
 //
 // There can be multiple FOR/IF clauses; the first is always a FOR.
 func (p *parser) parseComprehensionSuffix(lbrace Position, body Expr, endBrace Token) Expr {

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -99,9 +99,10 @@ func (*LoadStmt) stmt()   {}
 func (*ReturnStmt) stmt() {}
 
 // An AssignStmt represents an assignment:
+//
 //	x = 0
 //	x, y = y, x
-// 	x += 1
+//	x += 1
 type AssignStmt struct {
 	commentsRef
 	OpPos Position


### PR DESCRIPTION
The pipeline is already using go1.18 and 1.19, so we'd better to bump go version in go.mod file as well. 

I intentionally created three different commits, see detailed info below.

Steps what I did:
1. Manually updated go version to 1.19 in the go.mod file;  See https://github.com/google/starlark-go/commit/a9d10e312664bb26fae99b0803e189555c981e7a
2. Format all go source file by just executing "`gofmt -w .`". See https://github.com/google/starlark-go/commit/591514d7356a5c3655b02e985b65dfdac248e4a1
3. Update all dependencies by just executing "`go mod tidy`". See https://github.com/google/starlark-go/commit/64f0299a4ab1f5edf81a940824d54ef85793fe16

