### PR TITLE
fix: prevent race condition in List.Slice method

### DIFF
--- a/starlark/value_test.go
+++ b/starlark/value_test.go
@@ -8,7 +8,9 @@ package starlark_test
 
 import (
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.starlark.net/starlark"
@@ -153,5 +155,102 @@ func TestParamDefault(t *testing.T) {
 				t.Errorf("param defaults got diff (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestListSliceConcurrency tests that list slicing operations correctly prevent
+// concurrent modifications, adhering to the "fail-fast" iterator principle.
+// It simulates two goroutines: one repeatedly slicing the list and another
+// attempting to modify it concurrently. The test verifies that modifications
+// are blocked during slicing and can proceed once slicing is complete.
+func TestListSliceConcurrency(t *testing.T) {
+	// Setup: Create a large list
+	const listSize = 10000
+	elems := make([]starlark.Value, listSize)
+	for i := range elems {
+		elems[i] = starlark.MakeInt(i)
+	}
+	list := starlark.NewList(elems)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Channels to signal completion or errors from goroutines
+	slicerDone := make(chan struct{})
+	modifierErrChan := make(chan error, 1)
+
+	// Goroutine A: Repeatedly performs slicing operations. It should not panic.
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Slicing goroutine panicked unexpectedly: %v", r)
+			}
+			close(slicerDone)
+		}()
+
+		for i := 0; i < 100; i++ {
+			_ = list.Slice(0, list.Len()/2, 1)
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+
+	// Goroutine B: Attempts to modify the list while Goroutine A is potentially slicing.
+	// It expects to receive an error indicating the list is being iterated.
+	go func() {
+		defer wg.Done()
+		var firstError error
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Modifying goroutine panicked unexpectedly: %v", r)
+			}
+			modifierErrChan <- firstError
+			close(modifierErrChan)
+		}()
+
+		time.Sleep(5 * time.Millisecond)
+
+		for i := 0; i < 50; i++ {
+			// Attempt to append. This should fail if the slicer has incremented itercount.
+			err := list.Append(starlark.MakeInt(listSize))
+			if err != nil {
+				if firstError == nil {
+					firstError = err
+				}
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+	<-slicerDone
+
+	// 1. Check if the modifier goroutine encountered the expected error.
+	modifyErr := <-modifierErrChan
+	if modifyErr == nil {
+		t.Errorf("Modifier goroutine did not encounter an error. Expected modification to be blocked by concurrent slicing. List len: %d", list.Len())
+	} else {
+		// Verify the error is the specific "iteration" error.
+		// Using Errorf for specific error formatting from starlark package.
+		expectedErrStr := "cannot append to list during iteration"
+		if modifyErr.Error() != expectedErrStr {
+			t.Errorf("Modifier goroutine encountered wrong error.\nWant: %q\nGot:  %q", expectedErrStr, modifyErr.Error())
+		}
+	}
+
+	// 2. Verify the list can be modified *after* concurrent operations are finished.
+	lengthBeforeFinalAppend := list.Len()
+	finalValue := starlark.MakeInt(listSize + 1)
+	finalAppendErr := list.Append(finalValue)
+	if finalAppendErr != nil {
+		t.Fatalf("Append after concurrent operations failed unexpectedly: %v", finalAppendErr)
+	}
+
+	// 3. Check the final list length.
+	expectedFinalLength := lengthBeforeFinalAppend + 1
+	if list.Len() != expectedFinalLength {
+		t.Errorf("Final list length mismatch.\nWant: %d (length after concurrency %d + 1)\nGot:  %d",
+			expectedFinalLength, lengthBeforeFinalAppend, list.Len())
 	}
 }


### PR DESCRIPTION
## Description

This PR addresses a race condition in the list slicing operation (`list[start:end:step]`). When multiple Starlark threads operate concurrently on the same shared, mutable list, a slicing operation can lead to unexpected panics when another thread modifies the list during slicing.

Feedback welcome!

## Problem

Starlark's specification and implementation documentation explicitly specify that collections should be protected from concurrent modification during iteration. As noted in `doc/impl.md` under the "Fail-fast iterators" section:

> Instead of mutation of the collection invalidating the iterator, the act of iterating makes the collection temporarily immutable, so that an attempt to, say, delete a dict element while looping over the dict, will fail.

> This is implemented by having each mutable iterable value record a counter of active iterators. Starting a loop increments this counter, and completing a loop decrements it. A collection with a nonzero counter behaves as if frozen.

While this protection mechanism is correctly implemented for most operations, the List.Slice method was missing this crucial protection. Since slicing iterates through list elements, it should follow the same "fail-fast iterator" pattern as other iteration operations.

## Fix

This PR modifies the List.Slice method to:

- Increment the list's itercount at the start of slicing operations
- Decrement it when the operation completes (using a deferred function)

This makes slicing operations consistent with other list operations that iterate over elements, ensuring that attempts to modify a list while it's being sliced will fail with a clear error message instead of potentially causing a panic.

## References

I have a simple test application to validate this at https://go.dev/play/p/1CBhyyfJom0.

- Output without the proposed fix: `PANIC in Thread A (Slicing): runtime error: index out of range [724994] with length 1`
- Output with the proposed fix: `Thread B returned error: Error in clear: clear: cannot clear list during iteration`

Originally reported to Google OSS VRP.