### PR TITLE
Fix overflow checking for repeat operation

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"math/big"
+	"math/bits"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -1192,8 +1193,8 @@ func tupleRepeat(elems Tuple, n Int) (Tuple, error) {
 		return nil, nil
 	}
 	// Inv: i > 0, len > 0
-	sz := len(elems) * i
-	if sz < 0 || sz >= maxAlloc { // sz < 0 => overflow
+	of, sz := bits.Mul(uint(len(elems)), uint(i))
+	if of != 0 || sz >= maxAlloc { // of != 0 => overflow
 		// Don't print sz.
 		return nil, fmt.Errorf("excessive repeat (%d * %d elements)", len(elems), i)
 	}
@@ -1224,8 +1225,8 @@ func stringRepeat(s String, n Int) (String, error) {
 		return "", nil
 	}
 	// Inv: i > 0, len > 0
-	sz := len(s) * i
-	if sz < 0 || sz >= maxAlloc { // sz < 0 => overflow
+	of, sz := bits.Mul(uint(len(s)), uint(i))
+	if of != 0 || sz >= maxAlloc { // of != 0 => overflow
 		// Don't print sz.
 		return "", fmt.Errorf("excessive repeat (%d * %d elements)", len(s), i)
 	}


### PR DESCRIPTION
The current overflow check for repeat operation fails to check when a multiplication wraps to a positive number.

On 64 bits build it is hard to get one (as you would need a tuple/string with more than 2^32 element - but it's still possible).

On a 32 bits build however it is quite trivial:

```python
# tuples and lists return the wrong count
len((1,) * 641 * 6700417) # returns 1
len([1] * 641 * 6700417) # returns 1

# strings/bytes cause panic: strings: Repeat count causes overflow
"a" * 641 * 6700417
```

This PR uses `bits.Mul` to make sure that this does not happen. 