### PR TITLE
lib/json: fix trivially broken tests

### DIFF
--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -112,7 +112,7 @@ func encode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 		// cases did not show significant improvement on the benchmarks.
 		if ptr := pointer(x); ptr != nil {
 			if pathContains(path, ptr) {
-				return fmt.Errorf("cycle in json structure")
+				return fmt.Errorf("cycle in JSON structure")
 			}
 
 			path = append(path, ptr)

--- a/starlark/testdata/json.star
+++ b/starlark/testdata/json.star
@@ -39,15 +39,15 @@ encode_error({1: 2}, 'dict has int key, want string')
 
 recursive_map = {}
 recursive_map["r"] = recursive_map
-encode_error(recursive_map, 'json.encode: in dict key "r": Detected cycle in json structure')
+encode_error(recursive_map, 'json.encode: in dict key "r": cycle in JSON structure')
 
 recursive_list = []
 recursive_list.append(recursive_list)
-encode_error(recursive_list, 'json.encode: at list index 0: Detected cycle in json structure')
+encode_error(recursive_list, 'json.encode: at list index 0: cycle in JSON structure')
 
 recursive_tuple = (1, 2, [])
 recursive_tuple[2].append(recursive_tuple)
-encode_error(recursive_tuple, 'json.encode: at tuple index 2: at list index 0: Detected cycle in json structure')
+encode_error(recursive_tuple, 'json.encode: at tuple index 2: at list index 0: cycle in JSON structure')
 
 ## json.decode
 


### PR DESCRIPTION
Also, use uppercase for "JSON" in the same error message.