### PR TITLE
starlark: update go.mod to drop go1.18 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.starlark.net
 
-go 1.18
+go 1.19
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e


### PR DESCRIPTION
Also, use go1.19's maphash.String.
The benchmark supports continuing to use FNV for short strings.