### PR TITLE
draft: extended comparison functions return Value type

### DIFF
--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -161,7 +161,7 @@ loop:
 				err = err2
 				break loop
 			}
-			stack[sp] = Bool(ok)
+			stack[sp] = ok
 			sp++
 
 		case compile.PLUS,

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -756,7 +756,7 @@ func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 		if ok, err := Compare(op, key, extremeKey); err != nil {
 			return nil, nameErr(b, err)
-		} else if ok {
+		} else if ok.Truth() {
 			extremum = x
 			extremeKey = key
 		}
@@ -1068,8 +1068,9 @@ func (s *sortSlice) Less(i, j int) bool {
 	ok, err := Compare(syntax.LT, keys[i], keys[j])
 	if err != nil {
 		s.err = err
+		return false
 	}
-	return ok
+	return bool(ok.Truth())
 }
 func (s *sortSlice) Swap(i, j int) {
 	if s.keys != nil {


### PR DESCRIPTION
Ref #541
Note: draft 

Temporarily added a new interface to let the Compare method return the Value type, and use the Truth method of Value as the basis for the bool's judgment.

The purpose of this is to allow more flexibility in the types that can be implemented through Go code extensions.

