### PR TITLE
trivial: Fix golint errors

### DIFF
--- a/starlark/int.go
+++ b/starlark/int.go
@@ -192,7 +192,7 @@ func (i Int) Hash() (uint32, error) {
 }
 
 // Cmp implements comparison of two Int values.
-// Required by starlark.TotallyOrdered interface.
+// Required by the TotallyOrdered interface.
 func (i Int) Cmp(v Value, depth int) (int, error) {
 	j := v.(Int)
 	iSmall, iBig := i.get()

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -191,15 +191,16 @@ func (i Int) Hash() (uint32, error) {
 	return 12582917 * uint32(lo+3), nil
 }
 
-// Required by the TotallyOrdered interface
-func (x Int) Cmp(v Value, depth int) (int, error) {
-	y := v.(Int)
-	xSmall, xBig := x.get()
-	ySmall, yBig := y.get()
-	if xBig != nil || yBig != nil {
-		return x.bigInt().Cmp(y.bigInt()), nil
+// Cmp implements comparison of two Int values.
+// Required by starlark.TotallyOrdered interface.
+func (i Int) Cmp(v Value, depth int) (int, error) {
+	j := v.(Int)
+	iSmall, iBig := i.get()
+	jSmall, jBig := j.get()
+	if iBig != nil || jBig != nil {
+		return i.bigInt().Cmp(j.bigInt()), nil
 	}
-	return signum64(xSmall - ySmall), nil // safe: int32 operands
+	return signum64(iSmall - jSmall), nil // safe: int32 operands
 }
 
 // Float returns the float value nearest i.

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -466,7 +466,7 @@ func isFinite(f float64) bool {
 }
 
 // Cmp implements comparison of two Float values.
-// Required by starlark.TotallyOrdered interface.
+// Required by the TotallyOrdered interface.
 func (f Float) Cmp(v Value, depth int) (int, error) {
 	g := v.(Float)
 	return floatCmp(f, g), nil

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -465,9 +465,11 @@ func isFinite(f float64) bool {
 	return math.Abs(f) <= math.MaxFloat64
 }
 
-func (x Float) Cmp(y_ Value, depth int) (int, error) {
-	y := y_.(Float)
-	return floatCmp(x, y), nil
+// Cmp implements comparison of two Float values.
+// Required by starlark.TotallyOrdered interface.
+func (f Float) Cmp(v Value, depth int) (int, error) {
+	g := v.(Float)
+	return floatCmp(f, g), nil
 }
 
 // floatCmp performs a three-valued comparison on floats,


### PR DESCRIPTION
Google's linter is complaining about the following:

* comment on exported method Int.Cmp should be of the form "Cmp ..."
* receiver name x should be consistent with previous receiver name i for Int
* exported method Float.Cmp should have comment or be unexported
* receiver name x should be consistent with previous receiver name f for Float
* method parameter y_ should be y