### PR TITLE
Fix typo in import comment of json.go

### DIFF
--- a/starlarkjson/json.go
+++ b/starlarkjson/json.go
@@ -6,7 +6,7 @@
 // backwards compatibility
 //
 // Deprecated: use go.starlark.net/lib/json instead
-package starlarkjson // import "go.starlark.net/stalarkjson"
+package starlarkjson // import "go.starlark.net/starlarkjson"
 
 import (
 	"go.starlark.net/lib/json"


### PR DESCRIPTION
Hi,
I experienced a problem in which the go-list command couldn't find go.starlark.net/stalarkjson when making the Debian package of starlark-go.

The root cause is the typo in the [import comments](https://pkg.go.dev/cmd/go#hdr-Import_path_checking) of starlarkjson/json.go file caused by #367. This typo makes the go-list command under GO111MODULE=off to give up finding go files of starlark-go. As a result, the packaging in Debian failed.

Would you please accept the PR to fix that typo?  
