### PR TITLE
syntax: reserve async, await keywords

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -260,12 +260,14 @@ appear in the grammar; they are reserved as possible future keywords:
 <!-- and to remain a syntactic subset of Python -->
 
 ```text
-as             finally        nonlocal
-assert         from           raise
-class          global         try
-del            import         with
-except         is             yield
+as              except          nonlocal
+assert          finally         raise
+async           from            try
+await           global          with
+class           import          yield
+del             is   
 ```
+<!-- NB: bazelbuild/starlark puts `while` in the second list -->
 
 <b>Implementation note:</b>
 The Go implementation permits `assert` to be used as an identifier,

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -1107,6 +1107,8 @@ var keywordToken = map[string]Token{
 	// reserved words:
 	"as": ILLEGAL,
 	// "assert":   ILLEGAL, // heavily used by our tests
+	"async":    ILLEGAL,
+	"await":    ILLEGAL,
 	"class":    ILLEGAL,
 	"del":      ILLEGAL,
 	"except":   ILLEGAL,


### PR DESCRIPTION
This is technically a breaking change, but neither Google's nor GitHub's Starlark corpus contains a single instance of either of these used as identifiers, so the change looks pretty safe.

Fixes #471