### PR TITLE
Remove debug clock from Time.String()

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -19,37 +19,37 @@ import (
 // Module time is a Starlark module of time-related functions and constants.
 // The module defines the following functions:
 //
-//     from_timestamp(sec, nsec) - Converts the given Unix time corresponding to the number of seconds
-//                                 and (optionally) nanoseconds since January 1, 1970 UTC into an object
-//                                 of type Time. For more details, refer to https://pkg.go.dev/time#Unix.
+//	    from_timestamp(sec, nsec) - Converts the given Unix time corresponding to the number of seconds
+//	                                and (optionally) nanoseconds since January 1, 1970 UTC into an object
+//	                                of type Time. For more details, refer to https://pkg.go.dev/time#Unix.
 //
-//     is_valid_timezone(loc) - Reports whether loc is a valid time zone name.
+//	    is_valid_timezone(loc) - Reports whether loc is a valid time zone name.
 //
-//     now() - Returns the current local time. Applications may replace this function by a deterministic one.
+//	    now() - Returns the current local time. Applications may replace this function by a deterministic one.
 //
-//     parse_duration(d) - Parses the given duration string. For more details, refer to
-//                         https://pkg.go.dev/time#ParseDuration.
+//	    parse_duration(d) - Parses the given duration string. For more details, refer to
+//	                        https://pkg.go.dev/time#ParseDuration.
 //
-//     parse_time(x, format, location) - Parses the given time string using a specific time format and location.
-//                                      The expected arguments are a time string (mandatory), a time format
-//                                      (optional, set to RFC3339 by default, e.g. "2021-03-22T23:20:50.52Z")
-//                                      and a name of location (optional, set to UTC by default). For more details,
-//                                      refer to https://pkg.go.dev/time#Parse and https://pkg.go.dev/time#ParseInLocation.
+//	    parse_time(x, format, location) - Parses the given time string using a specific time format and location.
+//	                                     The expected arguments are a time string (mandatory), a time format
+//	                                     (optional, set to RFC3339 by default, e.g. "2021-03-22T23:20:50.52Z")
+//	                                     and a name of location (optional, set to UTC by default). For more details,
+//	                                     refer to https://pkg.go.dev/time#Parse and https://pkg.go.dev/time#ParseInLocation.
 //
-//     time(year, month, day, hour, minute, second, nanosecond, location) - Returns the Time corresponding to
-//	                                                                        yyyy-mm-dd hh:mm:ss + nsec nanoseconds
-//                                                                          in the appropriate zone for that time
-//                                                                          in the given location. All the parameters
-//                                                                          are optional.
+//	    time(year, month, day, hour, minute, second, nanosecond, location) - Returns the Time corresponding to
+//		                                                                        yyyy-mm-dd hh:mm:ss + nsec nanoseconds
+//	                                                                         in the appropriate zone for that time
+//	                                                                         in the given location. All the parameters
+//	                                                                         are optional.
+//
 // The module also defines the following constants:
 //
-//     nanosecond - A duration representing one nanosecond.
-//     microsecond - A duration representing one microsecond.
-//     millisecond - A duration representing one millisecond.
-//     second - A duration representing one second.
-//     minute - A duration representing one minute.
-//     hour - A duration representing one hour.
-//
+//	nanosecond - A duration representing one nanosecond.
+//	microsecond - A duration representing one microsecond.
+//	millisecond - A duration representing one millisecond.
+//	second - A duration representing one second.
+//	minute - A duration representing one minute.
+//	hour - A duration representing one hour.
 var Module = &starlarkstruct.Module{
 	Name: "time",
 	Members: starlark.StringDict{
@@ -253,14 +253,15 @@ func (d Duration) Cmp(v starlark.Value, depth int) (int, error) {
 
 // Binary implements binary operators, which satisfies the starlark.HasBinary
 // interface. operators:
-//    duration + duration = duration
-//    duration + time = time
-//    duration - duration = duration
-//    duration / duration = float
-//    duration / int = duration
-//    duration / float = duration
-//    duration // duration = int
-//    duration * int = duration
+//
+//	duration + duration = duration
+//	duration + time = time
+//	duration - duration = duration
+//	duration / duration = float
+//	duration / int = duration
+//	duration / float = duration
+//	duration // duration = int
+//	duration * int = duration
 func (d Duration) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
 	x := time.Duration(d)
 
@@ -360,8 +361,9 @@ func newTime(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, 
 }
 
 // String returns the time formatted using the format string
+//
 //	"2006-01-02 15:04:05.999999999 -0700 MST".
-func (t Time) String() string { return time.Time(t).String() }
+func (t Time) String() string { return time.Time(t).Format("2006-01-02 15:04:05.999999999 -0700 MST") }
 
 // Type returns "time.time".
 func (t Time) Type() string { return "time.time" }
@@ -437,9 +439,10 @@ func (t Time) Cmp(yV starlark.Value, depth int) (int, error) {
 
 // Binary implements binary operators, which satisfies the starlark.HasBinary
 // interface
-//    time + duration = time
-//    time - duration = time
-//    time - time = duration
+//
+//	time + duration = time
+//	time - duration = time
+//	time - time = duration
 func (t Time) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
 	x := time.Time(t)
 


### PR DESCRIPTION
`Time.String()` states in the documentation that it formats time according to the string `2006-01-02 15:04:05.999999999 -0700 MST`, however it uses `time.Time.String()` methods which, if available, adds to that string the monotonic clock, leading to inconsistent output. For example:

```
>>> time.now()
2024-01-23 14:47:50.352396992 +0100 CET m=+210.079650729
>>> time.parse_time("2024-01-23T14:47:50.352396992+01:00")
2024-01-23 14:47:50.352396992 +0100 CET
```

This PR uses a format string instead, so that the output does never contain the monotonic clock.