### PR TITLE
Fix build flags for s390x, ppc64, and ppc64le

### DIFF
--- a/starlark/int_generic.go
+++ b/starlark/int_generic.go
@@ -1,5 +1,5 @@
-//go:build (!linux && !darwin && !dragonfly && !freebsd && !netbsd && !solaris) || (!amd64 && !arm64 && !mips64x && !ppc64x && !loong64)
-// +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!solaris !amd64,!arm64,!mips64x,!ppc64x,!loong64
+//go:build (!linux && !darwin && !dragonfly && !freebsd && !netbsd && !solaris) || (!amd64 && !arm64 && !mips64x && !ppc64 && !ppc64le && !loong64 && !s390x)
+// +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!solaris !amd64,!arm64,!mips64x,!ppc64,!ppc64le,!loong64,!s390x
 
 package starlark
 

--- a/starlark/int_posix64.go
+++ b/starlark/int_posix64.go
@@ -1,6 +1,6 @@
-//go:build (linux || darwin || dragonfly || freebsd || netbsd || solaris) && (amd64 || arm64 || mips64x || ppc64x || loong64)
+//go:build (linux || darwin || dragonfly || freebsd || netbsd || solaris) && (amd64 || arm64 || mips64x || ppc64 || ppc64le || loong64 || s390x)
 // +build linux darwin dragonfly freebsd netbsd solaris
-// +build amd64 arm64 mips64x ppc64x loong64
+// +build amd64 arm64 mips64x ppc64 ppc64le loong64 s390x
 
 package starlark
 


### PR DESCRIPTION
According to the [documentation](https://pkg.go.dev/cmd/go#hdr-Build_constraints), ppc64x is not a valid flag, making `TestIntFallback` fail. s390x is also missing and it works fine.

```
--- FAIL: TestIntFallback (0.01s)
    int_test.go:130: expected warning was not printed. Output=<<>>
```