### PR TITLE
Never allow set.add() / set.discard() if set is frozen or being iterated

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3627,10 +3627,13 @@ x.remove(2)                             # error: element not found
 <a id='set·add'></a>
 ### set·add
 
-If `x` is not an element of set `S`, `S.add(x)` adds it to the set or fails if the set is frozen.
-If `x` already an element of the set, `add(x)` has no effect.
+`S.add(x)` adds the value `x` to the set `S`. It returns `None`.
 
-It returns None.
+It is permissible to `add` a value already present in the set; this leaves the
+set `S` unchanged.
+
+`add` fails if the set `S` is frozen or has active iterators, or if `x` is
+unhashable.
 
 ```python
 x = set([1, 2])
@@ -3668,10 +3671,14 @@ x.difference([3, 4, 5])                   # set([1, 2])
 <a id='set·discard'></a>
 ### set·discard
 
-If `x` is an element of set `S`, `S.discard(x)` removes `x` from the set, or fails if the
-set is frozen. If `x` is not an element of the set, discard has no effect.
+`S.discard(x)` removes the value `x` from the set `S` if present. It returns
+`None`.
 
-It returns None.
+It is permissible to `discard` a value not present in the set; this leaves the
+set `S` unchanged.
+
+`discard` fails if the set `S` is frozen or has active iterators, or if `x` is
+unhashable. This applies even if `x` is not a member of the set.
 
 ```python
 x = set([1, 2, 3])

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -2190,6 +2190,7 @@ func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := recv.ht.checkMutable("insert into"); err != nil {
 		return nil, nameErr(b, err)
 	}
+	// TODO(adonovan): opt: combine Has+Insert. (e.g. use Insert and re-check Len)
 	if found, err := recv.Has(elem); err != nil {
 		return nil, nameErr(b, err)
 	} else if found {
@@ -2288,6 +2289,7 @@ func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	if err := recv.ht.checkMutable("delete from"); err != nil {
 		return nil, nameErr(b, err)
 	}
+	// TODO(adonovan): opt: combine Has+Delete (e.g. use Delete and re-check Len)
 	if found, err := recv.Has(k); err != nil {
 		return nil, nameErr(b, err)
 	} else if !found {

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -2188,6 +2188,10 @@ func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if found, err := b.Receiver().(*Set).Has(elem); err != nil {
 		return nil, nameErr(b, err)
 	} else if found {
+		// It is always an error to attempt to mutate a set that cannot be mutated
+		if err := b.Receiver().(*Set).ht.checkMutable("insert into"); err != nil {
+			return nil, nameErr(b, err)
+		}
 		return None, nil
 	}
 	err := b.Receiver().(*Set).Insert(elem)
@@ -2281,6 +2285,10 @@ func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	if found, err := b.Receiver().(*Set).Has(k); err != nil {
 		return nil, nameErr(b, err)
 	} else if !found {
+		// It is always an error to attempt to mutate a set that cannot be mutated
+		if err := b.Receiver().(*Set).ht.checkMutable("delete from"); err != nil {
+			return nil, nameErr(b, err)
+		}
 		return None, nil
 	}
 	if _, err := b.Receiver().(*Set).Delete(k); err != nil {

--- a/starlark/testdata/set.star
+++ b/starlark/testdata/set.star
@@ -207,8 +207,15 @@ assert.fails(lambda : x[0], "unhandled.*operation")
 add_set = set([1,2,3])
 add_set.add(4)
 assert.true(4 in add_set)
-freeze(add_set) # no mutation of frozen set because key already present
-add_set.add(4)
+add_set.add(1)
+assert.eq(list(add_set), [1, 2, 3, 4]) # adding existing element is a no-op and doesn't change iteration order
+assert.fails(lambda: add_set.add([5]), "add: unhashable type: list")
+def add_during_iteration(s, v):
+    for _ in s:
+        s.add(v)
+assert.fails(lambda: add_during_iteration(add_set, 4), "add: cannot insert into hash table during iteration")
+freeze(add_set)
+assert.fails(lambda: add_set.add(4), "add: cannot insert into frozen hash table") # even a no-op mutation on a frozen set is an error
 assert.fails(lambda: add_set.add(5), "add: cannot insert into frozen hash table")
 
 # remove
@@ -224,8 +231,13 @@ discard_set = set([1,2,3])
 discard_set.discard(3)
 assert.true(3 not in discard_set)
 assert.eq(discard_set.discard(3), None)
+assert.fails(lambda: discard_set.discard([5]), "discard: unhashable type: list")
+def discard_during_iteration(s, v):
+    for _ in s:
+        s.discard(v)
+assert.fails(lambda: discard_during_iteration(discard_set, 2), "discard: cannot delete from hash table during iteration")
 freeze(discard_set)
-assert.eq(discard_set.discard(3), None)  # no mutation of frozen set because key doesn't exist
+assert.fails(lambda: discard_set.discard(3), "discard: cannot delete from frozen hash table") # even a no-op mutation on a frozen set is an error
 assert.fails(lambda: discard_set.discard(1), "discard: cannot delete from frozen hash table")
 
 # update


### PR DESCRIPTION
Match language spec: https://github.com/bazelbuild/starlark/blob/master/spec.md#set%C2%B7add

Working towards https://github.com/google/starlark-go/issues/584