### PR TITLE
feat: add method `CancelWithError()`

### DIFF
--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -105,8 +105,8 @@ loop:
 				thread.Cancel("too many steps")
 			}
 		}
-		if reason := atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&thread.cancelReason))); reason != nil {
-			err = fmt.Errorf("Starlark computation cancelled: %s", *(*string)(reason))
+		if reasonErr := atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&thread.cancelReason))); reasonErr != nil {
+			err = *(*error)(reasonErr)
 			break loop
 		}
 


### PR DESCRIPTION
I'm interested in knowing if the execution was cancelled, and I don't want to rely on string matching the error message to know it.