### PR TITLE
Improved generic int impl

### DIFF
--- a/starlark/int_posix64.go
+++ b/starlark/int_posix64.go
@@ -1,6 +1,7 @@
-//go:build (linux || darwin || dragonfly || freebsd || netbsd || solaris) && (amd64 || arm64 || mips64x || ppc64x || loong64)
+//go:build (linux || darwin || dragonfly || freebsd || netbsd || solaris) && (amd64 || arm64 || mips64x || ppc64x || loong64) && !noposixint
 // +build linux darwin dragonfly freebsd netbsd solaris
 // +build amd64 arm64 mips64x ppc64x loong64
+// +build !noposixint
 
 package starlark
 
@@ -26,15 +27,18 @@ package starlark
 // and it may panic if it encounters them; see Issue #382.
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"math/big"
+	"strconv"
 	"unsafe"
 
+	"go.starlark.net/syntax"
 	"golang.org/x/sys/unix"
 )
 
-// intImpl represents a union of (int32, *big.Int) in a single pointer,
+// Int represents a union of (int32, *big.Int) in a single pointer,
 // so that Int-to-Value conversions need not allocate.
 //
 // The pointer is either a *big.Int, if the value is big, or a pointer into a
@@ -42,37 +46,73 @@ import (
 // and the address space allocation succeeded.
 //
 // See int_generic.go for the basic representation concepts.
-type intImpl unsafe.Pointer
+type intPosix64 struct {
+	impl unsafe.Pointer
+}
 
-// get returns the (small, big) arms of the union.
-func (i Int) get() (int64, *big.Int) {
-	if smallints == 0 {
-		// optimization disabled
-		if x := (*big.Int)(i.impl); isSmall(x) {
-			return x.Int64(), nil
-		} else {
-			return 0, x
-		}
-	}
+const hasPosixInts = true
 
+func (i intPosix64) get() (int64, *big.Int) {
 	if ptr := uintptr(i.impl); ptr >= smallints && ptr < smallints+1<<32 {
 		return math.MinInt32 + int64(ptr-smallints), nil
 	}
 	return 0, (*big.Int)(i.impl)
 }
 
-// Precondition: math.MinInt32 <= x && x <= math.MaxInt32
-func makeSmallInt(x int64) Int {
-	if smallints == 0 {
-		// optimization disabled
-		return Int{intImpl(big.NewInt(x))}
+func (i intPosix64) Unary(op syntax.Token) (Value, error) {
+	switch op {
+	case syntax.MINUS:
+		return zero.Sub(i), nil
+	case syntax.PLUS:
+		return i, nil
+	case syntax.TILDE:
+		return i.Not(), nil
 	}
-
-	return Int{intImpl(uintptr(x-math.MinInt32) + smallints)}
+	return nil, nil
 }
 
-// Precondition: x cannot be represented as int32.
-func makeBigInt(x *big.Int) Int { return Int{intImpl(x)} }
+func (i intPosix64) Int64() (_ int64, ok bool) {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		x, acc := bigintToInt64(iBig)
+		if acc != big.Exact {
+			return // inexact
+		}
+		return x, true
+	}
+	return iSmall, true
+}
+
+func (i intPosix64) BigInt() *big.Int {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		return new(big.Int).Set(iBig)
+	}
+	return big.NewInt(iSmall)
+}
+
+func (i intPosix64) bigInt() *big.Int {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		return iBig
+	}
+	return big.NewInt(iSmall)
+}
+
+func (i intPosix64) Uint64() (_ uint64, ok bool) {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		x, acc := bigintToUint64(iBig)
+		if acc != big.Exact {
+			return // inexact
+		}
+		return x, true
+	}
+	if iSmall < 0 {
+		return // inexact
+	}
+	return uint64(iSmall), true
+}
 
 // smallints is the base address of a 2^32 byte memory region.
 // Pointers to addresses in this region represent int32 values.
@@ -88,4 +128,198 @@ func reserveAddresses(len int) uintptr {
 		return 0 // optimization disabled
 	}
 	return uintptr(unsafe.Pointer(&b[0]))
