### PR TITLE
Print token value for illegal tokens

### DIFF
--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -11,7 +11,10 @@ package syntax
 // package.  Verify that error positions are correct using the
 // chunkedfile mechanism.
 
-import "log"
+import (
+	"fmt"
+	"log"
+)
 
 // Enable this flag to print the token stream and log.Fatal on the first error.
 const debug = false
@@ -129,7 +132,7 @@ func (opts *FileOptions) ParseExpr(filename string, src interface{}, mode Mode) 
 	}
 
 	if p.tok != EOF {
-		p.in.errorf(p.in.pos, "got %#v after expression, want EOF", p.tok)
+		p.in.errorf(p.in.pos, "got %s after expression, want EOF", p.tokStr())
 	}
 	p.assignComments(expr)
 	return expr, nil
@@ -140,6 +143,17 @@ type parser struct {
 	in      *scanner
 	tok     Token
 	tokval  tokenValue
+}
+
+// tokStr returns a string representation of the current token.
+func (p *parser) tokStr() string {
+	if p.tok == ILLEGAL {
+		// ILLEGAL is a catch-all for Python keywords that aren't supported in Starlark.
+		// In this case, we return the raw token value alongside the "illegal token" string
+		// to output a more informative error message.
+		return fmt.Sprintf("%#v %q", p.tok, p.tokval.raw)
+	}
+	return fmt.Sprintf("%#v", p.tok)
 }
 
 // nextToken advances the scanner and returns the position of the
@@ -386,7 +400,7 @@ func (p *parser) parseLoadStmt() *LoadStmt {
 			})
 
 		default:
-			p.in.errorf(p.in.pos, `load operand must be "name" or localname="name" (got %#v)`, p.tok)
+			p.in.errorf(p.in.pos, `load operand must be "name" or localname="name" (got %s)`, p.tokStr())
 		}
 	}
 	rparen := p.consume(RPAREN)
@@ -434,7 +448,7 @@ func (p *parser) parseIdent() *Ident {
 
 func (p *parser) consume(t Token) Position {
 	if p.tok != t {
-		p.in.errorf(p.in.pos, "got %#v, want %#v", p.tok, t)
+		p.in.errorf(p.in.pos, "got %s, want %#v", p.tokStr(), t)
 	}
 	return p.nextToken()
 }
@@ -621,7 +635,7 @@ func (p *parser) parseBinopExpr(prec int) Expr {
 			// In this context, NOT must be followed by IN.
 			// Replace NOT IN by a single NOT_IN token.
 			if p.tok != IN {
-				p.in.errorf(p.in.pos, "got %#v, want in", p.tok)
+				p.in.errorf(p.in.pos, "got %#v, want in", p.tokStr())
 			}
 			p.tok = NOT_IN
 		}
@@ -862,7 +876,7 @@ func (p *parser) parsePrimary() Expr {
 	}
 
 	// Report start pos of final token as it may be a NEWLINE (#532).
-	p.in.errorf(p.tokval.pos, "got %#v, want primary expression", p.tok)
+	p.in.errorf(p.tokval.pos, "got %#v, want primary expression", p.tokStr())
 	panic("unreachable")
 }
 
