### PR TITLE
lib/time: consider any Time other than zero instant to be truthy

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -348,7 +348,7 @@ func (t Time) Hash() (uint32, error) {
 
 // Truth returns the truth value of an object required by starlark.Value
 // interface.
-func (t Time) Truth() starlark.Bool { return starlark.Bool(time.Time(t).IsZero()) }
+func (t Time) Truth() starlark.Bool { return !starlark.Bool(time.Time(t).IsZero()) }
 
 // Attr gets a value for a string attribute, implementing dot expression support
 // in starklark. required by starlark.HasAttrs interface.

--- a/starlark/testdata/time.star
+++ b/starlark/testdata/time.star
@@ -116,6 +116,8 @@ assert.eq(10, t1.second)
 assert.eq(99, t1.nanosecond)
 assert.eq(1244822770, t1.unix)
 assert.eq(1244822770000000099, t1.unix_nano)
+assert.true(not time.parse_time("0001-01-01T00:00:00Z"))
+assert.true(time.parse_time("2022-01-01T00:00:00Z"))
 
 # time type
 assert.eq("time.time", type(refTime))


### PR DESCRIPTION
I know that the truthiness of timestamps isn't well defined, but the current behaviour is the opposite of what I would expect:

```
Welcome to Starlark (go.starlark.net)
>>> bool(time.now())
False
>>> bool(time.parse_time("0001-01-01T00:00:00Z"))
True
```

This change inverts the existing logic so that any time other than `0001-01-01T00:00:00Z` will evaluate to True.

Alternatively, I think that considering all times to be `True` would also be acceptable. Thoughts?
