### PR TITLE
docs: fix typos

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1160,7 +1160,7 @@ A function call completes normally after the execution of either a
 `return` statement, or of the last statement in the function body.
 The result of the function call is the value of the return statement's
 operand, or `None` if the return statement had no operand or if the
-function completeted without executing a return statement.
+function completed without executing a return statement.
 
 ```python
 def f(x):
@@ -1345,7 +1345,7 @@ x = "hello"
 
 The same is also true for nested loops in comprehensions.
 In the (unnatural) examples below, the scope of the variables `x`, `y`, 
-and `z` is the entire compehension block, except the operand of the first
+and `z` is the entire comprehension block, except the operand of the first
 loop (`[]` or `[1]`), which is resolved in the enclosing environment.
 The second loop may thus refer to variables defined by the third (`z`),
 even though such references would fail if actually executed.
@@ -3983,7 +3983,7 @@ See also: `string·codepoints`.
 <a id='string·count'></a>
 ### string·count
 
-`S.count(sub[, start[, end]])` returns the number of occcurences of
+`S.count(sub[, start[, end]])` returns the number of occurrences of
 `sub` within the string S, or, if the optional substring indices
 `start` and `end` are provided, within the designated substring of S.
 They are interpreted according to Starlark's [indexing conventions](#indexing).

--- a/starlark/profile.go
+++ b/starlark/profile.go
@@ -22,7 +22,7 @@ package starlark
 // stack and sends it to the profiler goroutine, along with the number
 // of quanta, which are subtracted. For example, if the accumulator
 // holds 3ms and then a completed span adds 25ms to it, its value is 28ms,
-// which exceeeds 10ms. The profiler records a stack with the value 20ms
+// which exceeds 10ms. The profiler records a stack with the value 20ms
 // (2 quanta), and the accumulator is left with 8ms.
 //
 // The profiler goroutine converts the stacks into the pprof format and
@@ -391,7 +391,7 @@ func profFuncAddr(fn Callable) uintptr {
 	}
 
 	// User-defined callable types are typically of
-	// of kind pointer-to-struct. Handle them specially.
+	// kind pointer-to-struct. Handle them specially.
 	if v := reflect.ValueOf(fn); v.Type().Kind() == reflect.Ptr {
 		return v.Pointer()
 	}

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -535,7 +535,7 @@ func (f Float) Unary(op syntax.Token) (Value, error) {
 
 // String is the type of a Starlark text string.
 //
-// A String encapsulates an an immutable sequence of bytes,
+// A String encapsulates an immutable sequence of bytes,
 // but strings are not directly iterable. Instead, iterate
 // over the result of calling one of these four methods:
 // codepoints, codepoint_ords, elems, elem_ords.
@@ -1624,7 +1624,7 @@ func Iterate(x Value) Iterator {
 //
 //	for elem := range Elements(iterable) { ... }
 //
-// Push iterators are provided as a convience for Go client code. The
+// Push iterators are provided as a convenience for Go client code. The
 // core iteration behavior of Starlark for-loops is defined by the
 // [Iterable] interface.
 //
@@ -1654,7 +1654,7 @@ func Elements(iterable Iterable) func(yield func(Value) bool) {
 //
 //	for k, v := range Entries(mapping) { ... }
 //
-// Push iterators are provided as a convience for Go client code. The
+// Push iterators are provided as a convenience for Go client code. The
 // core iteration behavior of Starlark for-loops is defined by the
 // [Iterable] interface.
 //

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -556,7 +556,7 @@ func (p *parser) parseTest() Expr {
 	return x
 }
 
-// parseTestNoCond parses a a single-component expression without
+// parseTestNoCond parses a single-component expression without
 // consuming a trailing 'if expr else expr'.
 func (p *parser) parseTestNoCond() Expr {
 	if p.tok == LAMBDA {


### PR DESCRIPTION
The PR corrects grammar mistakes and removes duplicated words in doc comments.