@@ -962,7 +976,7 @@ func (p *parser) parseComprehensionSuffix(lbrace Position, body Expr, endBrace T
 			cond := p.parseTestNoCond()
 			clauses = append(clauses, &IfClause{If: pos, Cond: cond})
 		} else {
-			p.in.errorf(p.in.pos, "got %#v, want '%s', for, or if", p.tok, endBrace)
+			p.in.errorf(p.in.pos, "got %#v, want '%s', for, or if", p.tokStr(), endBrace)
 		}
 	}
 	rbrace := p.nextToken()

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -22,7 +22,7 @@ import (
 type Token int8
 
 const (
-	ILLEGAL Token = iota
+	ILLEGAL Token = iota // deprecated: illegal tokens are at the bottom of this block
 	EOF
 
 	NEWLINE
@@ -97,6 +97,26 @@ const (
 	PASS
 	RETURN
 	WHILE
+
+	// Illegal tokens (reserved Python keywords that aren't part of the Starlark language)
+
+	AS // illegal
+	// ASSERT  // illegal  // heavily used in our tests
+	ASYNC    // illegal
+	AWAIT    // illegal
+	CLASS    // illegal
+	DEL      // illegal
+	EXCEPT   // illegal
+	FINALLY  // illegal
+	FROM     // illegal
+	GLOBAL   // illegal
+	IMPORT   // illegal
+	IS       // illegal
+	NONLOCAL // illegal
+	RAISE    // illegal
+	TRY      // illegal
+	WITH     // illegal
+	YIELD    // illegal
 
 	maxToken
 )
@@ -180,6 +200,25 @@ var tokenNames = [...]string{
 	PASS:          "pass",
 	RETURN:        "return",
 	WHILE:         "while",
+
+	// illegal tokens
+	AS: "as",
+	// ASSERT:   "assert", // heavily used in our tests
+	ASYNC:    "async",
+	AWAIT:    "await",
+	CLASS:    "class",
+	DEL:      "del",
+	EXCEPT:   "except",
+	FINALLY:  "finally",
+	FROM:     "from",
+	GLOBAL:   "global",
+	IMPORT:   "import",
+	IS:       "is",
+	NONLOCAL: "nonlocal",
+	RAISE:    "raise",
+	TRY:      "try",
+	WITH:     "with",
+	YIELD:    "yield",
 }
 
 // A FilePortion describes the content of a portion of a file.
@@ -1104,21 +1143,21 @@ var keywordToken = map[string]Token{
 	"while":    WHILE,
 
 	// reserved words:
-	"as": ILLEGAL,
-	// "assert":   ILLEGAL, // heavily used by our tests
-	"async":    ILLEGAL,
-	"await":    ILLEGAL,
-	"class":    ILLEGAL,
-	"del":      ILLEGAL,
-	"except":   ILLEGAL,
-	"finally":  ILLEGAL,
-	"from":     ILLEGAL,
-	"global":   ILLEGAL,
-	"import":   ILLEGAL,
-	"is":       ILLEGAL,
-	"nonlocal": ILLEGAL,
-	"raise":    ILLEGAL,
-	"try":      ILLEGAL,
-	"with":     ILLEGAL,
-	"yield":    ILLEGAL,
+	"as": AS,
+	// "assert":   ASSERT, // heavily used by our tests
+	"async":    ASYNC,
+	"await":    AWAIT,
+	"class":    CLASS,
+	"del":      DEL,
+	"except":   EXCEPT,
+	"finally":  FINALLY,
+	"from":     FROM,
+	"global":   GLOBAL,
+	"import":   IMPORT,
+	"is":       IS,
+	"nonlocal": NONLOCAL,
+	"raise":    RAISE,
+	"try":      TRY,
+	"with":     WITH,
+	"yield":    YIELD,
 }

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -22,7 +22,7 @@ import (
 type Token int8
 
 const (
-	ILLEGAL Token = iota // deprecated: illegal tokens are at the bottom of this block
+	ILLEGAL Token = iota
 	EOF
 
 	NEWLINE
@@ -98,25 +98,25 @@ const (
 	RETURN
 	WHILE
 
-	// Illegal tokens (reserved Python keywords that aren't part of the Starlark language)
+	// Reserved words (following Python); unused in Starlark
 
-	AS // illegal
-	// ASSERT  // illegal  // heavily used in our tests
-	ASYNC    // illegal
-	AWAIT    // illegal
-	CLASS    // illegal
-	DEL      // illegal
-	EXCEPT   // illegal
-	FINALLY  // illegal
-	FROM     // illegal
-	GLOBAL   // illegal
-	IMPORT   // illegal
-	IS       // illegal
-	NONLOCAL // illegal
-	RAISE    // illegal
-	TRY      // illegal
-	WITH     // illegal
-	YIELD    // illegal
+	AS
+	// ASSERT    // heavily used in our tests
+	ASYNC
+	AWAIT
+	CLASS
+	DEL
+	EXCEPT
+	FINALLY
+	FROM
+	GLOBAL
+	IMPORT
+	IS
+	NONLOCAL
+	RAISE
+	TRY
+	WITH
+	YIELD
 
 	maxToken
 )
@@ -201,7 +201,8 @@ var tokenNames = [...]string{
 	RETURN:        "return",
 	WHILE:         "while",
 
-	// illegal tokens
+	// Reserved words (following Python); unused in Starlark
+
 	AS: "as",
 	// ASSERT:   "assert", // heavily used in our tests
 	ASYNC:    "async",


### PR DESCRIPTION
If an illegal token (typically a Python keyword that isn't supported in Starlark) is encountered, the parser prints it as just `illegal token` in the error message. Without looking at the precise line:col position, this can be very confusing, especially for people coming from a Python background that are new to Starlark.

This PR ensures that in the illegal token case, the token value is printed alongside the `illegal token` string.

Before:
```
print(None is None)  # <script>:1:14: got illegal token, want ','
```
After:
```
print(None is None)  # <script>:1:14: got illegal token "is", want ','
```
