### PR TITLE
Support `while` statements in `syntax.Walk`

### DIFF
--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -370,7 +370,7 @@ func (sc *scanner) recover(err *error) {
 	case Error:
 		*err = e
 	default:
-		*err = Error{sc.pos, fmt.Sprintf("internal error: %T %#v", e, e)}
+		*err = Error{sc.pos, fmt.Sprintf("internal error: %v", e)}
 		if debug {
 			log.Fatal(*err)
 		}


### PR DESCRIPTION
`WhileStmt` may occur if allowed via the `syntax.FileOptions`. If it's present in an AST, we should assume it is allowed in the respective context and handle it properly when `Walk`ing.