### PR TITLE
starlark: optimize TestProfile

### DIFF
--- a/starlark/profile_test.go
+++ b/starlark/profile_test.go
@@ -31,10 +31,10 @@ func TestProfile(t *testing.T) {
 
 	const src = `
 def fibonacci(n):
-	res = list(range(n))
-	for i in res[2:]:
-		res[i] = res[i-2] + res[i-1]
-	return res
+	x, y = 1, 1
+	for i in range(n):
+		x, y = y, x+y
+	return y
 
 fibonacci(100000)
 `


### PR DESCRIPTION
Previously, the test would compute the first 100,000 elements of the Fibonacci sequence, holding them all in an array. Since elements may have over 20,000 digits, this allocates a lot of memory, which, under tight ulimits of virtual address space, in conjunction with the mmap int optimization, may cause the process to have insufficient virtual address space to allocate the necessary memory.

This change causes it to compute but not retain the elements of the sequence.

Fixes google/starlark-go#455