### PR TITLE
proto: add tests for extensions

### DIFF
--- a/starlark/testdata/proto.star
+++ b/starlark/testdata/proto.star
@@ -66,3 +66,15 @@ assert.fails(_assign_bad_value, "converting map value: got int, want string")
 
 # not hashable
 assert.fails(lambda: {m.map_field: 1}, "unhashable")
+
+# Extensions
+
+assert.eq(str(schema.ext_string_field), "go.starlark.net.testdata.ext_string_field")
+assert.eq(type(schema.ext_string_field), "proto.FieldDescriptor")
+assert.eq(dir(schema.ext_string_field), [])
+
+m2 = schema.Test(string_field="A")
+assert.eq(proto.has(m2, schema.ext_string_field), False)
+proto.set_field(m2, schema.ext_string_field, "B")
+assert.eq(proto.has(m2, schema.ext_string_field), True)
+assert.eq(proto.get_field(m2, schema.ext_string_field), "B")

--- a/starlark/testdata/proto/test.fds
+++ b/starlark/testdata/proto/test.fds
@@ -1,7 +1,7 @@
 
-ª
+ÿ
 
-test.protogo.starlark.net.testdata"ù
+test.protogo.starlark.net.testdata"ÿ
 Test!
 string_field (	RstringField
 int32_field (R
@@ -10,4 +10,5 @@ int32Field%
 	map_field (2,.go.starlark.net.testdata.Test.MapFieldEntryRmapField;
 MapFieldEntry
 key (	Rkey
-value (	Rvalue:8bproto3
+value (	Rvalue:8*de:H
+ext_string_field.go.starlark.net.testdata.Testd (	RextStringFieldbeditionspè

--- a/starlark/testdata/proto/test.proto
+++ b/starlark/testdata/proto/test.proto
@@ -6,7 +6,7 @@
 //
 // (Requires the "protobuf" brew/apt package, see
 // https://protobuf.dev/installation/)
-syntax = "proto3";
+edition = "2023";
 
 package go.starlark.net.testdata;
 
@@ -15,5 +15,10 @@ message Test {
     int32 int32_field = 2;
     repeated string repeated_field = 3;
     map<string, string> map_field = 4;
+
+    extensions 100 to 100;
 }
 
+extend Test {
+  string ext_string_field = 100;
+}


### PR DESCRIPTION
This encodes the existing behaviour.
It adds a fix to `has()`.