+}
+
+func (i intPosix64) Format(s fmt.State, ch rune) {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		iBig.Format(s, ch)
+		return
+	}
+	big.NewInt(iSmall).Format(s, ch)
+}
+func (i intPosix64) String() string {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		return iBig.Text(10)
+	}
+	return strconv.FormatInt(iSmall, 10)
+}
+func (i intPosix64) Type() string { return "int" }
+func (i intPosix64) Freeze()      {} // immutable
+func (i intPosix64) Truth() Bool  { return i.Sign() != 0 }
+func (i intPosix64) Hash() (uint32, error) {
+	iSmall, iBig := i.get()
+	var lo big.Word
+	if iBig != nil {
+		lo = iBig.Bits()[0]
+	} else {
+		lo = big.Word(iSmall)
+	}
+	return 12582917 * uint32(lo+3), nil
+}
+func (x intPosix64) CompareSameType(op syntax.Token, v Value, depth int) (bool, error) {
+	y := v.(Int)
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return threeway(op, x.bigInt().Cmp(y.bigInt())), nil
+	}
+	return threeway(op, signum64(xSmall-ySmall)), nil
+}
+
+// Float returns the float value nearest i.
+func (i intPosix64) Float() Float {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		// Fast path for hardware int-to-float conversions.
+		if iBig.IsUint64() {
+			return Float(iBig.Uint64())
+		} else if iBig.IsInt64() {
+			return Float(iBig.Int64())
+		}
+
+		f, _ := new(big.Float).SetInt(iBig).Float64()
+		return Float(f)
+	}
+	return Float(iSmall)
+}
+
+// finiteFloat returns the finite float value nearest i,
+// or an error if the magnitude is too large.
+func (i intPosix64) finiteFloat() (Float, error) {
+	f := i.Float()
+	if math.IsInf(float64(f), 0) {
+		return 0, fmt.Errorf("int too large to convert to float")
+	}
+	return f, nil
+}
+
+func (x intPosix64) Sign() int {
+	xSmall, xBig := x.get()
+	if xBig != nil {
+		return xBig.Sign()
+	}
+	return signum64(xSmall)
+}
+
+func (x intPosix64) Add(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return MakeBigInt(new(big.Int).Add(x.bigInt(), y.bigInt()))
+	}
+	return MakeInt64(xSmall + ySmall)
+}
+func (x intPosix64) Sub(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return MakeBigInt(new(big.Int).Sub(x.bigInt(), y.bigInt()))
+	}
+	return MakeInt64(xSmall - ySmall)
+}
+func (x intPosix64) Mul(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return MakeBigInt(new(big.Int).Mul(x.bigInt(), y.bigInt()))
+	}
+	return MakeInt64(xSmall * ySmall)
+}
+func (x intPosix64) Or(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return MakeBigInt(new(big.Int).Or(x.bigInt(), y.bigInt()))
+	}
+	return makeSmallInt(xSmall | ySmall)
+}
+func (x intPosix64) And(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return MakeBigInt(new(big.Int).And(x.bigInt(), y.bigInt()))
+	}
+	return makeSmallInt(xSmall & ySmall)
+}
+func (x intPosix64) Xor(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return MakeBigInt(new(big.Int).Xor(x.bigInt(), y.bigInt()))
+	}
+	return makeSmallInt(xSmall ^ ySmall)
+}
+func (x intPosix64) Not() Int {
+	xSmall, xBig := x.get()
+	if xBig != nil {
+		return MakeBigInt(new(big.Int).Not(xBig))
+	}
+	return makeSmallInt(^xSmall)
+}
+func (x intPosix64) Lsh(y uint) Int { return MakeBigInt(new(big.Int).Lsh(x.bigInt(), y)) }
+func (x intPosix64) Rsh(y uint) Int { return MakeBigInt(new(big.Int).Rsh(x.bigInt(), y)) }
+
+// Precondition: y is nonzero.
+func (x intPosix64) Div(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	// http://python-history.blogspot.com/2010/08/why-pythons-integer-division-floors.html
+	if xBig != nil || yBig != nil {
+		return int_div_big(x.bigInt(), y.bigInt())
+	}
+
+	return int_div_small(xSmall, ySmall)
+}
+
+// Precondition: y is nonzero.
+func (x intPosix64) Mod(y Int) Int {
+	xSmall, xBig := x.get()
+	ySmall, yBig := int_get(y)
+	if xBig != nil || yBig != nil {
+		return int_mod_big(x.bigInt(), y.bigInt())
+	}
+
+	return int_mod_small(xSmall, ySmall)
+}
+
+func (i intPosix64) rational() *big.Rat {
+	iSmall, iBig := i.get()
+	if iBig != nil {
+		return new(big.Rat).SetInt(iBig)
+	}
+	return new(big.Rat).SetInt64(iSmall)
+}
+
+// int_get returns the (small, big) arms of the union.
+func int_get(i Int) (int64, *big.Int) {
+	switch i := i.(type) {
+	case intSmall:
+		return int64(i), nil
+	case *intBig:
+		return 0, (*big.Int)(i)
+	case intPosix64:
+		return i.get()
+	default:
+		panic("Int is not an int?")
+	}
+}
+
+// Precondition: x cannot be represented as int32.
+func makeBigInt(x *big.Int) Int {
+	if smallints == 0 {
+		return (*intBig)(x)
+	}
+	return intPosix64{unsafe.Pointer(x)}
+}
+
+// Precondition: math.MinInt32 <= x && x <= math.MaxInt32
+func makeSmallInt(x int64) Int {
+	if smallints == 0 {
+		// optimization disabled
+		return intSmall(x)
+	}
+
+	return intPosix64{unsafe.Pointer(uintptr(x-math.MinInt32) + smallints)}
 }

