### PR TITLE
Walk syntax.DictEntry instead of ignoring it

### DIFF
--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -119,9 +119,7 @@ func Walk(n Node, f func(Node) bool) {
 
 	case *DictExpr:
 		for _, entry := range n.List {
-			entry := entry.(*DictEntry)
-			Walk(entry.Key, f)
-			Walk(entry.Value, f)
+			Walk(entry, f)
 		}
 
 	case *UnaryExpr:


### PR DESCRIPTION
`*syntax.DictExpr` has a field `List []Expr` which is supposed to only contain `*syntax.DictEntry`s:

https://github.com/google/starlark-go/blob/d7da88764354917a82dfa84a8ae1cb04f107ab78/syntax/syntax.go#L377

However, when we are walking `*syntax.DictExpr` node in `syntax.Walk` function, we are ignoring `*syntax.DictEntry`s, directly unwrapping it, and then continuing the walk recursions. This means the caller will not be able to "see" a `*syntax.DictEntry` node when calling the walk function. 

This PR fixes this by directly walking on each element of the `List` field, which in turn will be automatically handled by the `*syntax.DictEntry` case in `Walk`.