### PR TITLE
Bytes Index(i) should return int value of the ith element. 

### DIFF
--- a/starlark/testdata/bytes.star
+++ b/starlark/testdata/bytes.star
@@ -84,8 +84,8 @@ assert.eq(hash(b"ab"), 0x4d2505ca)
 assert.eq(hash(b"abc"), 0x1a47e90b)
 
 # indexing
-assert.eq(goodbye[0], b"g")
-assert.eq(goodbye[-1], b"e")
+assert.eq(goodbye[0], 103)
+assert.eq(goodbye[-1], 101)
 assert.fails(lambda: goodbye[100], "out of range")
 
 # slicing

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -1621,7 +1621,7 @@ func (b Bytes) Freeze()               {} // immutable
 func (b Bytes) Truth() Bool           { return len(b) > 0 }
 func (b Bytes) Hash() (uint32, error) { return String(b).Hash() }
 func (b Bytes) Len() int              { return len(b) }
-func (b Bytes) Index(i int) Value     { return b[i : i+1] }
+func (b Bytes) Index(i int) Value     { return MakeInt(int(b[i])) }
 
 func (b Bytes) Attr(name string) (Value, error) { return builtinAttr(b, name, bytesMethods) }
 func (b Bytes) AttrNames() []string             { return builtinAttrNames(bytesMethods) }


### PR DESCRIPTION
According to the Starlark Spec https://github.com/bazelbuild/starlark/blob/master/spec.md#bytes `bytes` index should return an `int` not a subsequence of length 1.