### PR TITLE
use StringDictLike instead of StringDict to provide predefined symbols

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -33,7 +33,6 @@ var interrupted = make(chan os.Signal, 1)
 // variable named "context" to a context.Context that is cancelled by a
 // SIGINT (Control-C). Client-supplied global functions may use this
 // context to make long-running operations interruptable.
-//
 func REPL(thread *starlark.Thread, globals starlark.StringDict) {
 	signal.Notify(interrupted, os.Interrupt)
 	defer signal.Stop(interrupted)
@@ -152,7 +151,7 @@ func PrintError(err error) {
 // MakeLoad returns a simple sequential implementation of module loading
 // suitable for use in the REPL.
 // Each function returned by MakeLoad accesses a distinct private cache.
-func MakeLoad() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+func MakeLoad() func(thread *starlark.Thread, module string) (starlark.StringDictLike, error) {
 	type entry struct {
 		globals starlark.StringDict
 		err     error
@@ -160,7 +159,7 @@ func MakeLoad() func(thread *starlark.Thread, module string) (starlark.StringDic
 
 	var cache = make(map[string]*entry)
 
-	return func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	return func(thread *starlark.Thread, module string) (starlark.StringDictLike, error) {
 		e, ok := cache[module]
 		if e == nil {
 			if ok {

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -195,7 +195,7 @@ func (it *fibIterator) Next(p *starlark.Value) bool {
 func (it *fibIterator) Done() {}
 
 // load implements the 'load' operation as used in the evaluator tests.
-func load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+func load(thread *starlark.Thread, module string) (starlark.StringDictLike, error) {
 	if module == "assert.star" {
 		return starlarktest.LoadAssertModule()
 	}
@@ -588,7 +588,7 @@ def f(x):
 f(0)
 `
 	thread := new(starlark.Thread)
-	thread.Load = func(t *starlark.Thread, module string) (starlark.StringDict, error) {
+	thread.Load = func(t *starlark.Thread, module string) (starlark.StringDictLike, error) {
 		return starlark.ExecFile(new(starlark.Thread), module, loadedSrc, nil)
 	}
 	_, err := starlark.ExecFile(thread, "root.star", src, nil)

--- a/starlark/example_test.go
+++ b/starlark/example_test.go
@@ -92,8 +92,8 @@ func ExampleThread_Load_sequential() {
 
 	cache := make(map[string]*entry)
 
-	var load func(_ *starlark.Thread, module string) (starlark.StringDict, error)
-	load = func(_ *starlark.Thread, module string) (starlark.StringDict, error) {
+	var load func(_ *starlark.Thread, module string) (starlark.StringDictLike, error)
+	load = func(_ *starlark.Thread, module string) (starlark.StringDictLike, error) {
 		e, ok := cache[module]
 		if e == nil {
 			if ok {
@@ -120,7 +120,7 @@ func ExampleThread_Load_sequential() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(globals["c"])
+	fmt.Println(globals.Get("c"))
 
 	// Output:
 	// "Hello, world!"
@@ -267,7 +267,7 @@ func (c *cache) doLoad(cc *cycleChecker, module string) (starlark.StringDict, er
 	thread := &starlark.Thread{
 		Name:  "exec " + module,
 		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
-		Load: func(_ *starlark.Thread, module string) (starlark.StringDict, error) {
+		Load: func(_ *starlark.Thread, module string) (starlark.StringDictLike, error) {
 			// Tunnel the cycle-checker state for this "thread of loading".
 			return c.get(cc, module)
 		},

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -575,15 +575,14 @@ loop:
 
 			for i := 0; i < n; i++ {
 				from := string(stack[sp-1-i].(String))
-				v, ok := dict[from]
-				if !ok {
+				if ok := dict.Has(from); !ok {
 					err = fmt.Errorf("load: name %s not found in module %s", from, module)
 					if n := spell.Nearest(from, dict.Keys()); n != "" {
 						err = fmt.Errorf("%s (did you mean %s?)", err, n)
 					}
 					break loop
 				}
-				stack[sp-1-i] = v
+				stack[sp-1-i] = dict.Get(from)
 			}
 
 		case compile.SETLOCAL:
@@ -640,7 +639,7 @@ loop:
 
 		case compile.PREDECLARED:
 			name := f.Prog.Names[arg]
-			x := fn.module.predeclared[name]
+			x := fn.module.predeclared.Get(name)
 			if x == nil {
 				err = fmt.Errorf("internal error: predeclared variable %s is uninitialized", name)
 				break loop

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -691,7 +691,7 @@ type Function struct {
 // All functions in the same program share a module.
 type module struct {
 	program     *compile.Program
-	predeclared StringDict
+	predeclared StringDictLike
 	globals     []Value
 	constants   []Value
 }

--- a/starlarkstruct/struct_test.go
+++ b/starlarkstruct/struct_test.go
@@ -32,7 +32,7 @@ func Test(t *testing.T) {
 }
 
 // load implements the 'load' operation as used in the evaluator tests.
-func load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+func load(thread *starlark.Thread, module string) (starlark.StringDictLike, error) {
 	if module == "assert.star" {
 		return starlarktest.LoadAssertModule()
 	}


### PR DESCRIPTION
DO NOT SUBMIT

This CL allows users to provide predefined symbols in a lazily loaded manner, which could be helpful when loading the program for static analysis (eg. extracting docs from .bzl files).

Fixes #463 