### PR TITLE
spec: fix dict.setdefault typo

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3466,7 +3466,7 @@ x.setdefault("one")                     # 1
 x.setdefault("three", 0)                # 0
 x                                       # {"one": 1, "two": 2, "three": 0}
 x.setdefault("four")                    # None
-x                                       # {"one": 1, "two": 2, "three": None}
+x                                       # {"one": 1, "two": 2, "three": 0, "four": None}
 ```
 
 <a id='dict·update'></a>


### PR DESCRIPTION
```py
❯ go run go.starlark.net/cmd/starlark@latest
Welcome to Starlark (go.starlark.net)
>>> x = {"one": 1, "two": 2}
>>> x.setdefault("one")                     # 1
1
>>> x.setdefault("three", 0)                # 0
0
>>> x                                       # {"one": 1, "two": 2, "three": 0}
{"one": 1, "two": 2, "three": 0}
>>> x.setdefault("four")                    # None
>>> x                                       # {"one": 1, "two": 2, "three": None}
{"one": 1, "two": 2, "three": 0, "four": None}
```