### PR TITLE
Implement set.update method

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3774,6 +3774,19 @@ y = set([2, 3])
 x.union(y)                              # set([1, 2, 3])
 ```
 
+<a id='set·update'></a>
+### set·update
+
+`S.update(iterable)` will have the effect of adding the members
+of the supplied iterable to the set. If no argument is provided
+then the method call will have no effect. The method will return
+`None`.
+
+```python
+x = set([1, 2])
+x.update([2, 3])
+```
+
 <a id='string·elem_ords'></a>
 ### string·elem_ords
 

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -839,7 +839,7 @@ A set has these methods:
 * [`remove`](#set·remove)
 * [`symmetric_difference`](#set·symmetric_difference)
 * [`union`](#set·union)
-
+* [`update`](#set·update)
 
 A set used in a Boolean context is considered true if it is non-empty.
 
@@ -3777,14 +3777,12 @@ x.union(y)                              # set([1, 2, 3])
 <a id='set·update'></a>
 ### set·update
 
-`S.update(iterable)` will have the effect of adding the members
-of the supplied iterable to the set. If no argument is provided
-then the method call will have no effect. The method will return
-`None`.
+`S.update(iterable...)` adds to S each element of the iterable
+sequences. The method will return `None`.
 
 ```python
 x = set([1, 2])
