### PR TITLE
Remove 'too many arguments' error when interpolating over mappings

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2197,6 +2197,9 @@ which must be a tuple with exactly one component per conversion,
 unless the format string contains only a single conversion, in which
 case `args` itself is its operand.
 
+If the format string contains no conversions, the operand must be a
+`Mapping` or an empty tuple.
+
 Starlark does not support the flag, width, and padding specifiers
 supported by Python's `%` and other variants of C's `printf`.
 

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1659,11 +1659,14 @@ func interpolate(format string, x Value) (Value, error) {
 		index++
 	}
 
-	if _, ok := x.(Mapping); !ok {
-		if index < nargs {
-			return nil, fmt.Errorf("too many arguments for format string")
-		}
+	if index < nargs && !is[Mapping](x) {
+		return nil, fmt.Errorf("too many arguments for format string")
 	}
 
 	return String(buf.String()), nil
+}
+
+func is[T any](x any) bool {
+	_, ok := x.(T)
+	return ok
 }

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -1659,8 +1659,10 @@ func interpolate(format string, x Value) (Value, error) {
 		index++
 	}
 
-	if index < nargs {
-		return nil, fmt.Errorf("too many arguments for format string")
+	if _, ok := x.(Mapping); !ok {
+		if index < nargs {
+			return nil, fmt.Errorf("too many arguments for format string")
+		}
 	}
 
 	return String(buf.String()), nil

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -40,7 +40,7 @@ func init() {
 		"True":      True,
 		"False":     False,
 		"abs":       NewBuiltin("abs", abs),
-		"any":       NewBuiltin("any", any),
+		"any":       NewBuiltin("any", any_),
 		"all":       NewBuiltin("all", all),
 		"bool":      NewBuiltin("bool", bool_),
 		"bytes":     NewBuiltin("bytes", bytes_),
@@ -210,7 +210,7 @@ func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#any
-func any(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := UnpackPositionalArgs("any", args, kwargs, 1, &iterable); err != nil {
 		return nil, err

--- a/starlark/testdata/string.star
+++ b/starlark/testdata/string.star
@@ -172,7 +172,9 @@ assert.eq(gothash, wanthash)
 # TODO(adonovan): ordered comparisons
 
 # string % tuple formatting
+assert.eq("A" % (), "A")
 assert.eq("A %d %x Z" % (123, 456), "A 123 1c8 Z")
+assert.eq("A" % {'unused': 123}, "A")
 assert.eq("A %(foo)d %(bar)s Z" % {"foo": 123, "bar": "hi"}, "A 123 hi Z")
 assert.eq("%s %r" % ("hi", "hi"), 'hi "hi"')  # TODO(adonovan): use ''-quotation
 assert.eq("%%d %d" % 1, "%d 1")


### PR DESCRIPTION
When no conversions are specified, interpolation over an empty tuple is accepted, but interpolation over an empty dict is rejected:
```
>>> 'foo' % ()
"foo"
>>> 'foo' % {}
Traceback (most recent call last):
  <stdin>:1:7: in <expr>
Error: too many arguments for format string
```
For context, extra dict arguments are not rejected when a conversion is present:
```
>>> '%(a)d' % {'a': 1, 'unused': 2}
"1"
```
This PR relaxes the 'too many arguments' check for mappings and adds tests to ensure consistency between tuples and dicts