### PR TITLE
starlark: impose limit on Starlark recursion

### DIFF
--- a/starlark/testdata/recursion.star
+++ b/starlark/testdata/recursion.star
@@ -12,3 +12,10 @@ def fib(n):
 	return fib(n-1) + fib(n-2)
 
 assert.eq(fib(5), 8)
+
+def runaway():
+	return runaway()
+
+# Runaway recursion should not overflow the Go stack (#617).
+# The interpreter imposes a limit long before then.
+assert.fails(runaway, "Starlark stack overflow")


### PR DESCRIPTION
Exceeding this limit should not crash the Go program.

Fixes google/starlark-go#617