### PR TITLE
lib/proto: Allow replacing repeated fields, instead of appending.

### DIFF
--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -396,6 +396,7 @@ func setField(msg protoreflect.Message, fdesc protoreflect.FieldDescriptor, valu
 		defer iter.Done()
 
 		// TODO(adonovan): handle maps
+		msg.Clear(fdesc)
 		list := msg.Mutable(fdesc).List()
 		var x starlark.Value
 		for i := 0; iter.Next(&x); i++ {

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -396,8 +396,8 @@ func setField(msg protoreflect.Message, fdesc protoreflect.FieldDescriptor, valu
 		defer iter.Done()
 
 		// TODO(adonovan): handle maps
-		msg.Clear(fdesc)
 		list := msg.Mutable(fdesc).List()
+		list.Truncate(0)
 		var x starlark.Value
 		for i := 0; iter.Next(&x); i++ {
 			v, err := toProto(fdesc, x)

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -18,12 +18,16 @@ import (
 	"go.starlark.net/internal/chunkedfile"
 	"go.starlark.net/lib/json"
 	starlarkmath "go.starlark.net/lib/math"
+	"go.starlark.net/lib/proto"
 	"go.starlark.net/lib/time"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/starlarktest"
 	"go.starlark.net/syntax"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	_ "google.golang.org/protobuf/types/descriptorpb" // example descriptor needed for lib/proto tests
 )
 
 // A test may enable non-standard options by containing (e.g.) "option:recursion".
@@ -113,6 +117,7 @@ func TestExecFile(t *testing.T) {
 	testdata := starlarktest.DataFile("starlark", ".")
 	thread := &starlark.Thread{Load: load}
 	starlarktest.SetReporter(thread, t)
+	proto.SetPool(thread, protoregistry.GlobalFiles)
 	for _, file := range []string{
 		"testdata/assign.star",
 		"testdata/bool.star",
@@ -127,6 +132,7 @@ func TestExecFile(t *testing.T) {
 		"testdata/list.star",
 		"testdata/math.star",
 		"testdata/misc.star",
+		"testdata/proto.star",
 		"testdata/set.star",
 		"testdata/string.star",
 		"testdata/time.star",
@@ -201,6 +207,9 @@ func load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	}
 	if module == "math.star" {
 		return starlark.StringDict{"math": starlarkmath.Module}, nil
+	}
+	if module == "proto.star" {
+		return starlark.StringDict{"proto": proto.Module}, nil
 	}
 
 	// TODO(adonovan): test load() using this execution path.

--- a/starlark/testdata/proto.star
+++ b/starlark/testdata/proto.star
@@ -1,0 +1,14 @@
+# Tests of the experimental 'lib/proto' module.
+
+load("assert.star", "assert")
+load("proto.star", "proto")
+
+schema = proto.file("google/protobuf/descriptor.proto")
+
+m = schema.FileDescriptorProto(name = "somename.proto", dependency = ["a", "b", "c"])
+assert.eq(type(m), "proto.Message")
+assert.eq(m.name, "somename.proto")
+assert.eq(list(m.dependency), ["a", "b", "c"])
+m.dependency = ["d", "e"]
+assert.eq(list(m.dependency), ["d", "e"])
+


### PR DESCRIPTION
Consider the following Stralark line:

        msg.repeated = [1,2,3]

Without this commit, that line appends three elements to the previous existing repeated values. With this commit, that line replaces the previous repeated values with new three items.

I believe the old semantics is simply a bug, and that most users would expect an assignment to overwrite the previous value.