### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1439,7 +1439,7 @@ on the value returned by `get_filename()`.
 ## Value concepts
 
 Starlark has eleven core [data types](#data-types).  An application
-that embeds the Starlark intepreter may define additional types that
+that embeds the Starlark interpreter may define additional types that
 behave like Starlark values.  All values, whether core or
 application-defined, implement a few basic behaviors:
 

--- a/resolve/binding.go
+++ b/resolve/binding.go
@@ -10,7 +10,7 @@ import "go.starlark.net/syntax"
 // We cannot guarantee API stability for these types
 // as they are closely tied to the implementation.
 
-// A Binding contains resolver information about an identifer.
+// A Binding contains resolver information about an identifier.
 // The resolver populates the Binding field of each syntax.Identifier.
 // The Binding ties together all identifiers that denote the same variable.
 type Binding struct {

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -1453,7 +1453,7 @@ func Iterate(x Value) Iterator {
 // Bytes is the type of a Starlark binary string.
 //
 // A Bytes encapsulates an immutable sequence of bytes.
-// It is comparable, indexable, and sliceable, but not direcly iterable;
+// It is comparable, indexable, and sliceable, but not directly iterable;
 // use bytes.elems() for an iterable view.
 //
 // In this Go implementation, the elements of 'string' and 'bytes' are

--- a/syntax/walk_test.go
+++ b/syntax/walk_test.go
@@ -96,7 +96,7 @@ for o in [p for q, r in s if t]:
 	})
 	fmt.Println(strings.Join(idents, " "))
 
-	// The identifer 'a' appears in both LoadStmt.From[0] and LoadStmt.To[0].
+	// The identifier 'a' appears in both LoadStmt.From[0] and LoadStmt.To[0].
 
 	// Output:
 	// a a b c d e f g h i j k l m n o p q r s t u v w x y z


### PR DESCRIPTION
This PR fixes typos in the Go comments and markdown docs.