--- a/starlark/int_test.go
+++ b/starlark/int_test.go
@@ -62,7 +62,7 @@ func TestIntOpts(t *testing.T) {
 		if got := fmt.Sprintf("%x", test.val); got != test.want {
 			t.Errorf("%d equals %s, want %s", i, got, test.want)
 		}
-		small, big := test.val.get()
+		small, big := int_get(test.val)
 		if small < math.MinInt32 || math.MaxInt32 < small {
 			t.Errorf("expected big, %d %s", i, test.val)
 		}
@@ -110,11 +110,14 @@ func TestImmutabilityBigInt(t *testing.T) {
 // TestIntFallback creates a small Int value in a child process with
 // limited address space to ensure that it still works, but prints a warning.
 func TestIntFallback(t *testing.T) {
+	if !hasPosixInts {
+		t.Skipf("test disabled on this target")
+	}
 
-	if (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" && runtime.GOARCH != "mips64x" && runtime.GOARCH != "ppc64x" && runtime.GOARCH != "loong64") ||
-		(runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "dragonfly" && runtime.GOOS != "freebsd" && runtime.GOOS != "netbsd" && runtime.GOOS != "solaris") {
+	if runtime.GOOS != "linux" {
 		t.Skipf("test disabled on this platform (requires ulimit -v)")
 	}
+
 	exe, err := os.Executable()
 	if err != nil {
 		t.Fatalf("can't find file name of executable: %v", err)

--- a/starlark/int_test.go
+++ b/starlark/int_test.go
@@ -110,7 +110,9 @@ func TestImmutabilityBigInt(t *testing.T) {
 // TestIntFallback creates a small Int value in a child process with
 // limited address space to ensure that it still works, but prints a warning.
 func TestIntFallback(t *testing.T) {
-	if runtime.GOOS != "linux" {
+
+	if (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" && runtime.GOARCH != "mips64x" && runtime.GOARCH != "ppc64x" && runtime.GOARCH != "loong64") ||
+		(runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "dragonfly" && runtime.GOOS != "freebsd" && runtime.GOOS != "netbsd" && runtime.GOOS != "solaris") {
 		t.Skipf("test disabled on this platform (requires ulimit -v)")
 	}
 	exe, err := os.Executable()

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -133,7 +133,6 @@ type Comparable interface {
 }
 
 var (
-	_ Comparable = Int{}
 	_ Comparable = False
 	_ Comparable = Float(0)
 	_ Comparable = String("")


### PR DESCRIPTION
In this PR I propose a new generic representation for Int(s) which would work for all non-posix non-x64 targets. 

Moreover, I propose to add a build tag to completely remove the integer optimizations even for targets like linux x64 since being able to allocate 4GB of ram is not enough of a reason to believe that consuming 4GB of virtual memory is irrelevant. 

For example:

```bash
# Running the test suite on a linux x64 box, running in the folder <repo>/starlark

# 2 GB, it works
( ulimit -v $(( 2 * 1 << 20 )) && go test . -count=1 ) 

# 4 GB, it works
( ulimit -v $(( 4 * 1 << 20 )) && go test . -count=1 ) 

# 5 GB, it crashes with OOM
( ulimit -v $(( 5 * 1 << 20 )) && go test . -count=1 ) 
```

IMHO, it should never happen that **adding** more than twice the memory causes an "Out Of Memory" for an otherwise working program.

## Benchmarking

Here follows some benchmarking, performed on an Ubuntu 22.10, with an Intel Core i5.

### x86 

Current master:
```
goos: linux
goarch: 386
pkg: go.starlark.net/starlark
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
BenchmarkStarlark/bench_bigint-4         	    1719	    914096 ns/op	   96120 B/op	    7008 allocs/op
BenchmarkStarlark/bench_gauss-4          	      25	  48124428 ns/op	 4637752 B/op	  316324 allocs/op
BenchmarkStarlark/bench_int-4            	    2826	    516878 ns/op	   32040 B/op	    2002 allocs/op
BenchmarkStarlark/bench_mix-4            	    2570	    466473 ns/op	   53404 B/op	    1961 allocs/op
PASS
ok  	go.starlark.net/starlark	9.426s
```

This PR:
```
goos: linux
goarch: 386
pkg: go.starlark.net/starlark
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
BenchmarkStarlark/bench_bigint-4         	    1869	    647316 ns/op	   70031 B/op	    5749 allocs/op
BenchmarkStarlark/bench_gauss-4          	      27	  43207239 ns/op	 2951792 B/op	  289580 allocs/op
BenchmarkStarlark/bench_int-4            	    2424	    506344 ns/op	   11943 B/op	    1490 allocs/op
BenchmarkStarlark/bench_mix-4            	    3367	    373223 ns/op	   32215 B/op	     636 allocs/op
PASS
ok  	go.starlark.net/starlark	6.826s
```

Both faster and consumes less memory.

### x64

#### With the optimization on (no memory limits)

Current master:
```
goos: linux
goarch: amd64
pkg: go.starlark.net/starlark
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
BenchmarkStarlark/bench_bigint-4         	    3208	    436642 ns/op	  128176 B/op	    5006 allocs/op
BenchmarkStarlark/bench_gauss-4          	      80	  18628541 ns/op	 3387445 B/op	  132323 allocs/op
BenchmarkStarlark/bench_int-4            	    9541	    119273 ns/op	      48 B/op	       1 allocs/op
BenchmarkStarlark/bench_mix-4            	    6494	    167812 ns/op	   63608 B/op	     636 allocs/op
PASS
ok  	go.starlark.net/starlark	7.744s
```

This PR:
```
goos: linux
goarch: amd64
pkg: go.starlark.net/starlark
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
BenchmarkStarlark/bench_bigint-4         	    2724	    422222 ns/op	  128176 B/op	    5006 allocs/op
BenchmarkStarlark/bench_gauss-4          	      75	  19292476 ns/op	 3387464 B/op	  132323 allocs/op
BenchmarkStarlark/bench_int-4            	    9775	    130073 ns/op	      48 B/op	       1 allocs/op
BenchmarkStarlark/bench_mix-4            	    6882	    179801 ns/op	   63608 B/op	     636 allocs/op
PASS
ok  	go.starlark.net/starlark	6.337s
```

The difference in the metrics seems varying from run to run, the allocation pattern is the same.

#### With memory limits (ulimit -v 2000000)

Current master:
```
2023/01/20 16:53:56 Starlark failed to allocate 4GB address space: cannot allocate memory. Integer performance may suffer.
goos: linux
goarch: amd64
pkg: go.starlark.net/starlark
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
BenchmarkStarlark/bench_bigint-4         	    1654	    640482 ns/op	  168210 B/op	    7007 allocs/op
BenchmarkStarlark/bench_gauss-4          	      36	  40755274 ns/op	 9688947 B/op	  447395 allocs/op
BenchmarkStarlark/bench_int-4            	    3549	    355176 ns/op	   80080 B/op	    4002 allocs/op
BenchmarkStarlark/bench_mix-4            	    3476	    387892 ns/op	  116208 B/op	    3236 allocs/op
PASS
ok  	go.starlark.net/starlark	7.836s
```

This PR:
```
2023/01/20 16:54:14 Starlark failed to allocate 4GB address space: cannot allocate memory. Integer performance may suffer.
goos: linux
goarch: amd64
pkg: go.starlark.net/starlark
cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
BenchmarkStarlark/bench_bigint-4         	    2896	    401010 ns/op	  134104 B/op	    5749 allocs/op
BenchmarkStarlark/bench_gauss-4          	      52	  21606800 ns/op	 4645504 B/op	  289580 allocs/op
BenchmarkStarlark/bench_int-4            	    7246	    160877 ns/op	   11967 B/op	    1490 allocs/op
BenchmarkStarlark/bench_mix-4            	    6639	    213752 ns/op	   63616 B/op	     636 allocs/op
PASS
ok  	go.starlark.net/starlark	7.837s
```

Both faster and consumes less memory. Small ints suffer more than big ones as it must allocate values above 255.

