### PR TITLE
Disambiguate a resolve message

### DIFF
--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -746,7 +746,7 @@ func (r *resolver) expr(e syntax.Expr) {
 				}
 				x := binop.X.(*syntax.Ident)
 				if seenName[x.Name] {
-					r.errorf(x.NamePos, "keyword argument %s repeated", x.Name)
+					r.errorf(x.NamePos, "keyword argument %q is repeated", x.Name)
 				} else {
 					if seenName == nil {
 						seenName = make(map[string]bool)

--- a/resolve/testdata/resolve.star
+++ b/resolve/testdata/resolve.star
@@ -340,7 +340,7 @@ U = 1 # ok (legacy)
 ---
 # https://github.com/bazelbuild/starlark/starlark/issues/21
 def f(**kwargs): pass
-f(a=1, a=1) ### `keyword argument a repeated`
+f(a=1, a=1) ### `keyword argument "a" is repeated`
 
 
 ---


### PR DESCRIPTION
I had a duplicate kwargs named 'disabled'. This
ended up with a message 'keyword argument disabled repeated', which is really difficult to parse.

Hope to clarify things by changing that text a bit.