### PR TITLE
starlark: do not use reflect.Value.MethodByName

### DIFF
--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -300,7 +300,9 @@ func unpackOneArg(v Value, ptr interface{}) error {
 			// Attempt to call Value.Type method.
 			func() {
 				defer func() { recover() }()
-				paramType = paramVar.MethodByName("Type").Call(nil)[0].String()
+				if typer, _ := paramVar.Interface().(interface{ Type() string }); typer != nil {
+					paramType = typer.Type()
+				}
 			}()
 			return fmt.Errorf("got %s, want %s", v.Type(), paramType)
 		}


### PR DESCRIPTION
Using MethodByName disables deadcode elimination in the linker (see the
deadcode function in $GOROOT/src/cmd/link/internal/ld/deadcode.go).

Since the only use of MethodByName is with a static string as an
argument it can be easily replaced with a downcast to an interface.