-x.update([2, 3])
+x.update([2, 3], [4, 5])
 ```
 
 <a id='string·elem_ords'></a>

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -151,6 +151,7 @@ var (
 		"remove":               NewBuiltin("remove", set_remove),
 		"symmetric_difference": NewBuiltin("symmetric_difference", set_symmetric_difference),
 		"union":                NewBuiltin("union", set_union),
+		"update":               NewBuiltin("update", set_update),
 	}
 )
 
@@ -2347,6 +2348,22 @@ func set_union(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 		return nil, nameErr(b, err)
 	}
 	return union, nil
+}
+
+// https://github.com/google/starlark-go/blob/master/doc/spec.md#set·update.
+func set_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+	var iterable Iterable
+	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &iterable); err != nil {
+		return nil, err
+	}
+	if iterable != nil {
+		iter := iterable.Iterate()
+		defer iter.Done()
+		if err := b.Receiver().(*Set).InsertAll(iter); err != nil {
+			return None, nameErr(b, err)
+		}
+	}
+	return None, nil
 }
 
 // Common implementation of string_{r}{find,index}.

--- a/starlark/testdata/builtins.star
+++ b/starlark/testdata/builtins.star
@@ -196,7 +196,7 @@ assert.eq(getattr(hf, "x"), 2)
 assert.eq(hf.x, 2)
 # built-in types can have attributes (methods) too.
 myset = set([])
-assert.eq(dir(myset), ["add", "clear", "difference", "discard", "intersection", "issubset", "issuperset", "pop", "remove", "symmetric_difference", "union"])
+assert.eq(dir(myset), ["add", "clear", "difference", "discard", "intersection", "issubset", "issuperset", "pop", "remove", "symmetric_difference", "union", "update"])
 assert.true(hasattr(myset, "union"))
 assert.true(not hasattr(myset, "onion"))
 assert.eq(str(getattr(myset, "union")), "<built-in method union of set value>")

--- a/starlark/testdata/set.star
+++ b/starlark/testdata/set.star
@@ -95,6 +95,13 @@ def test_update_set():
 
 test_update_set()
 
+def test_update_set_multiple_args():
+    s = set(x)
+    s.update([11, 12], [11, 13, 14])
+    assert.eq(list(s), [1, 2, 3, 11, 12, 13, 14])
+
+test_update_set_multiple_args()
+
 def test_update_list_intersecting():
     s = set(x)
     s.update([5, 1])
@@ -117,9 +124,15 @@ test_update_non_hashable()
 
 def test_update_non_iterable():
     s = set(x)
-    assert.fails(lambda: x.update(9), "update: for parameter 1: got int, want iterable")
+    assert.fails(lambda: x.update(9), "update: arg at 0 was int, want interable")
 
 test_update_non_iterable()
+
+def test_update_kwargs():
+    s = set(x)
+    assert.fails(lambda: x.update(gee = [3, 4]), "update: kwargs disallowed")
+
+test_update_kwargs()
 
 def test_update_no_arg():
     s = set(x)

--- a/starlark/testdata/set.star
+++ b/starlark/testdata/set.star
@@ -124,13 +124,13 @@ test_update_non_hashable()
 
 def test_update_non_iterable():
     s = set(x)
-    assert.fails(lambda: x.update(9), "update: arg at 0 was int, want interable")
+    assert.fails(lambda: x.update(9), "update: argument #1 is not iterable: int")
 
 test_update_non_iterable()
 
 def test_update_kwargs():
     s = set(x)
-    assert.fails(lambda: x.update(gee = [3, 4]), "update: kwargs disallowed")
+    assert.fails(lambda: x.update(gee = [3, 4]), "update: update does not accept keyword arguments")
 
 test_update_kwargs()
 

--- a/starlark/testdata/set.star
+++ b/starlark/testdata/set.star
@@ -9,7 +9,6 @@
 
 # TODO(adonovan): support set mutation:
 # - del set[k]
-# - set.update
 # - set += iterable, perhaps?
 # Test iterator invalidation.
 
@@ -64,6 +63,70 @@ assert.eq(list(x.union(y)), [1, 2, 3, 4, 5])
 assert.eq(list(x.union([5, 1])), [1, 2, 3, 5])
 assert.eq(list(x.union((6, 5, 4))), [1, 2, 3, 6, 5, 4])
 assert.fails(lambda : x.union([1, 2, {}]), "unhashable type: dict")
+
+# set.update (allows any iterable for the right operand)
+# The update function will mutate the set so the tests below are
+# scoped using a function.
+def test_update_elems_singular():
+    s = set("a".elems())
+    s.update("b".elems())
+    assert.eq(list(s), ["a", "b"])
+
+test_update_elems_singular()
+
+def test_update_elems_multiple():
+    s = set("a".elems())
+    s.update("bc".elems())
+    assert.eq(list(s), ["a", "b", "c"])
+
+test_update_elems_multiple()
+
+def test_update_empty():
+    s = set()
+    s.update([])
+    assert.eq(s, set())
+
+test_update_empty()
+
+def test_update_set():
+    s = set(x)
+    s.update(y)
+    assert.eq(list(s), [1, 2, 3, 4, 5])
+
+test_update_set()
+
+def test_update_list_intersecting():
+    s = set(x)
+    s.update([5, 1])
+    assert.eq(list(s), [1, 2, 3, 5])
+
+test_update_list_intersecting()
+
+def test_update_list_non_intersecting():
+    s = set(x)
+    s.update([6, 5, 4])
+    assert.eq(list(s), [1, 2, 3, 6, 5, 4])
+
+test_update_list_non_intersecting()
+
+def test_update_non_hashable():
+    s = set(x)
+    assert.fails(lambda: x.update([1, 2, {}]), "unhashable type: dict")
+
+test_update_non_hashable()
+
+def test_update_non_iterable():
+    s = set(x)
+    assert.fails(lambda: x.update(9), "update: for parameter 1: got int, want iterable")
+
+test_update_non_iterable()
+
+def test_update_no_arg():
+    s = set(x)
+    s.update()
+    assert.eq(list(s), [1, 2, 3])
+
+test_update_no_arg()
 
 # intersection, set & set or set.intersection(iterable)
 assert.eq(list(set("a".elems()) & set("b".elems())), [])
@@ -143,6 +206,12 @@ freeze(discard_set)
 assert.eq(discard_set.discard(3), None)  # no mutation of frozen set because key doesn't exist
 assert.fails(lambda: discard_set.discard(1), "discard: cannot delete from frozen hash table")
 
+# update
+update_set = set([1, 2, 3])
+update_set.update([4])
+assert.true(4 in update_set)
+freeze(update_set)
+assert.fails(lambda: update_set.update([5]), "update: cannot insert into frozen hash table")
 
 # pop
 pop_set = set([1,2,3])

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -1232,6 +1232,16 @@ func (s *Set) Union(iter Iterator) (Value, error) {
 	return set, nil
 }
 
+func (s *Set) InsertAll(iter Iterator) error {
+	var x Value
+	for iter.Next(&x) {
+		if err := s.Insert(x); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Set) Difference(other Iterator) (Value, error) {
 	diff := s.clone()
 	var x Value


### PR DESCRIPTION
The method [update](https://github.com/bazelbuild/starlark/blob/master/spec.md#setupdate) on the type `set` is available in the Bazel implementation of Starlark, but unfortunately not this Go implementation. This PR will augment the `set` implementation to also support the `update` method.