### PR TITLE
Update Iterator comment for correct usage

### DIFF
--- a/starlark/value.go
+++ b/starlark/value.go
@@ -275,7 +275,7 @@ var (
 //	iter := seq.Iterate()
 //	defer iter.Done()
 //	var elem Value
-//	for iter.Next(elem) {
+//	for iter.Next(&elem) {
 //		...
 //	}
 //


### PR DESCRIPTION
Pass a pointer to Value to Next() in the docs. Only relevant for older Go versions but still worth fixing.