### PR TITLE
Allow json.decode to return a default value if decoding fails

### DIFF
--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -290,6 +290,11 @@ func decode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "x", &s, "default?", &d); err != nil {
 		return nil, err
 	}
+	if len(args) < 1 {
+		// "x" parameter is positional only; UnpackArgs does not allow us to
+		// directly express def(x, *, default)
+		return nil, fmt.Errorf("%s: unexpected keyword argument x", b.Name())
+	}
 
 	// The decoder necessarily makes certain representation choices
 	// such as list vs tuple, struct vs dict, int vs float.

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -502,7 +502,7 @@ func decode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 		switch x := x.(type) {
 		case failure:
 			if d != nil {
-			    v = d
+				v = d
 			} else {
 				err = fmt.Errorf("json.decode: at offset %d, %s", i, x)
 			}

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -62,11 +62,9 @@ import (
 //   contain a decimal point.
 // - JSON objects are parsed as new unfrozen Starlark dicts.
 // - JSON arrays are parsed as new unfrozen Starlark lists.
-// If `x` is not a valid JSON string and the optional, positional-only `default`
-// parameter is specified (including specified as `None`), the decode function
-// returns the `default` value.
-// If `x` is not a valid JSON string and the optional, positional-only `default`
-// parameter is not specified, the decode function fails.
+// If x is not a valid JSON string, the behavior depends on the "default"
+// positional-only parameter: if present, Decode returns its value; otherwise,
+// Decode fails.
 //
 // def indent(str, *, prefix="", indent="\t"):
 //

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -63,8 +63,7 @@ import (
 // - JSON objects are parsed as new unfrozen Starlark dicts.
 // - JSON arrays are parsed as new unfrozen Starlark lists.
 // If x is not a valid JSON string, the behavior depends on the "default"
-// positional-only parameter: if present, Decode returns its value; otherwise,
-// Decode fails.
+// parameter: if present, Decode returns its value; otherwise, Decode fails.
 //
 // def indent(str, *, prefix="", indent="\t"):
 //
@@ -288,7 +287,7 @@ func indent(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 func decode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
 	var s string
 	var d starlark.Value
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &s, &d); err != nil {
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "x", &s, "default?", &d); err != nil {
 		return nil, err
 	}
 

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -292,7 +292,7 @@ func decode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 	}
 	if len(args) < 1 {
 		// "x" parameter is positional only; UnpackArgs does not allow us to
-		// directly express def(x, *, default)
+		// directly express "def decode(x, *, default)"
 		return nil, fmt.Errorf("%s: unexpected keyword argument x", b.Name())
 	}
 

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -298,6 +298,11 @@ func decode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 	// control the returned types, but there's no compelling need yet.
 
 	// Use panic/recover with a distinguished type (failure) for error handling.
+	// If "default" is set, we only want to return it when encountering invalid
+	// json - not for any other possible causes of panic.
+	// In particular, if we ever extend the json.decode API to take a callback,
+	// a distinguished, private failure type prevents the possibility of
+	// json.decode with "default" becoming abused as a try-catch mechanism.
 	type failure string
 	fail := func(format string, args ...interface{}) {
 		panic(failure(fmt.Sprintf(format, args...)))

--- a/starlark/testdata/json.star
+++ b/starlark/testdata/json.star
@@ -113,14 +113,12 @@ decode_error('{"one": 1]', "in object, got ']', want ',' or '}'")
 
 ## json.decode with default specified
 
+assert.eq(json.decode('{"valid": "json"}', default = "default value"), {"valid": "json"})
 assert.eq(json.decode('{"valid": "json"}', "default value"), {"valid": "json"})
+assert.eq(json.decode('{"invalid": "json"', default = "default value"), "default value")
 assert.eq(json.decode('{"invalid": "json"', "default value"), "default value")
+assert.eq(json.decode('{"invalid": "json"', default = None), None)
 assert.eq(json.decode('{"invalid": "json"', None), None)
-
-assert.fails(
-    lambda: json.decode('{"invalid": "json"', default = "default value"),
-    "unexpected keyword argument",
-)
 
 def codec(x):
     return json.decode(json.encode(x))

--- a/starlark/testdata/json.star
+++ b/starlark/testdata/json.star
@@ -111,6 +111,17 @@ decode_error('{"one": 1,', "unexpected end of file")
 decode_error('{"one": 1, }', "unexpected character '}'")
 decode_error('{"one": 1]', "in object, got ']', want ',' or '}'")
 
+## json.decode with default specified
+
+assert.eq(json.decode('{"valid": "json"}', "default value"), {"valid": "json"})
+assert.eq(json.decode('{"invalid": "json"', "default value"), "default value")
+assert.eq(json.decode('{"invalid": "json"', None), None)
+
+assert.fails(
+    lambda: json.decode('{"invalid": "json"', default = "default value"),
+    "unexpected keyword argument",
+)
+
 def codec(x):
     return json.decode(json.encode(x))
 

--- a/starlark/testdata/json.star
+++ b/starlark/testdata/json.star
@@ -120,6 +120,11 @@ assert.eq(json.decode('{"invalid": "json"', "default value"), "default value")
 assert.eq(json.decode('{"invalid": "json"', default = None), None)
 assert.eq(json.decode('{"invalid": "json"', None), None)
 
+assert.fails(
+    lambda: json.decode(x = '{"invalid": "json"', default = "default value"),
+    "unexpected keyword argument x"
+)
+
 def codec(x):
     return json.decode(json.encode(x))
 


### PR DESCRIPTION
This is the starlark-go counterpart to bazelbuild/bazel@71fb1e4

It is useful to be able to decode a potentially invalid JSON string without
failing Starlark evaluation. Typically, in this case, we would want to return
a default value - either a reasonable safe default or some domain-specific
representation of "we encountered an error".

Note that the original behavior of json.decode failing on invalid JSON input
still remains (for lack of a better word) the default: the `default` value,
even if it is `None`, must be specified explicitly.

Fixes #465