### PR TITLE
Proposal: Add Function Type Annotation Syntax

### DIFF
--- a/resolve/binding.go
+++ b/resolve/binding.go
@@ -61,10 +61,11 @@ type Module struct {
 // A Function contains resolver information about a named or anonymous function.
 // The resolver populates the Function field of each syntax.DefStmt and syntax.LambdaExpr.
 type Function struct {
-	Pos    syntax.Position // of DEF or LAMBDA
-	Name   string          // name of def, or "lambda"
-	Params []syntax.Expr   // param = ident | ident=expr | * | *ident | **ident
-	Body   []syntax.Stmt   // contains synthetic 'return expr' for lambda
+	Pos        syntax.Position // of DEF or LAMBDA
+	Name       string          // name of def, or "lambda"
+	Params     []syntax.Expr   // param = ident | ident=expr | * | *ident | **ident
+	Body       []syntax.Stmt   // contains synthetic 'return expr' for lambda
+	ReturnType syntax.Expr     // can be nil, type hint expression after '->'
 
 	HasVarargs      bool       // whether params includes *args (convenience)
 	HasKwargs       bool       // whether params includes **kwargs (convenience)

--- a/syntax/grammar.txt
+++ b/syntax/grammar.txt
@@ -6,11 +6,11 @@ File = {Statement | newline} eof .
 
 Statement = DefStmt | IfStmt | ForStmt | WhileStmt | SimpleStmt .
 
-DefStmt = 'def' identifier '(' [Parameters [',']] ')' ':' Suite .
+DefStmt = 'def' identifier '(' [Parameters [',']] ')' ['->' Test] ':' Suite .
 
 Parameters = Parameter {',' Parameter}.
 
-Parameter = identifier | identifier '=' Test | '*' | '*' identifier | '**' identifier .
+Parameter = identifier [':' Test] | identifier [':' Test] '=' Test | '*' | '*' identifier [':' Test] | '**' identifier [':' Test] .
 
 IfStmt = 'if' Test ':' Suite {'elif' Test ':' Suite} ['else' ':' Suite] .
 

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -177,6 +177,9 @@ else:
 			`(DefStmt Name=f Params=(x (UnaryExpr Op=* X=args) (UnaryExpr Op=** X=kwargs)) Body=((BranchStmt Token=pass)))`},
 		{`def f(**kwargs, *args): pass`,
 			`(DefStmt Name=f Params=((UnaryExpr Op=** X=kwargs) (UnaryExpr Op=* X=args)) Body=((BranchStmt Token=pass)))`},
+		{`def f(x, y: str, z: list[str]=None) -> int:
+	pass`,
+			`(DefStmt Name=f Params=(x y (BinaryExpr X=z Op== Y=None)) Body=((BranchStmt Token=pass)) ReturnType=int)`},
 		{`def f(a, b, c=d): pass`,
 			`(DefStmt Name=f Params=(a b (BinaryExpr X=c Op== Y=d)) Body=((BranchStmt Token=pass)))`},
 		{`def f(a, b=c, d): pass`,

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -79,6 +79,7 @@ const (
 	LTLT_EQ       // <<=
 	GTGT_EQ       // >>=
 	STARSTAR      // **
+	ARROW         // ->
 
 	// Keywords
 	AND
@@ -164,6 +165,7 @@ var tokenNames = [...]string{
 	LTLT_EQ:       "<<=",
 	GTGT_EQ:       ">>=",
 	STARSTAR:      "**",
+	ARROW:         "->",
 	AND:           "and",
 	BREAK:         "break",
 	CONTINUE:      "continue",
@@ -772,6 +774,10 @@ start:
 		case '+':
 			return PLUS
 		case '-':
+			if sc.peekRune() == '>' {
+				sc.readRune()
+				return ARROW
+			}
 			return MINUS
 		case '/':
 			if sc.peekRune() == '/' {

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -99,9 +99,10 @@ func (*LoadStmt) stmt()   {}
 func (*ReturnStmt) stmt() {}
 
 // An AssignStmt represents an assignment:
+//
 //	x = 0
 //	x, y = y, x
-// 	x += 1
+//	x += 1
 type AssignStmt struct {
 	commentsRef
 	OpPos Position
@@ -119,10 +120,11 @@ func (x *AssignStmt) Span() (start, end Position) {
 // A DefStmt represents a function definition.
 type DefStmt struct {
 	commentsRef
-	Def    Position
-	Name   *Ident
-	Params []Expr // param = ident | ident=expr | * | *ident | **ident
-	Body   []Stmt
+	Def        Position
+	Name       *Ident
+	Params     []Expr // param = ident | ident=expr | * | *ident | **ident
+	Body       []Stmt
+	ReturnType Expr
 
 	Function interface{} // a *resolve.Function, set by resolver
 }
@@ -238,13 +240,18 @@ func (*UnaryExpr) expr()     {}
 // An Ident represents an identifier.
 type Ident struct {
 	commentsRef
-	NamePos Position
-	Name    string
+	NamePos  Position
+	Name     string
+	TypeHint Expr
 
 	Binding interface{} // a *resolver.Binding, set by resolver
 }
 
 func (x *Ident) Span() (start, end Position) {
+	if x.TypeHint != nil {
+		_, end := x.TypeHint.Span()
+		return x.NamePos, end
+	}
 	return x.NamePos, x.NamePos.add(x.Name)
 }
 


### PR DESCRIPTION

I'd like to re-visit the proposal for python-like function type annotations in starlark, at least in the `starlark-go` implementation. This has been discussed before in:
* https://groups.google.com/g/bazel-dev/c/Pk9VrPCqby0/m/zoOL1IkxEAAJ?pli=1
* https://github.com/bazelbuild/starlark/issues/106
* https://github.com/bazelbuild/buildtools/issues/900

An example of what this looks like in practice:
```python
def func_one(a, b: str, c: list[int]) -> bool:
	pass
```

This proposal is only for function definition type hints. Other kinds (such as assignment annotations) could be discussed, but I believe function annotations provide the most value with least effort, and can be done without changing any runtime semantics. Function type annotation syntax has already been implemented in `buildifier` (https://github.com/bazelbuild/buildtools/pull/946) and `starlark-rust` (https://github.com/facebookexperimental/starlark-rust/blob/main/docs/types.md).

The proposed syntax follows a subset of python type annotations, as well as the same syntax already supported by `buildifier` and `starlark-rust`. Type annotations are `Test` syntax elements, and are parsed as expressions.

```diff
-DefStmt = 'def' identifier '(' [Parameters [',']] ')' ':' Suite .
+DefStmt = 'def' identifier '(' [Parameters [',']] ')' ['->' Test] ':' Suite .

 Parameters = Parameter {',' Parameter}.

-Parameter = identifier | identifier '=' Test | '*' | '*' identifier | '**' identifier .
+Parameter = identifier [':' Test] | identifier [':' Test] '=' Test | '*' | '*' identifier [':' Test] | '**' identifier [':' Test] .
```

## Requirements

- Support function definition type annotations in-line with existing starlark implementations and python syntax.
- Does not change the compiled result of a program. 
- Maintain backwards compatibility with existing starlark code using the starlark-go interpeter and compiler.
- Maintain backwards compatability with existing code using starlark-go to parse and compile starlark code.

## Why Now?

* Other starlark implementations already have function type annotations, with the same syntax, and share the same syntax as python.
* Python type hints (certainly function definition hints) have had quite a bit of time to mature.
* I believe starlark is a great language for defining simple logic and configuration, but lack of tooling and IDE assistance around typing hampers useability, safety, and simplicity. Even in the context of bazel -- I know my experience would be greatly improved with IDE assisted type support and documentation.

## Choices

### Syntatic Element of a Type Annotation

Test / Expr. This is the same element chosen by `starlark-rust` and `buildifier`, and is the closest analogue to python type hints which allows arbitrary expressions. 

### Ident with TypeHint Field instead of TypedIdent

The buildifier implementation parses a TypedIdent with an ident and type hint:
```go
type TypedIdent struct {
	Comments
	Ident   *Ident
	Type    Expr
}
```

Whereas the proposed implementation for `starlark-go` reuses `type Ident struct` with a TypeHint `Expr` field:

```go
type Ident struct {
	commentsRef
	NamePos  Position
	Name     string
	TypeHint Expr // TypeHint can be nil

	Binding interface{} // a *resolver.Binding, set by resolver
}
```

There are two reasons for this:
* Maintain backwards compatibility with programs using the parser: parameters with type hints will still produce the same output type, and Go programs make heavy use of type switches for consuming the tree. 
* In writing code that consumes the type hints, I found the TypeHint field approach easier to use, as it requires fewer type switches and idents can be treated the same. Generally types are either extracted or an Any type is returned if TypeHint is nil.

### syntax.Walk Support

This PR intentionally excludes `syntax.Walk` support for type hints, as it would change the behaviour for programs using `starlark-go` to parse starlark.

## On-the-fence Choices

### Syntax Feature Flag

Whether or not to lock the syntax behind a flag. Unlike other features behind flags, this does not change the output of programs and does not have backwards compatibility implications. 
* This could potentially only be an issue if syntax.Walk is altered to recurse under type hints, as it would change the expected behaviour of programs calling it. 
* By keeping this on by default, it increases the likelihood programs will take advantage of type hints as it will at least always be valid in starlark-go.

### Resolving Type Annotation Identifiers

The PR adds a `ResolveTypeHintIdents` flag in the `resolve` package, which defaults to false. When it is false, type hints cannot cause resolution/compilation failures. 

When it is true, type annotation identifiers are resolved and given binding information. If a type annotation refers to an unknown identifier, it could cause resolution to fail. Additionally, if a type hint in a nested function definition referred to an identifier from its parent scopes, it could cause local variables to be promoted to `Cell`. Because this can slightly change program behaviour, and cause compilation failures it is enabled behind a flag. 

I consider this fairly desirable because:
* It follows python's behaviour with respect to resolving type annotation identifiers, and producing errors on resolution failure.
* Tooling that consumes type hints will likely want to make sure type annotations refer to valid identifiers.
* Tooling that consumes type hints might want scope/binding information for type identifiers. By re-using the existing `resolve` code this is readily available (otherwise the `resolve` logic would have to be heavily duplicated).

### Skip Type Hints for Assignment Syntax

These are supported by `starlark-rust`, but not `buildifier`. Python PEP-526 formalizes this for python, however the only applicable syntax for starlark would be variable assignment and definition:

```python
x  # Binding failure
x: int  # Works in python, binding failure in starlark
y: str = "asdf" # Would work in starlark, but we could infer type anyways.
```

Python changed its behaviour slightly to allow binding unknown variables if given a typehint. This would be a runtime behaviour change in starlark. The currently supported behaviour would require assignment anyways, where we can often infer the type anyways. 

While assignment annotations could provide some value, it's a lot less clear cut to me than function definition annotations. I'd like to table discussion of assignment type hints for a different proposal.