### PR TITLE
Adding new ThreeWayComparable interface

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -212,13 +212,12 @@ func (d Duration) AttrNames() []string {
 // CompareSameType implements comparison of two Duration values. required by
 // starlark.Comparable interface.
 func (d Duration) CompareSameType(op syntax.Token, v starlark.Value, depth int) (bool, error) {
-	cmp := 0
 	if x, y := d, v.(Duration); x < y {
-		cmp = -1
+		return -1, nil
 	} else if x > y {
-		cmp = 1
+		return 1, nil
 	}
-	return threeway(op, cmp), nil
+	return 0, nil
 }
 
 // Binary implements binary operators, which satisfies the starlark.HasBinary
@@ -394,16 +393,15 @@ func (t Time) AttrNames() []string {
 
 // CompareSameType implements comparison of two Time values. required by
 // starlark.Comparable interface.
-func (t Time) CompareSameType(op syntax.Token, yV starlark.Value, depth int) (bool, error) {
+func (t Time) CompareSameType(yV starlark.Value, depth int) (int, error) {
 	x := time.Time(t)
 	y := time.Time(yV.(Time))
-	cmp := 0
 	if x.Before(y) {
-		cmp = -1
+		return -1, nil
 	} else if x.After(y) {
-		cmp = 1
+		return 1, nil
 	}
-	return threeway(op, cmp), nil
+	return 0, nil
 }
 
 // Binary implements binary operators, which satisfies the starlark.HasBinary
@@ -484,24 +482,4 @@ func builtinAttrNames(methods map[string]builtinMethod) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-// Threeway interprets a three-way comparison value cmp (-1, 0, +1)
-// as a boolean comparison (e.g. x < y).
-func threeway(op syntax.Token, cmp int) bool {
-	switch op {
-	case syntax.EQL:
-		return cmp == 0
-	case syntax.NEQ:
-		return cmp != 0
-	case syntax.LE:
-		return cmp <= 0
-	case syntax.LT:
-		return cmp < 0
-	case syntax.GE:
-		return cmp >= 0
-	case syntax.GT:
-		return cmp > 0
-	}
-	panic(op)
 }

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -209,8 +209,8 @@ func (d Duration) AttrNames() []string {
 	}
 }
 
-// CompareSameType implements comparison of two Duration values. required by
-// starlark.Comparable interface.
+// Cmp implements comparison of two Duration values. required by
+// starlark.TotallyOrdered interface.
 func (d Duration) Cmp(v starlark.Value, depth int) (int, error) {
 	if x, y := d, v.(Duration); x < y {
 		return -1, nil
@@ -391,8 +391,8 @@ func (t Time) AttrNames() []string {
 	)
 }
 
-// CompareSameType implements comparison of two Time values. required by
-// starlark.Comparable interface.
+// Cmp implements comparison of two Time values. Required by
+// starlark.TotallyOrdered interface.
 func (t Time) Cmp(yV starlark.Value, depth int) (int, error) {
 	x := time.Time(t)
 	y := time.Time(yV.(Time))

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -211,7 +211,7 @@ func (d Duration) AttrNames() []string {
 
 // CompareSameType implements comparison of two Duration values. required by
 // starlark.Comparable interface.
-func (d Duration) ThreeWayCompareSameType(v starlark.Value, depth int) (int, error) {
+func (d Duration) Cmp(v starlark.Value, depth int) (int, error) {
 	if x, y := d, v.(Duration); x < y {
 		return -1, nil
 	} else if x > y {
@@ -393,7 +393,7 @@ func (t Time) AttrNames() []string {
 
 // CompareSameType implements comparison of two Time values. required by
 // starlark.Comparable interface.
-func (t Time) ThreeWayCompareSameType(yV starlark.Value, depth int) (int, error) {
+func (t Time) Cmp(yV starlark.Value, depth int) (int, error) {
 	x := time.Time(t)
 	y := time.Time(yV.(Time))
 	if x.Before(y) {

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -211,7 +211,7 @@ func (d Duration) AttrNames() []string {
 
 // CompareSameType implements comparison of two Duration values. required by
 // starlark.Comparable interface.
-func (d Duration) CompareSameType(op syntax.Token, v starlark.Value, depth int) (bool, error) {
+func (d Duration) ThreeWayCompareSameType(v starlark.Value, depth int) (int, error) {
 	if x, y := d, v.(Duration); x < y {
 		return -1, nil
 	} else if x > y {
@@ -393,7 +393,7 @@ func (t Time) AttrNames() []string {
 
 // CompareSameType implements comparison of two Time values. required by
 // starlark.Comparable interface.
-func (t Time) CompareSameType(yV starlark.Value, depth int) (int, error) {
+func (t Time) ThreeWayCompareSameType(yV starlark.Value, depth int) (int, error) {
 	x := time.Time(t)
 	y := time.Time(yV.(Time))
 	if x.Before(y) {

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -191,7 +191,7 @@ func (i Int) Hash() (uint32, error) {
 	return 12582917 * uint32(lo+3), nil
 }
 
-func (x Int) CompareSameType(v Value, depth int) (int, error) {
+func (x Int) ThreeWayCompareSameType(v Value, depth int) (int, error) {
 	y := v.(Int)
 	xSmall, xBig := x.get()
 	ySmall, yBig := y.get()

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -191,6 +191,7 @@ func (i Int) Hash() (uint32, error) {
 	return 12582917 * uint32(lo+3), nil
 }
 
+// Required by the TotallyOrdered interface
 func (x Int) Cmp(v Value, depth int) (int, error) {
 	y := v.(Int)
 	xSmall, xBig := x.get()
@@ -198,7 +199,7 @@ func (x Int) Cmp(v Value, depth int) (int, error) {
 	if xBig != nil || yBig != nil {
 		return x.bigInt().Cmp(y.bigInt()), nil
 	}
-	return signum64(xSmall - ySmall), nil
+	return signum64(xSmall - ySmall), nil // safe: int32 operands
 }
 
 // Float returns the float value nearest i.

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -191,7 +191,7 @@ func (i Int) Hash() (uint32, error) {
 	return 12582917 * uint32(lo+3), nil
 }
 
-func (x Int) ThreeWayCompareSameType(v Value, depth int) (int, error) {
+func (x Int) Cmp(v Value, depth int) (int, error) {
 	y := v.(Int)
 	xSmall, xBig := x.get()
 	ySmall, yBig := y.get()

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -190,14 +190,15 @@ func (i Int) Hash() (uint32, error) {
 	}
 	return 12582917 * uint32(lo+3), nil
 }
-func (x Int) CompareSameType(op syntax.Token, v Value, depth int) (bool, error) {
+
+func (x Int) CompareSameType(v Value, depth int) (int, error) {
 	y := v.(Int)
 	xSmall, xBig := x.get()
 	ySmall, yBig := y.get()
 	if xBig != nil || yBig != nil {
-		return threeway(op, x.bigInt().Cmp(y.bigInt())), nil
+		return x.bigInt().Cmp(y.bigInt()), nil
 	}
-	return threeway(op, signum64(xSmall-ySmall)), nil
+	return signum64(xSmall - ySmall), nil
 }
 
 // Float returns the float value nearest i.

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -155,7 +155,7 @@ type ThreeWayComparable interface {
 }
 
 var (
-	_ Comparable = Int{}
+	_ ThreeWayComparable = Int{}
 	_ Comparable         = False
 	_ Comparable         = Float(0)
 	_ Comparable         = String("")

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -134,10 +134,8 @@ type Comparable interface {
 // Alternate, simplified comparison interface
 type ThreeWayComparable interface {
 	Value
-	// CompareSameType compares one value to another of the same Type()
-	// and returns a three-way comparison value (-1, 0, 1)
-	// CompareSameType returns an error if an ordered comparison was
-	// requested for a type that does not support it.
+	// ThreeWayCompareSameType compares one value to another of the same orderable
+	// Type() and returns a three-way comparison value (-1, 0, 1)
 	//
 	// Implementations that recursively compare subcomponents of
 	// the value should use the CompareDepth function, not Compare, to
@@ -151,7 +149,7 @@ type ThreeWayComparable interface {
 	// Client code should not call this method.  Instead, use the
 	// standalone Compare or Equals functions, which are defined for
 	// all pairs of operands.
-	CompareSameType(y Value, depth int) (int, error)
+	ThreeWayCompareSameType(y Value, depth int) (int, error)
 }
 
 var (
@@ -1318,13 +1316,12 @@ func CompareDepth(op syntax.Token, x, y Value, depth int) (bool, error) {
 		return false, fmt.Errorf("comparison exceeded maximum recursion depth")
 	}
 	if sameType(x, y) {
-
 		if xcomp, ok := x.(Comparable); ok {
 			return xcomp.CompareSameType(op, y, depth)
 		}
 
 		if xcomp, ok := x.(ThreeWayComparable); ok {
-			t, err := xcomp.CompareSameType(y, depth)
+			t, err := xcomp.ThreeWayCompareSameType(y, depth)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
Re: https://github.com/google/starlark-go/issues/356

This adds a new `TotallyOrdered` interface, similar to `Comparable` which returns an integer representing the <, ==, > relation between values. The `CompareDepth` function has been to updated check for this interface and handle this return style if applicable.

Also refactors `int`, `float`, `time.Time` and `time.Duration` types to use the new interface.

The previous `Comparable` interface will have to be maintained, not just for API compatibility but also for types which define equality/inequality but not ordering (for example, [structs](https://github.com/google/starlark-go/blob/c52844e64a10fb0a67ae99619ee98a49de4f8210/starlarkstruct/struct.go#L247))

#### Open questions:

 - Is the ThreeWayCompareSameType name too verbose? I was thinking about overloading the name CompareSameType but that felt like it would get confusing. -> Yes, change to `TotallyOrdered`
 - Should I also update the other orderable types (float, str, list, etc) to use this interface in this PR? -> Yes.


