### PR TITLE
int_test: Move `--entry` flag definition from TestMain to package init.

### DIFF
--- a/starlark/int_test.go
+++ b/starlark/int_test.go
@@ -140,16 +140,18 @@ func intfallback() {
 }
 
 // The --entry flag invokes an alternate entry point, for use in subprocess tests.
+var testEntry = flag.String("entry", "", "child process entry-point")
+
 func TestMain(m *testing.M) {
-	var entry string
-	flag.StringVar(&entry, "entry", "", "child process entry-point")
+	// In some build systems, notably Blaze, flag.Parse is called before TestMain,
+	// in violation of the TestMain contract, making this second call a no-op.
 	flag.Parse()
-	switch entry {
+	switch *testEntry {
 	case "":
 		os.Exit(m.Run()) // normal case
 	case "intfallback":
 		intfallback()
 	default:
-		log.Fatalf("unknown entry point: %s", entry)
+		log.Fatalf("unknown entry point: %s", *testEntry)
 	}
 }


### PR DESCRIPTION
This change matters only in google3/blaze.

Within google3/blaze, all Go tests have additional initialization logic added by the build system. That causes the flags to be parsed before TestMain runs, resulting in a "flag provided but not defined" error when the test spawns itself from a subshell. Moving the flag definition to package-level variable is enough to fix the initialization order.