### PR TITLE
syntax: report start-of-token pos for parsePrimary errors

### DIFF
--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -857,7 +857,9 @@ func (p *parser) parsePrimary() Expr {
 			X:     x,
 		}
 	}
-	p.in.errorf(p.in.pos, "got %#v, want primary expression", p.tok)
+
+	// Report start pos of final token as it may be a NEWLINE (#532).
+	p.in.errorf(p.tokval.pos, "got %#v, want primary expression", p.tok)
 	panic("unreachable")
 }
 

--- a/syntax/testdata/errors.star
+++ b/syntax/testdata/errors.star
@@ -3,8 +3,8 @@
 #
 # TODO(adonovan): lots more tests.
 
-x = 1 +
-2 ### "got newline, want primary expression"
+x = 1 + ### "got newline, want primary expression"
+2 
 
 ---
 
@@ -174,8 +174,8 @@ def f(load): ### `not an identifier`
 # A load statement allows a trailing comma.
 load("module", "x",)
 ---
-x = 1 +
-2 ### "got newline, want primary expression"
+x = 1 + ### "got newline, want primary expression"
+2 
 ---
 def f():
     pass


### PR DESCRIPTION
syntax: report start-of-token pos for parsePrimary errors
    
(Conceivably other places need a similar ttreament, but they all seemed benign or marginal.)
    
Fixes #532 
