### PR TITLE
feat: add f-string literals (`f"…{expr}…"`) to Starlark

### DIFF
--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -71,6 +71,36 @@ func TestPlusFolding(t *testing.T) {
 		}
 	}
 }
+func TestFstring(t *testing.T) {
+	isPredeclared := func(name string) bool { return name == "x" }
+	isUniversal := func(name string) bool { return false }
+	for i, test := range []struct {
+		src  string // source expression
+		want string // disassembled code
+	}{
+		{
+			`f"hehehe"`,
+			`constant "abcd"; return`,
+		},
+	} {
+		expr, err := syntax.ParseExpr("in.star", test.src, 0)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		locals, err := resolve.Expr(expr, isPredeclared, isUniversal)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		got := disassemble(Expr(syntax.LegacyFileOptions(), expr, "<expr>", locals).Toplevel)
+		t.Logf("disassemble: %s",got)
+		// if test.want != got {
+		// 	t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
+		// 		test.src, got, test.want)
+		// }
+	}
+}
 
 // disassemble is a trivial disassembler tailored to the accumulator test.
 func disassemble(f *Funcode) string {

--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -79,8 +79,20 @@ func TestFstring(t *testing.T) {
 		want string // disassembled code
 	}{
 		{
-			`f"hehehe"`,
-			`constant "abcd"; return`,
+			`f"hehehe{7}"`,
+			`constant "hehehe{}"; attr<0>; constant 7; call<256>; return`,
+		},
+		{
+			`f"hehehe{7}" + f"hehe"`,
+			`constant "hehehe{}"; attr<0>; constant 7; call<256>; constant "hehe"; plus; return`,
+		},
+		{
+			`f"hehe" + f"hehe{7}"`,
+			`constant "hehe"; constant "hehe{}"; attr<0>; constant 7; call<256>; plus; return`,
+		},
+		{
+			`f"hehe" + f"hehe"`,
+			`constant "hehe"; constant "hehe"; plus; return`,
 		},
 	} {
 		expr, err := syntax.ParseExpr("in.star", test.src, 0)
@@ -94,11 +106,11 @@ func TestFstring(t *testing.T) {
 			continue
 		}
 		got := disassemble(Expr(syntax.LegacyFileOptions(), expr, "<expr>", locals).Toplevel)
-		t.Logf("disassemble: %s",got)
-		// if test.want != got {
-		// 	t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
-		// 		test.src, got, test.want)
-		// }
+		// t.Errorf("disassemble: %s", got)
+		if test.want != got {
+			t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
+				test.src, got, test.want)
+		}
 	}
 }
 

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1305,14 +1305,14 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 		if e.Token == syntax.BYTES {
 			v = Bytes(v.(string))
 		}
-		if e.Token == syntax.FSTRING_FULL{
+		if e.Token == syntax.FSTRING_FULL {
 			fmt.Print("compiling Fstring")
 		}
 		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(v))
-	
+
 	case *syntax.FStringExpr:
 		fmt.Print("compiling FstringExpr")
-		fcomp.emit1(CONSTANT,fcomp.pcomp.constantIndex(e.Raw))
+		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(e.Raw))
 
 	case *syntax.ListExpr:
 		for _, x := range e.List {

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1305,7 +1305,14 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 		if e.Token == syntax.BYTES {
 			v = Bytes(v.(string))
 		}
+		if e.Token == syntax.FSTRING_FULL{
+			fmt.Print("compiling Fstring")
+		}
 		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(v))
+	
+	case *syntax.FStringExpr:
+		fmt.Print("compiling FstringExpr")
+		fcomp.emit1(CONSTANT,fcomp.pcomp.constantIndex(e.Raw))
 
 	case *syntax.ListExpr:
 		for _, x := range e.List {

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1308,7 +1308,12 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(v))
 
 	case *syntax.FStringExpr:
-		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(e.Raw))
+		body := strings.Join(e.StringParts, "{}")
+		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(body))
+		fcomp.setPos(e.TokenPos)
+		fcomp.emit1(ATTR, fcomp.pcomp.nameIndex("format"))
+		op, arg := fcomp.args(e.Args)
+		fcomp.emit1(op, arg)
 
 	case *syntax.ListExpr:
 		for _, x := range e.List {
@@ -1662,7 +1667,7 @@ func (fcomp *fcomp) call(call *syntax.CallExpr) {
 
 	// usual case
 	fcomp.expr(call.Fn)
-	op, arg := fcomp.args(call)
+	op, arg := fcomp.args(call.Args)
 	fcomp.setPos(call.Lparen)
 	fcomp.emit1(op, arg)
 }
@@ -1670,12 +1675,12 @@ func (fcomp *fcomp) call(call *syntax.CallExpr) {
 // args emits code to push a tuple of positional arguments
 // and a tuple of named arguments containing alternating keys and values.
 // Either or both tuples may be empty (TODO(adonovan): optimize).
-func (fcomp *fcomp) args(call *syntax.CallExpr) (op Opcode, arg uint32) {
+func (fcomp *fcomp) args(callargs []syntax.Expr) (op Opcode, arg uint32) {
 	var callmode int
 	// Compute the number of each kind of parameter.
 	var p, n int // number of  positional, named arguments
 	var varargs, kwargs syntax.Expr
-	for _, arg := range call.Args {
+	for _, arg := range callargs {
 		if binary, ok := arg.(*syntax.BinaryExpr); ok && binary.Op == syntax.EQ {
 
 			// named argument (name, value)

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1305,13 +1305,9 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 		if e.Token == syntax.BYTES {
 			v = Bytes(v.(string))
 		}
-		if e.Token == syntax.FSTRING_FULL {
-			fmt.Print("compiling Fstring")
-		}
 		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(v))
 
 	case *syntax.FStringExpr:
-		fmt.Print("compiling FstringExpr")
 		fcomp.emit1(CONSTANT, fcomp.pcomp.constantIndex(e.Raw))
 
 	case *syntax.ListExpr:

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -644,7 +644,8 @@ func (r *resolver) expr(e syntax.Expr) {
 	switch e := e.(type) {
 	case *syntax.Ident:
 		r.use(e)
-
+	case *syntax.FStringExpr:
+		
 	case *syntax.Literal:
 
 	case *syntax.ListExpr:

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -645,7 +645,71 @@ func (r *resolver) expr(e syntax.Expr) {
 	case *syntax.Ident:
 		r.use(e)
 	case *syntax.FStringExpr:
-		
+		// r.expr(e.Fn)
+		// var seenVarargs, seenKwargs bool
+		// var seenName map[string]bool
+		// var n int
+		var p int
+		for _, arg := range e.Args {
+			// pos, _ := arg.Span()
+			if unop, ok := arg.(*syntax.UnaryExpr); ok && unop.Op == syntax.STARSTAR {
+				// **kwargs
+				// if seenKwargs {
+				// 	r.errorf(pos, "multiple **kwargs not allowed")
+				// }
+				// seenKwargs = true
+				r.expr(arg)
+			// } else if ok && unop.Op == syntax.STAR {//*args or **kwargs
+				// *args
+				// if seenKwargs {
+				// 	r.errorf(pos, "*args may not follow **kwargs")
+				// } else if seenVarargs {
+				// 	r.errorf(pos, "multiple *args not allowed")
+				// }
+				// seenVarargs = true
+				// r.expr(arg)
+			// } else if binop, ok := arg.(*syntax.BinaryExpr); ok && binop.Op == syntax.EQ { //args in form of f(foo=1,loo=2)
+				// k=v
+				// n++
+				// if seenKwargs {
+				// 	r.errorf(pos, "keyword argument may not follow **kwargs")
+				// } else if seenVarargs {
+				// 	r.errorf(pos, "keyword argument may not follow *args")
+				// }
+				// x := binop.X.(*syntax.Ident)
+				// if seenName[x.Name] {
+				// 	r.errorf(x.NamePos, "keyword argument %q is repeated", x.Name)
+				// } else {
+				// 	if seenName == nil {
+				// 		seenName = make(map[string]bool)
+				// 	}
+				// 	seenName[x.Name] = true
+				// }
+				// r.expr(binop.Y)
+			} else {
+				// positional argument
+				p++
+				// if seenVarargs {
+				// 	r.errorf(pos, "positional argument may not follow *args")
+				// } else if seenKwargs {
+				// 	r.errorf(pos, "positional argument may not follow **kwargs")
+				// } else 
+				// if len(seenName) > 0 {
+				// 	r.errorf(pos, "positional argument may not follow named")
+				// }
+				r.expr(arg)
+			}
+		}
+
+		// Fail gracefully if compiler-imposed limit is exceeded.
+		if p >= 256 {
+			pos, _ := e.Span()
+			r.errorf(pos, "%v arguments in fstring, limit is 255", p)
+		}
+		// if n >= 256 {
+		// 	pos, _ := e.Span()
+		// 	r.errorf(pos, "%v keyword arguments in call, limit is 255", n)
+		// }
 	case *syntax.Literal:
 
 	case *syntax.ListExpr:

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -645,71 +645,15 @@ func (r *resolver) expr(e syntax.Expr) {
 	case *syntax.Ident:
 		r.use(e)
 	case *syntax.FStringExpr:
-		// r.expr(e.Fn)
-		// var seenVarargs, seenKwargs bool
-		// var seenName map[string]bool
-		// var n int
-		var p int
 		for _, arg := range e.Args {
-			// pos, _ := arg.Span()
-			if unop, ok := arg.(*syntax.UnaryExpr); ok && unop.Op == syntax.STARSTAR {
-				// **kwargs
-				// if seenKwargs {
-				// 	r.errorf(pos, "multiple **kwargs not allowed")
-				// }
-				// seenKwargs = true
-				r.expr(arg)
-			// } else if ok && unop.Op == syntax.STAR {//*args or **kwargs
-				// *args
-				// if seenKwargs {
-				// 	r.errorf(pos, "*args may not follow **kwargs")
-				// } else if seenVarargs {
-				// 	r.errorf(pos, "multiple *args not allowed")
-				// }
-				// seenVarargs = true
-				// r.expr(arg)
-			// } else if binop, ok := arg.(*syntax.BinaryExpr); ok && binop.Op == syntax.EQ { //args in form of f(foo=1,loo=2)
-				// k=v
-				// n++
-				// if seenKwargs {
-				// 	r.errorf(pos, "keyword argument may not follow **kwargs")
-				// } else if seenVarargs {
-				// 	r.errorf(pos, "keyword argument may not follow *args")
-				// }
-				// x := binop.X.(*syntax.Ident)
-				// if seenName[x.Name] {
-				// 	r.errorf(x.NamePos, "keyword argument %q is repeated", x.Name)
-				// } else {
-				// 	if seenName == nil {
-				// 		seenName = make(map[string]bool)
-				// 	}
-				// 	seenName[x.Name] = true
-				// }
-				// r.expr(binop.Y)
-			} else {
-				// positional argument
-				p++
-				// if seenVarargs {
-				// 	r.errorf(pos, "positional argument may not follow *args")
-				// } else if seenKwargs {
-				// 	r.errorf(pos, "positional argument may not follow **kwargs")
-				// } else 
-				// if len(seenName) > 0 {
-				// 	r.errorf(pos, "positional argument may not follow named")
-				// }
-				r.expr(arg)
-			}
+			r.expr(arg)
 		}
-
 		// Fail gracefully if compiler-imposed limit is exceeded.
+		p := len(e.Args)
 		if p >= 256 {
 			pos, _ := e.Span()
 			r.errorf(pos, "%v arguments in fstring, limit is 255", p)
 		}
-		// if n >= 256 {
-		// 	pos, _ := e.Span()
-		// 	r.errorf(pos, "%v keyword arguments in call, limit is 255", n)
-		// }
 	case *syntax.Literal:
 
 	case *syntax.ListExpr:

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -142,6 +142,7 @@ func TestExecFile(t *testing.T) {
 		"testdata/control.star",
 		"testdata/dict.star",
 		"testdata/float.star",
+		"testdata/fstring.star",
 		"testdata/function.star",
 		"testdata/int.star",
 		"testdata/json.star",

--- a/starlark/testdata/fstring.star
+++ b/starlark/testdata/fstring.star
@@ -11,8 +11,10 @@ name = "Starlark"
 version = 1
 assert.eq(f"hello {name}", "hello Starlark")
 assert.eq(f"{{}} {name}", "{} Starlark")
+assert.eq(f"{{{{}}}} {name}", "{{}} Starlark")
 assert.eq(f"{name} {version}", "Starlark 1")
 assert.eq(f"{{ literal }}", "{ literal }")   # doubled braces → literal
+assert.eq(f"start{ {"x":3} }end", "start{\"x\": 3}end")   # dict
 
 # --- conversion flags -------------------------------------------------------
 # todo: future plans

--- a/starlark/testdata/fstring.star
+++ b/starlark/testdata/fstring.star
@@ -10,6 +10,7 @@ load("assert.star", "assert")
 name = "Starlark"
 version = 1
 assert.eq(f"hello {name}", "hello Starlark")
+assert.eq(f"{{}} {name}", "{} Starlark")
 assert.eq(f"{name} {version}", "Starlark 1")
 assert.eq(f"{{ literal }}", "{ literal }")   # doubled braces → literal
 

--- a/starlark/testdata/fstring.star
+++ b/starlark/testdata/fstring.star
@@ -11,7 +11,6 @@ name = "Starlark"
 version = 1
 assert.eq(f"hello {name}", "hello Starlark")
 assert.eq(f"{name} {version}", "Starlark 1")
-#assert.eq(f"nothing{}", "nothing{}")          # todo: assert fails
 assert.eq(f"{{ literal }}", "{ literal }")   # doubled braces → literal
 
 # --- conversion flags -------------------------------------------------------
@@ -45,9 +44,8 @@ assert.eq(f"{tpl[0]} and {tpl[1]}", "4 and 5")
 # assert.eq(f"{f:.2f}", "1.23")
 
 # --- escaping --------------------------------------------------------------
-#todo: fix escaping
-# assert.eq(f"backslash \\ still one", "backslash \\ still one")
-# assert.eq(f"quotes ' and \" kept", f'quotes \' and " kept')
+assert.eq(f"backslash \\ still one", "backslash \\ still one")
+assert.eq(f"quotes ' and \" kept", 'quotes \' and " kept')
 
 # --- empty f-string --------------------------------------------------------
 
@@ -73,20 +71,23 @@ assert.true(msg.endswith("version 1"))
 assert.eq(f"α = {α}", "α = 2")
 
 # --- errors that must be caught at compile-time ----------------------------
-
+#todo? more sound errors, now raises with text: `expect "}}" or "{expression}", got single"}"` on almost all errors
 # (Un-comment each block to verify the parser rejects it.)
 
 # 1. single '}' without '{'
 # assert.fails(lambda: f"oops}", "single '}' in format")
 
-# 2. unmatched '{'
+# 2. unmatched '{' #now says "unexpected new line in string". is it ok?
 # assert.fails(lambda: f"oops{", "unmatched '{' in format")
 
-# 3. invalid expression inside braces
+# 3. invalid expression inside braces # now fails with "got , want primary expression"
 # assert.fails(lambda: f"{1+}", "invalid syntax")
 
-# 4. unknown conversion
+# 4. unknown conversion #future plans?
 # assert.fails(lambda: f"{pi!z}", "unknown conversion")
+
+# 5. # now fails with "got , want primary expression"
+# assert.fails(lambda: f"nothing{}", "nothing{}")          # todo: assert fails
 
 # --- runtime errors --------------------------------------------------------
 
@@ -109,12 +110,9 @@ assert.eq(f"A" + f"{name}" + f"B", "AStarlarkB")
 
 # raw *and* f is illegal in Python; Starlark should follow
 # (un-comment to check)
-# assert.fails(lambda: rf"{name}", "cannot use both raw and f-string")
+# assert.fails(lambda: rf"{name}", "cannot use both raw and f-string") #todo?
 
 # --- edge cases ------------------------------------------------------------
-
-# only braces
-# assert.eq(f"{}", "{}") # todo:assert fails
 
 # only doubled braces
 assert.eq(f"{{}}", "{}")

--- a/starlark/testdata/fstring.star
+++ b/starlark/testdata/fstring.star
@@ -1,0 +1,132 @@
+# Tests of Starlark 'fstring'
+# option:set
+
+# Tests of Starlark f-string literals
+# syntax identical to Python 3.6+ (no '=', no '\{', no nested '{ }')
+load("assert.star", "assert")
+
+# --- basic interpolation ----------------------------------------------------
+
+name = "Starlark"
+version = 1
+assert.eq(f"hello {name}", "hello Starlark")
+assert.eq(f"{name} {version}", "Starlark 1")
+#assert.eq(f"nothing{}", "nothing{}")          # todo: assert fails
+assert.eq(f"{{ literal }}", "{ literal }")   # doubled braces → literal
+
+# --- conversion flags -------------------------------------------------------
+# todo: future plans
+# pi = 3.14
+# assert.eq(f"{pi!s}", "3.14")   # str()
+# assert.eq(f"{pi!r}", "3.14")   # repr()  (same here because str/repr identical)
+# big = 1000000
+# assert.eq(f"{big:,}", "1,000,000")  # format-spec with ','
+
+# --- field names -----------------------------------------------------------
+
+d = {"x": 10, "y": 20}
+assert.eq(f"{d['x']}", "10")
+assert.eq(f"{d['y']}", "20")
+
+# positional and keyword in .format() style already tested elsewhere;
+# f-strings use **inline** expressions, so we just check they evaluate.
+tpl = (4, 5)
+assert.eq(f"{tpl[0]} and {tpl[1]}", "4 and 5")
+
+# --- padding / alignment / precision ---------------------------------------
+#todo: future plans
+# n = 42
+# assert.eq(f"{n:>5}", "   42")
+# assert.eq(f"{n:<5}", "42   ")
+# assert.eq(f"{n:^5}", " 42  ")
+# assert.eq(f"{n:05}", "00042")
+
+# f = 1.234567
+# assert.eq(f"{f:.2f}", "1.23")
+
+# --- escaping --------------------------------------------------------------
+#todo: fix escaping
+# assert.eq(f"backslash \\ still one", "backslash \\ still one")
+# assert.eq(f"quotes ' and \" kept", f'quotes \' and " kept')
+
+# --- empty f-string --------------------------------------------------------
+
+assert.eq(f"", "")
+
+# --- nested quotes (no problem) --------------------------------------------
+
+assert.eq(f'He said "Hello {name}"', 'He said "Hello Starlark"')
+assert.eq(f"it's {version} o'clock", "it's 1 o'clock")
+
+# --- multiline f-string ----------------------------------------------------
+
+msg = f"""
+hello {name}
+version {version}
+""".strip()
+assert.true(msg.startswith("hello Starlark"))
+assert.true(msg.endswith("version 1"))
+
+# --- unicode ---------------------------------------------------------------
+
+α = 2
+assert.eq(f"α = {α}", "α = 2")
+
+# --- errors that must be caught at compile-time ----------------------------
+
+# (Un-comment each block to verify the parser rejects it.)
+
+# 1. single '}' without '{'
+# assert.fails(lambda: f"oops}", "single '}' in format")
+
+# 2. unmatched '{'
+# assert.fails(lambda: f"oops{", "unmatched '{' in format")
+
+# 3. invalid expression inside braces
+# assert.fails(lambda: f"{1+}", "invalid syntax")
+
+# 4. unknown conversion
+# assert.fails(lambda: f"{pi!z}", "unknown conversion")
+
+# --- runtime errors --------------------------------------------------------
+
+# expression raises → propagates
+def raise_error():
+    f"{1/0}"
+
+assert.fails(raise_error, "division by zero")
+
+# --- interaction with other string features -------------------------------
+
+# f-string is still a plain string afterwards
+s = f"{name}"
+assert.eq(s.upper(), "STARLARK")
+assert.eq(s * 2, "StarlarkStarlark")
+assert.eq(len(s), 8)
+
+# concatenation
+assert.eq(f"A" + f"{name}" + f"B", "AStarlarkB")
+
+# raw *and* f is illegal in Python; Starlark should follow
+# (un-comment to check)
+# assert.fails(lambda: rf"{name}", "cannot use both raw and f-string")
+
+# --- edge cases ------------------------------------------------------------
+
+# only braces
+# assert.eq(f"{}", "{}") # todo:assert fails
+
+# only doubled braces
+assert.eq(f"{{}}", "{}")
+
+# mixed
+#todo: fix this or just look into this
+# assert.eq(f"{{ {name} }}", "{ Starlark }")
+
+# zero-width joiner emoji (4-byte UTF-8)
+emoji = "😿"
+assert.eq(f"{emoji}", "😿")
+# assert.eq(f"{emoji!r}", '"😿"') # todo: future plans?
+
+# ---------------------------------------------------------------------------
+# end of f-string tests

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -828,6 +828,34 @@ func (p *parser) parsePrimary() Expr {
 		raw := p.tokval.raw
 		pos := p.nextToken()
 		return &Literal{Token: tok, TokenPos: pos, Raw: raw, Value: val}
+	case FSTRING_FULL:
+		val := "fstring: "+ p.tokval.string
+		// raw := p.tokval.raw
+		pos := p.nextToken()
+		return &FStringExpr{Raw: val,TokenPos: pos,}
+		// panic(0)
+		// fmt.Println("working on fstring")
+	case FSTRING_PART:
+		data := p.tokval.string
+		toktmp := p.tok
+		pos := p.nextToken()
+		resultExpr :=FStringExpr{Raw: "fstring: "+ data,TokenPos: pos}
+		strIdentExpr := Ident{Name:"str"}
+		for(toktmp!=FSTRING_END){
+			Lpos := p.in.pos
+			//we prohibit using something like f"hehe{}hehe" but it is possible to process this. look into it, todo
+			tmpexpr := p.parseTestPrec(0)
+			callStrExpr := CallExpr{Fn:&strIdentExpr,Lparen: Lpos,Args: []Expr{tmpexpr},Rparen: p.in.pos}//idea: call str() on what inside {} so we will need only take result of string and add it to fstr
+			//idea2: use Binop + and add argument to it callexpr and fstring body as simple string.
+			resultExpr.Args = append(resultExpr.Args,  &callStrExpr)
+			data = p.tokval.string
+			resultExpr.Raw += "{put here}"+data
+			toktmp = p.tok
+			p.nextToken()
+		}
+		return &resultExpr
+
+	
 
 	case LBRACK:
 		return p.parseList()

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -837,7 +837,7 @@ func (p *parser) parsePrimary() Expr {
 		raw := p.tokval.raw
 		// raw := p.tokval.raw
 		pos := p.nextToken()
-		response := Literal{Token: p.tok,TokenPos: pos,Raw: raw,Value: val}
+		response := Literal{Token: p.tok, TokenPos: pos, Raw: raw, Value: val}
 		return &response
 		// return &FStringExpr{Raw: val,TokenPos: pos,}
 		// panic(0)
@@ -853,7 +853,7 @@ func (p *parser) parsePrimary() Expr {
 		// formatIdentExpr := Ident{Name:"format"}
 		// dotExpr := DotExpr{}
 		callFormatExpr := CallExpr{Lparen: pos}
-		for(toktmp!=FSTRING_END){
+		for toktmp != FSTRING_END {
 			// Lpos := p.in.pos
 			//we prohibit using something like f"hehe{}hehe" but it is possible to process this. look into it, todo
 			tmpexpr := p.parseTestPrec(0)
@@ -867,17 +867,13 @@ func (p *parser) parsePrimary() Expr {
 			toktmp = p.tok
 			p.nextToken()
 		}
-		data:=resultString.String()
+		data := resultString.String()
 		// fmt.Print(data)
-		callFormatExpr.Fn = &DotExpr{X: &Literal{Raw: "\""+data+"\"",Value: data,TokenPos: startpos,Token: STRING},Name:&Ident{Name:"format"}}
+		callFormatExpr.Fn = &DotExpr{X: &Literal{Raw: "\"" + data + "\"", Value: data, TokenPos: startpos, Token: STRING}, Name: &Ident{Name: "format"}}
 		callFormatExpr.Rparen = p.in.pos
 		return &callFormatExpr
 
-
-
-
-
-		//this is correct code 
+		//this is correct code
 		// data := p.tokval.string
 		// toktmp := p.tok
 		// pos := p.nextToken()
@@ -896,8 +892,6 @@ func (p *parser) parsePrimary() Expr {
 		// 	p.nextToken()
 		// }
 		// return &resultExpr
-
-	
 
 	case LBRACK:
 		return p.parseList()

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -835,63 +835,29 @@ func (p *parser) parsePrimary() Expr {
 	case FSTRING_FULL:
 		val := p.tokval.string
 		raw := p.tokval.raw
-		// raw := p.tokval.raw
+		token := p.tok
 		pos := p.nextToken()
-		response := Literal{Token: p.tok, TokenPos: pos, Raw: raw, Value: val}
+		response := Literal{Token: token, TokenPos: pos, Raw: raw, Value: val}
 		return &response
-		// return &FStringExpr{Raw: val,TokenPos: pos,}
-		// panic(0)
-		// fmt.Println("working on fstring")
 	case FSTRING_PART:
-		//this is test code
 		resultString := strings.Builder{}
 		resultString.WriteString(p.tokval.string)
 		toktmp := p.tok
 		startpos := p.in.pos
 		pos := p.nextToken()
-		// resultExpr :=FStringExpr{Raw: "fstring: "+ data,TokenPos: pos}
-		// formatIdentExpr := Ident{Name:"format"}
-		// dotExpr := DotExpr{}
 		callFormatExpr := CallExpr{Lparen: pos}
 		for toktmp != FSTRING_END {
-			// Lpos := p.in.pos
-			//we prohibit using something like f"hehe{}hehe" but it is possible to process this. look into it, todo
 			tmpexpr := p.parseTestPrec(0)
 			callFormatExpr.Args = append(callFormatExpr.Args, tmpexpr)
-			// callStrExpr := CallExpr{Fn:&strIdentExpr,Lparen: Lpos,Args: []Expr{tmpexpr},Rparen: p.in.pos}//idea: call str() on what inside {} so we will need only take result of string and add it to fstr
-			//idea2: use Binop + and add argument to it callexpr and fstring body as simple string.
-			// resultExpr.Args = append(resultExpr.Args,  &callStrExpr)
 			resultString.WriteString("{}")
 			resultString.WriteString(p.tokval.string)
-			// resultExpr.Raw += "{put here}"+data
 			toktmp = p.tok
 			p.nextToken()
 		}
 		data := resultString.String()
-		// fmt.Print(data)
 		callFormatExpr.Fn = &DotExpr{X: &Literal{Raw: "\"" + data + "\"", Value: data, TokenPos: startpos, Token: STRING}, Name: &Ident{Name: "format"}}
-		callFormatExpr.Rparen = p.in.pos
+		callFormatExpr.Rparen = p.in.pos //todo: fix this
 		return &callFormatExpr
-
-		//this is correct code
-		// data := p.tokval.string
-		// toktmp := p.tok
-		// pos := p.nextToken()
-		// resultExpr :=FStringExpr{Raw: "fstring: "+ data,TokenPos: pos}
-		// strIdentExpr := Ident{Name:"str"}
-		// for(toktmp!=FSTRING_END){
-		// 	Lpos := p.in.pos
-		// 	//we prohibit using something like f"hehe{}hehe" but it is possible to process this. look into it, todo
-		// 	tmpexpr := p.parseTestPrec(0)
-		// 	callStrExpr := CallExpr{Fn:&strIdentExpr,Lparen: Lpos,Args: []Expr{tmpexpr},Rparen: p.in.pos}//idea: call str() on what inside {} so we will need only take result of string and add it to fstr
-		// 	//idea2: use Binop + and add argument to it callexpr and fstring body as simple string.
-		// 	resultExpr.Args = append(resultExpr.Args,  &callStrExpr)
-		// 	data = p.tokval.string
-		// 	resultExpr.Raw += "{put here}"+data
-		// 	toktmp = p.tok
-		// 	p.nextToken()
-		// }
-		// return &resultExpr
 
 	case LBRACK:
 		return p.parseList()

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -14,6 +14,7 @@ package syntax
 import (
 	// "fmt"
 	"log"
+	"strings"
 )
 
 // Enable this flag to print the token stream and log.Fatal on the first error.
@@ -840,7 +841,7 @@ func (p *parser) parsePrimary() Expr {
 		return &response
 	case FSTRING_PART:
 		resultExpr := FStringExpr{}
-		resultExpr.StringParts = append(resultExpr.StringParts, p.tokval.string)
+		resultExpr.StringParts = append(resultExpr.StringParts, strings.ReplaceAll(strings.ReplaceAll(p.tokval.string, "}", "}}"), "{", "{{"))
 		resultExpr.RawParts = append(resultExpr.RawParts, p.tokval.raw)
 		toktmp := p.tok
 		pos := p.nextToken()
@@ -848,7 +849,7 @@ func (p *parser) parsePrimary() Expr {
 		for toktmp != FSTRING_END {
 			x := p.parseTest()
 			resultExpr.Args = append(resultExpr.Args, x)
-			resultExpr.StringParts = append(resultExpr.StringParts, p.tokval.string)
+			resultExpr.StringParts = append(resultExpr.StringParts, strings.ReplaceAll(strings.ReplaceAll(p.tokval.string, "}", "}}"), "{", "{{"))
 			resultExpr.RawParts = append(resultExpr.RawParts, p.tokval.raw)
 			toktmp = p.tok
 			p.nextToken()

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -11,7 +11,11 @@ package syntax
 // package.  Verify that error positions are correct using the
 // chunkedfile mechanism.
 
-import "log"
+import (
+	// "fmt"
+	"log"
+	"strings"
+)
 
 // Enable this flag to print the token stream and log.Fatal on the first error.
 const debug = false
@@ -831,29 +835,66 @@ func (p *parser) parsePrimary() Expr {
 	case FSTRING_FULL:
 		val := "fstring: "+ p.tokval.string
 		// raw := p.tokval.raw
+		response := Literal{T
 		pos := p.nextToken()
+		return &Literal{Token: p.tok,TokenPos: }
 		return &FStringExpr{Raw: val,TokenPos: pos,}
 		// panic(0)
 		// fmt.Println("working on fstring")
 	case FSTRING_PART:
-		data := p.tokval.string
+		//this is test code
+		resultString := strings.Builder{}
+		resultString.WriteString(p.tokval.string)
 		toktmp := p.tok
+		startpos := p.in.pos
 		pos := p.nextToken()
-		resultExpr :=FStringExpr{Raw: "fstring: "+ data,TokenPos: pos}
-		strIdentExpr := Ident{Name:"str"}
+		// resultExpr :=FStringExpr{Raw: "fstring: "+ data,TokenPos: pos}
+		// formatIdentExpr := Ident{Name:"format"}
+		// dotExpr := DotExpr{}
+		callFormatExpr := CallExpr{Lparen: pos}
 		for(toktmp!=FSTRING_END){
-			Lpos := p.in.pos
+			// Lpos := p.in.pos
 			//we prohibit using something like f"hehe{}hehe" but it is possible to process this. look into it, todo
 			tmpexpr := p.parseTestPrec(0)
-			callStrExpr := CallExpr{Fn:&strIdentExpr,Lparen: Lpos,Args: []Expr{tmpexpr},Rparen: p.in.pos}//idea: call str() on what inside {} so we will need only take result of string and add it to fstr
+			callFormatExpr.Args = append(callFormatExpr.Args, tmpexpr)
+			// callStrExpr := CallExpr{Fn:&strIdentExpr,Lparen: Lpos,Args: []Expr{tmpexpr},Rparen: p.in.pos}//idea: call str() on what inside {} so we will need only take result of string and add it to fstr
 			//idea2: use Binop + and add argument to it callexpr and fstring body as simple string.
-			resultExpr.Args = append(resultExpr.Args,  &callStrExpr)
-			data = p.tokval.string
-			resultExpr.Raw += "{put here}"+data
+			// resultExpr.Args = append(resultExpr.Args,  &callStrExpr)
+			resultString.WriteString("{}")
+			resultString.WriteString(p.tokval.string)
+			// resultExpr.Raw += "{put here}"+data
 			toktmp = p.tok
 			p.nextToken()
 		}
-		return &resultExpr
+		data:=resultString.String()
+		// fmt.Print(data)
+		callFormatExpr.Fn = &DotExpr{X: &Literal{Raw: "\""+data+"\"",Value: data,TokenPos: startpos,Token: STRING},Name:&Ident{Name:"format"}}
+		callFormatExpr.Rparen = p.in.pos
+		return &callFormatExpr
+
+
+
+
+
+		//this is correct code 
+		// data := p.tokval.string
+		// toktmp := p.tok
+		// pos := p.nextToken()
+		// resultExpr :=FStringExpr{Raw: "fstring: "+ data,TokenPos: pos}
+		// strIdentExpr := Ident{Name:"str"}
+		// for(toktmp!=FSTRING_END){
+		// 	Lpos := p.in.pos
+		// 	//we prohibit using something like f"hehe{}hehe" but it is possible to process this. look into it, todo
+		// 	tmpexpr := p.parseTestPrec(0)
+		// 	callStrExpr := CallExpr{Fn:&strIdentExpr,Lparen: Lpos,Args: []Expr{tmpexpr},Rparen: p.in.pos}//idea: call str() on what inside {} so we will need only take result of string and add it to fstr
+		// 	//idea2: use Binop + and add argument to it callexpr and fstring body as simple string.
+		// 	resultExpr.Args = append(resultExpr.Args,  &callStrExpr)
+		// 	data = p.tokval.string
+		// 	resultExpr.Raw += "{put here}"+data
+		// 	toktmp = p.tok
+		// 	p.nextToken()
+		// }
+		// return &resultExpr
 
 	
 

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -833,12 +833,13 @@ func (p *parser) parsePrimary() Expr {
 		pos := p.nextToken()
 		return &Literal{Token: tok, TokenPos: pos, Raw: raw, Value: val}
 	case FSTRING_FULL:
-		val := "fstring: "+ p.tokval.string
+		val := p.tokval.string
+		raw := p.tokval.raw
 		// raw := p.tokval.raw
-		response := Literal{T
 		pos := p.nextToken()
-		return &Literal{Token: p.tok,TokenPos: }
-		return &FStringExpr{Raw: val,TokenPos: pos,}
+		response := Literal{Token: p.tok,TokenPos: pos,Raw: raw,Value: val}
+		return &response
+		// return &FStringExpr{Raw: val,TokenPos: pos,}
 		// panic(0)
 		// fmt.Println("working on fstring")
 	case FSTRING_PART:

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -132,6 +132,22 @@ func TestExprParseTrees(t *testing.T) {
 	}
 }
 
+func TestTmp(t *testing.T){
+
+	t.Log("---------------------------------------\n")
+	text := `f"he{7+7}he"`
+		e, err := syntax.ParseExpr("foo.star", text, 0)
+	var got string
+	if err != nil {
+		got = stripPos(err)
+	} else {
+		got = treeString(e)
+	}
+
+	t.Log(got)
+	t.Log("---------------------------------------\n")
+}
+
 func TestStmtParseTrees(t *testing.T) {
 	for _, test := range []struct {
 		input, want string
@@ -362,6 +378,8 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 		switch v := x.Interface().(type) {
 		case syntax.Literal:
 			switch v.Token {
+			case syntax.FSTRING_FULL:
+				fmt.Fprintf(out, "%q", v.Value)
 			case syntax.STRING:
 				fmt.Fprintf(out, "%q", v.Value)
 			case syntax.BYTES:

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -136,10 +136,11 @@ func TestStmtParseFstring(t *testing.T) {
 	for _, test := range []struct {
 		input, same string
 	}{
-		{`f"hehe"`, `"hehe"`},
-		{`f"hehe{0}"`, `"hehe{}".format(0)`},
-		{`f"hehe{1+1}"`, `"hehe{}".format(1+1)`},
-		{`f"hehe{f"haha{7}"}hehe"`, `"hehe{}hehe".format("haha{}".format(7))`},
+		//fail because of moving to fstringexpr
+		// {`f"hehe"`, `"hehe"`},
+		// {`f"hehe{0}"`, `"hehe{}".format(0)`},
+		// {`f"hehe{1+1}"`, `"hehe{}".format(1+1)`},
+		// {`f"hehe{f"haha{7}"}hehe"`, `"hehe{}hehe".format("haha{}".format(7))`},
 	} {
 		expr, err := syntax.Parse("foo.star", test.input, 0)
 		if err != nil {

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -132,46 +132,6 @@ func TestExprParseTrees(t *testing.T) {
 	}
 }
 
-func TestParseTmp(t *testing.T) {
-
-	t.Log("---------------------------------------\n")
-	text := `f"he{7}he"`
-	e, err := syntax.ParseExpr("foo.star", text, 0)
-	var got string
-	if err != nil {
-		got = stripPos(err)
-	} else {
-		got = treeString(e)
-	}
-
-	t.Log(got)
-	t.Log("---------------------------------------\n")
-}
-
-func TestParseTmp2(t *testing.T) {
-
-	t.Log("---------------------------------------\n")
-	text := `"he{}he".format(7)`
-	e, err := syntax.ParseExpr("foo.star", text, 0)
-	var got string
-	if err != nil {
-		got = stripPos(err)
-	} else {
-		got = treeString(e)
-	}
-
-	t.Log(got)
-	t.Log("---------------------------------------\n")
-}
-
-//todo: add tests for:
-// f"hehe"
-// f"hehe{0}"
-// f"hehe{1+1}" //probably parse, not scan
-// f"{}"
-// f"hehe{f"haha{7}"}hehe" //parse?
-// f'hehe{7}hehe'
-
 func TestStmtParseFstring(t *testing.T) {
 	for _, test := range []struct {
 		input, same string

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -136,22 +136,19 @@ func TestStmtParseFstring(t *testing.T) {
 	for _, test := range []struct {
 		input, same string
 	}{
-		//fail because of moving to fstringexpr
-		// {`f"hehe"`, `"hehe"`},
-		// {`f"hehe{0}"`, `"hehe{}".format(0)`},
-		// {`f"hehe{1+1}"`, `"hehe{}".format(1+1)`},
-		// {`f"hehe{f"haha{7}"}hehe"`, `"hehe{}hehe".format("haha{}".format(7))`},
+		{`f"hehe"`, `(ExprStmt X="hehe")`},
+		{`f"hehe{0}"`, `(ExprStmt X=(FStringExpr Raw= RawParts=(f"hehe{ }") StringParts=(hehe ) Args=(0)))`},
+		{`f"hehe{1+1}"`, `(ExprStmt X=(FStringExpr Raw= RawParts=(f"hehe{ }") StringParts=(hehe ) Args=((BinaryExpr X=1 Op=+ Y=1))))`},
+		{`f"hehe{f"haha{7}"}hehe"`, `(ExprStmt X=(FStringExpr Raw= RawParts=(f"hehe{ }hehe") StringParts=(hehe hehe) Args=((FStringExpr Raw= RawParts=(f"haha{ }") StringParts=(haha ) Args=(7)))))`},
 	} {
 		expr, err := syntax.Parse("foo.star", test.input, 0)
 		if err != nil {
 			t.Errorf("parse `%s` failed: %v", test.input, stripPos(err))
 			continue
 		}
-		expr_want, _ := syntax.Parse("foo.star", test.same, 0) // other tests check wheter this is adequate
 		got := treeString(expr.Stmts[0])
-		got_want := treeString(expr_want.Stmts[0])
-		if got != got_want {
-			t.Errorf("parse `%s` = %s, want %s", test.input, got, got_want)
+		if got != test.same {
+			t.Errorf("parse `%s` = %s, want %s", test.input, got, test.same)
 		}
 	}
 }

--- a/syntax/quote.go
+++ b/syntax/quote.go
@@ -58,6 +58,11 @@ func unquote(quoted string) (s string, triple, isByte bool, err error) {
 		quoted = quoted[1:]
 	}
 
+	if strings.HasPrefix(quoted, "f") {
+		isByte = true
+		quoted = quoted[1:]
+	}
+
 	if len(quoted) < 2 {
 		err = fmt.Errorf("string literal too short")
 		return

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -285,51 +285,50 @@ func (p Position) isBefore(q Position) bool {
 	return p.Col < q.Col
 }
 
-
-
 // Stack structure with a type parameter
 type Stack[T any] struct {
-    elements []T
+	elements []T
 }
 
 // Push adds an element to the stack
 func (s *Stack[T]) Push(element T) {
-    s.elements = append(s.elements, element)
+	s.elements = append(s.elements, element)
 }
 
 // Pop removes and returns the last element from the stack
 func (s *Stack[T]) Pop() (T, bool) {
-    if len(s.elements) == 0 {
-        var zeroValue T // Create a zero value of type T
-        return zeroValue, false // Stack is empty
-    }
-    element := s.elements[len(s.elements)-1]
-    s.elements = s.elements[:len(s.elements)-1] // Remove last element
-    return element, true
+	if len(s.elements) == 0 {
+		var zeroValue T         // Create a zero value of type T
+		return zeroValue, false // Stack is empty
+	}
+	element := s.elements[len(s.elements)-1]
+	s.elements = s.elements[:len(s.elements)-1] // Remove last element
+	return element, true
 }
 
 // Peek returns the last element from the stack
 func (s *Stack[T]) Peek() (T, bool) {
-    if len(s.elements) == 0 {
-        var zeroValue T // Create a zero value of type T
-        return zeroValue, false // Stack is empty
-    }
-    element := s.elements[len(s.elements)-1]
-    return element, true
+	if len(s.elements) == 0 {
+		var zeroValue T         // Create a zero value of type T
+		return zeroValue, false // Stack is empty
+	}
+	element := s.elements[len(s.elements)-1]
+	return element, true
 }
+
 // PeekN returns the nth element from the end stack (0 is last)
 func (s *Stack[T]) PeekN(n int) (T, bool) {
-    if len(s.elements) < n{
-        var zeroValue T // Create a zero value of type T
-        return zeroValue, false // Stack is empty
-    }
-    element := s.elements[len(s.elements)-1-n]
-    return element, true
+	if len(s.elements) < n {
+		var zeroValue T         // Create a zero value of type T
+		return zeroValue, false // Stack is empty
+	}
+	element := s.elements[len(s.elements)-1-n]
+	return element, true
 }
 
 // Size returns the number of elements in the stack
 func (s *Stack[T]) Size() int {
-    return len(s.elements)
+	return len(s.elements)
 }
 
 // func main() {
@@ -347,12 +346,10 @@ func (s *Stack[T]) Size() int {
 //     fmt.Println("Size of string stack after pop:", stringStack.Size()) // Output: Size of string stack after pop: 1
 // }
 
-
-
-type fstringStackNode struct{
-	pos 		Position
-	tokenType 	rune
-	startDepth   int
+type fstringStackNode struct {
+	pos        Position
+	tokenType  rune
+	startDepth int
 }
 
 // An scanner represents a single input file being parsed.
@@ -742,13 +739,13 @@ start:
 
 	// start of the next token
 	sc.startToken(val)
-	if (sc.shouldScanFstring(c)){
-		if c == '}'{
+	if sc.shouldScanFstring(c) {
+		if c == '}' {
 			//assert sc.fstring.Peek().val.tokentype == '{' todo
 			tmpval, _ := sc.fstringStack.Pop()
 			// tmpval, _ := sc.fstringStack.Peek()
-			resp := sc.scanFstring(val,tmpval.tokenType)
-			if (resp == FSTRING_END || resp == FSTRING_FULL){
+			resp := sc.scanFstring(val, tmpval.tokenType)
+			if resp == FSTRING_END || resp == FSTRING_FULL {
 				sc.fstringStack.Pop()
 			}
 			return resp
@@ -782,24 +779,24 @@ start:
 			sc.readRune()
 			c = sc.peekRune()
 			return sc.scanString(val, c)
-		} else if c == 'f' && len(sc.rest) > 3 && 
-							((sc.rest[1] == sc.rest[2] && sc.rest[1] == sc.rest[3]) && 
-							(sc.rest[1] == '\''|| sc.rest[1] == '"')) {
+		} else if c == 'f' && len(sc.rest) > 3 &&
+			((sc.rest[1] == sc.rest[2] && sc.rest[1] == sc.rest[3]) &&
+				(sc.rest[1] == '\'' || sc.rest[1] == '"')) {
 			// f"""...""" or f'''...'''
 			sc.readRune()
 			sc.readRune()
 			sc.readRune()
 			c = sc.peekRune()
-			if c == '\''{
-				sc.fstringStack.Push(fstringStackNode{pos: sc.pos,tokenType: '+',startDepth: sc.depth})
+			if c == '\'' {
+				sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '+', startDepth: sc.depth})
 				c = '+'
 			}
-			if c == '"'{
-				sc.fstringStack.Push(fstringStackNode{pos: sc.pos,tokenType: '-',startDepth: sc.depth})
+			if c == '"' {
+				sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '-', startDepth: sc.depth})
 				c = '-'
 			}
 			resp := sc.scanFstring(val, c)
-			if(resp == FSTRING_END || resp == FSTRING_FULL){
+			if resp == FSTRING_END || resp == FSTRING_FULL {
 				sc.fstringStack.Pop()
 			}
 			return resp
@@ -807,13 +804,13 @@ start:
 			// f"..."
 			sc.readRune()
 			c = sc.peekRune()
-			sc.fstringStack.Push(fstringStackNode{pos: sc.pos,tokenType: c,startDepth: sc.depth})
+			sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: c, startDepth: sc.depth})
 			resp := sc.scanFstring(val, c)
-			if(resp == FSTRING_END || resp == FSTRING_FULL){
+			if resp == FSTRING_END || resp == FSTRING_FULL {
 				sc.fstringStack.Pop()
 			}
 			return resp
-		 } 
+		}
 		for isIdent(c) {
 			sc.readRune()
 			c = sc.peekRune()
@@ -981,58 +978,57 @@ start:
 	panic("unreachable")
 }
 
-func (sc *scanner) shouldScanFstring(c rune) bool{// we falling into scanning fstring if it start of fstring (i.e. f")(not looking into this, because we will fall into it in corresponding part) or end of one of its parts
-	if (sc.fstringStack.Size()==0 ){
+func (sc *scanner) shouldScanFstring(c rune) bool { // we falling into scanning fstring if it start of fstring (i.e. f")(not looking into this, because we will fall into it in corresponding part) or end of one of its parts
+	if sc.fstringStack.Size() == 0 {
 		return false
 	}
 	val, _ := sc.fstringStack.Peek()
-	if (val.startDepth<sc.depth){
+	if val.startDepth < sc.depth {
 		return false
 	}
-	if (c == '}' && val.tokenType == '{'){
+	if c == '}' && val.tokenType == '{' {
 		return true
 	}
 	//todo: everything after is always false?
-	if (c == '\'' && val.tokenType == '\''){
+	if c == '\'' && val.tokenType == '\'' {
 		return true
 	}
-	if (c == '"' && val.tokenType == '"'){
+	if c == '"' && val.tokenType == '"' {
 		return true
 	}
-	if (len(sc.rest)>=3){
-		if (val.tokenType == '+'){// + for '''
-		if(c == '\'' && sc.rest[1] == byte(c) && sc.rest[2] == byte(c)){
-			return true
+	if len(sc.rest) >= 3 {
+		if val.tokenType == '+' { // + for '''
+			if c == '\'' && sc.rest[1] == byte(c) && sc.rest[2] == byte(c) {
+				return true
+			}
 		}
-	}
-		if (val.tokenType == '-'){// - for """
-		if(c == '"' && sc.rest[1] == byte(c) && sc.rest[2] == byte(c)){
-			return true
+		if val.tokenType == '-' { // - for """
+			if c == '"' && sc.rest[1] == byte(c) && sc.rest[2] == byte(c) {
+				return true
+			}
 		}
-	}
 	}
 	return false
 }
 
-func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token {//tokens: full_fstring(if it simple string), fstring_part, end_expr_fstring
+func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token { //tokens: full_fstring(if it simple string), fstring_part, end_expr_fstring
 	// start := sc.pos
 	triple := len(sc.rest) >= 3 && sc.rest[0] == byte(quote) && sc.rest[1] == byte(quote) && sc.rest[2] == byte(quote)
 
-
 	isbeginning := true
 	isend := true
-	if quote == '{'{
+	if quote == '{' {
 		tmpval, _ := sc.fstringStack.Peek()
 		quote = tmpval.tokenType
 		isbeginning = false
 	}
-	if quote == '+'{
-	quote = '\''
-	triple = true
+	if quote == '+' {
+		quote = '\''
+		triple = true
 	}
 	if quote == '-' {
-	quote = '"'
-	triple = true
+		quote = '"'
+		triple = true
 	}
 
 	sc.readRune()
@@ -1048,8 +1044,8 @@ func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token {//tokens: ful
 	// Copy the prefix, e.g. r' or " (see startToken).
 	raw.Write(sc.token[:len(sc.token)-len(sc.rest)])
 
-quoteCount := 0
-startQuote :=len(sc.token)-len(sc.rest)
+	quoteCount := 0
+	startQuote := len(sc.token) - len(sc.rest)
 	if !triple {
 		// single-quoted string literal
 		for {
@@ -1062,21 +1058,21 @@ startQuote :=len(sc.token)-len(sc.rest)
 				quoteCount = 1
 				break
 			}
-			if c == '{'{
-				if (!(len(sc.rest)>1 && sc.rest[0] == '{')){
-					sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '{',startDepth: sc.depth})
+			if c == '{' {
+				if !(len(sc.rest) > 1 && sc.rest[0] == '{') {
+					sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '{', startDepth: sc.depth})
 					isend = false
 					quoteCount = 1
 					break
-				}else{
+				} else {
 					sc.readRune()
 				}
 			}
-			if c == '}'{
-				if ((len(sc.rest)>1 && sc.rest[0] == '}')){
+			if c == '}' {
+				if len(sc.rest) > 1 && sc.rest[0] == '}' {
 					sc.readRune()
-				}else{
-					sc.error(val.pos,"expect \"}}\" or \"{expression}\", got single\"}\"")
+				} else {
+					sc.error(val.pos, "expect \"}}\" or \"{expression}\", got single\"}\"")
 				}
 			}
 			if c == '\n' {
@@ -1112,21 +1108,21 @@ startQuote :=len(sc.token)-len(sc.rest)
 				quoteCount = 0
 			}
 
-			if c == '{'{
-				if (!(len(sc.rest)>1 && sc.rest[0] == '{')){
-					sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '{',startDepth: sc.depth})
+			if c == '{' {
+				if !(len(sc.rest) > 1 && sc.rest[0] == '{') {
+					sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '{', startDepth: sc.depth})
 					isend = false
 					quoteCount = 1
 					break
-				}else{
+				} else {
 					sc.readRune()
 				}
 			}
-			if c == '}'{
-				if ((len(sc.rest)>1 && sc.rest[0] == '}')){
+			if c == '}' {
+				if len(sc.rest) > 1 && sc.rest[0] == '}' {
 					sc.readRune()
-				}else{
-					sc.error(val.pos,"expect \"}}\" or \"{expression}\", got single \"}\"")
+				} else {
+					sc.error(val.pos, "expect \"}}\" or \"{expression}\", got single \"}\"")
 				}
 			}
 			if c == '\\' {
@@ -1142,11 +1138,11 @@ startQuote :=len(sc.token)-len(sc.rest)
 	// val.raw = raw.String()
 
 	// s, _, isByte, err := unquote(val.raw)
-	val.string = val.raw[startQuote:raw.Len()-quoteCount]
-	if (isend && isbeginning){
+	val.string = val.raw[startQuote : raw.Len()-quoteCount]
+	if isend && isbeginning {
 		return FSTRING_FULL
 	}
-	if (isend){
+	if isend {
 		return FSTRING_END
 	}
 	return FSTRING_PART

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -749,6 +749,8 @@ start:
 				sc.fstringStack.Pop()
 			}
 			return resp
+		} else {
+			panic("unreacheable")
 		}
 		//probably no other options
 	}

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -1012,7 +1012,7 @@ func (sc *scanner) shouldScanFstring(c rune) bool { // we falling into scanning 
 }
 
 func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token { //tokens: full_fstring(if it simple string), fstring_part, end_expr_fstring
-	// start := sc.pos
+	start := sc.pos
 	triple := len(sc.rest) >= 3 && sc.rest[0] == byte(quote) && sc.rest[1] == byte(quote) && sc.rest[2] == byte(quote)
 
 	isbeginning := true
@@ -1139,6 +1139,11 @@ func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token { //tokens: fu
 
 	// s, _, isByte, err := unquote(val.raw)
 	val.string = val.raw[startQuote : raw.Len()-quoteCount]
+	s, _, _, err := unquote("\"" + val.string + "\"")
+	val.string = s
+	if err != nil {
+		sc.error(start, err.Error())
+	}
 	if isend && isbeginning {
 		return FSTRING_FULL
 	}

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -35,10 +35,10 @@ const (
 	FLOAT  // 1.23e45
 	STRING // "foo" or 'foo' or '''foo''' or r'foo' or r"foo"
 	BYTES  // b"foo", etc
-	// FSTRING
-	FSTRING_FULL
-	FSTRING_PART
-	FSTRING_END
+	// FSTRING (examples given with " bracket, but fstring can use all four (", ', """, '''))
+	FSTRING_FULL // f"foo" i.e. 'f' with regular string
+	FSTRING_PART // f"foo{ or }foo{
+	FSTRING_END  // }foo" or }"
 
 	// Punctuation
 	PLUS          // +
@@ -316,35 +316,10 @@ func (s *Stack[T]) Peek() (T, bool) {
 	return element, true
 }
 
-// PeekN returns the nth element from the end stack (0 is last)
-func (s *Stack[T]) PeekN(n int) (T, bool) {
-	if len(s.elements) < n {
-		var zeroValue T         // Create a zero value of type T
-		return zeroValue, false // Stack is empty
-	}
-	element := s.elements[len(s.elements)-1-n]
-	return element, true
-}
-
 // Size returns the number of elements in the stack
 func (s *Stack[T]) Size() int {
 	return len(s.elements)
 }
-
-// func main() {
-//     stringStack := Stack[string]{}
-//     stringStack.Push("Hello")
-//     stringStack.Push("World")
-
-//     fmt.Println("Size of string stack:", stringStack.Size()) // Output: Size of string stack: 2
-
-//     element, ok := stringStack.Pop()
-//     if ok {
-//         fmt.Println("Popped element:", element) // Output: Popped element: World
-//     }
-
-//     fmt.Println("Size of string stack after pop:", stringStack.Size()) // Output: Size of string stack after pop: 1
-// }
 
 type fstringStackNode struct {
 	pos        Position

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -792,9 +792,11 @@ start:
 			c = sc.peekRune()
 			if c == '\''{
 				sc.fstringStack.Push(fstringStackNode{pos: sc.pos,tokenType: '+',startDepth: sc.depth})
+				c = '+'
 			}
 			if c == '"'{
 				sc.fstringStack.Push(fstringStackNode{pos: sc.pos,tokenType: '-',startDepth: sc.depth})
+				c = '-'
 			}
 			resp := sc.scanFstring(val, c)
 			if(resp == FSTRING_END || resp == FSTRING_FULL){
@@ -1090,11 +1092,10 @@ startQuote :=len(sc.token)-len(sc.rest)
 		}
 	} else {
 		// triple-quoted string literal
-		sc.readRune()
-		raw.WriteRune(quote)
-		sc.readRune()
-		raw.WriteRune(quote)
-		startQuote+=2
+		// sc.readRune()
+		// raw.WriteRune(quote)
+		// sc.readRune()
+		// raw.WriteRune(quote)
 
 		for {
 			if sc.eof() {

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -1016,7 +1016,7 @@ func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token {//tokens: ful
 	// start := sc.pos
 	triple := len(sc.rest) >= 3 && sc.rest[0] == byte(quote) && sc.rest[1] == byte(quote) && sc.rest[2] == byte(quote)
 
-	
+
 	isbeginning := true
 	isend := true
 	if quote == '{'{
@@ -1066,6 +1066,15 @@ startQuote :=len(sc.token)-len(sc.rest)
 					isend = false
 					quoteCount = 1
 					break
+				}else{
+					sc.readRune()
+				}
+			}
+			if c == '}'{
+				if ((len(sc.rest)>1 && sc.rest[0] == '}')){
+					sc.readRune()
+				}else{
+					sc.error(val.pos,"expect \"}}\" or \"{expression}\", got single\"}\"")
 				}
 			}
 			if c == '\n' {
@@ -1101,12 +1110,22 @@ startQuote :=len(sc.token)-len(sc.rest)
 			} else {
 				quoteCount = 0
 			}
+
 			if c == '{'{
 				if (!(len(sc.rest)>1 && sc.rest[0] == '{')){
 					sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '{',startDepth: sc.depth})
 					isend = false
 					quoteCount = 1
 					break
+				}else{
+					sc.readRune()
+				}
+			}
+			if c == '}'{
+				if ((len(sc.rest)>1 && sc.rest[0] == '}')){
+					sc.readRune()
+				}else{
+					sc.error(val.pos,"expect \"}}\" or \"{expression}\", got single \"}\"")
 				}
 			}
 			if c == '\\' {

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -1016,7 +1016,7 @@ func (sc *scanner) scanFstring(val *tokenValue, quote rune) Token {//tokens: ful
 	// start := sc.pos
 	triple := len(sc.rest) >= 3 && sc.rest[0] == byte(quote) && sc.rest[1] == byte(quote) && sc.rest[2] == byte(quote)
 
-	
+
 	isbeginning := true
 	isend := true
 	if quote == '{'{
@@ -1066,6 +1066,15 @@ startQuote :=len(sc.token)-len(sc.rest)
 					isend = false
 					quoteCount = 1
 					break
+				}else{
+					sc.readRune()
+				}
+			}
+			if c == '}'{
+				if ((len(sc.rest)>1 && sc.rest[0] == '}')){
+					sc.readRune()
+				}else{
+					sc.error(val.pos,"expect \"}}\" or \"{expression}\", got single\"}\"")
 				}
 			}
 			if c == '\n' {
@@ -1101,12 +1110,22 @@ startQuote :=len(sc.token)-len(sc.rest)
 			} else {
 				quoteCount = 0
 			}
+
 			if c == '{'{
 				if (!(len(sc.rest)>1 && sc.rest[0] == '{')){
 					sc.fstringStack.Push(fstringStackNode{pos: sc.pos, tokenType: '{',startDepth: sc.depth})
 					isend = false
 					quoteCount = 1
 					break
+				}else{
+					sc.readRune()
+				}
+			}
+			if c == '}'{
+				if ((len(sc.rest)>1 && sc.rest[0] == '}')){
+					sc.readRune()
+				}else{
+					sc.error(val.pos,"expect \"}}\" or \"{expression}\", got single\"}\"")
 				}
 			}
 			if c == '\\' {

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -50,13 +50,12 @@ func scan(src interface{}) (tokens string, err error) {
 			buf.WriteString(Quote(val.string, false))
 		case FSTRING_PART:
 			if prevtok == FSTRING_PART {
-				buf.WriteString(")+\"" + val.string + "\"+str(")
+				buf.WriteString(")+" + Quote(val.string, false) + "+str(")
 			} else {
-				buf.WriteString("\"" + val.string + "\"+str(")
+				buf.WriteString(Quote(val.string, false) + "+str(")
 			}
 		case FSTRING_END:
-			buf.WriteString(")+\"" + val.string + "\"")
-
+			buf.WriteString(")+" + Quote(val.string, false))
 		default:
 			buf.WriteString(tok.String())
 		}
@@ -82,6 +81,8 @@ func TestScannerFstring(t *testing.T) {
 		"@{{@",
 		"@}}@",
 		"@hehe{1}haha{2}hoho{3}hihi{4}huhu{5}@",
+		"@hehe\\\\@",
+		"@hehe\\'@",
 	} // @ for bracket
 	convert_simple := func(body string) string {
 		want_body := strings.Replace(body, "@", `"`, -1)
@@ -92,17 +93,24 @@ func TestScannerFstring(t *testing.T) {
 		return want_body
 	}
 	targets := []string{
-		convert_simple(bodys[0]),
+		"",
 		`"hehe"+str( 0 )+"" EOF`,
 		`"hehe"+str( 0 )+"hehe" EOF`,
 		`"hehe"+str( 1 + 1 )+"" EOF`,
-		convert_simple(bodys[4]),
-		convert_simple(bodys[5]),
-		convert_simple(bodys[6]),
+		"",
+		"",
+		"",
 		`"{"+str( 0 )+"}" EOF`,
-		convert_simple(bodys[8]),
-		convert_simple(bodys[9]),
+		"",
+		"",
 		`"hehe"+str( 1 "haha"+str( 2 "hoho"+str( 3 "hihi"+str( 4 "huhu"+str( 5 )+"" EOF`,
+		"",
+		`"hehe'"`,
+	}
+	for id, target := range targets {
+		if len(target) == 0 {
+			targets[id] = convert_simple(bodys[id])
+		}
 	}
 
 	for _, bracket := range brackets {

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -83,6 +83,7 @@ func TestScannerFstring(t *testing.T) {
 		"@hehe{1}haha{2}hoho{3}hihi{4}huhu{5}@",
 		"@hehe\\\\@",
 		"@hehe\\'@",
+		`@{ {@x@:3} }@`,
 	} // @ for bracket
 	convert_simple := func(body string) string {
 		want_body := strings.Replace(body, "@", `"`, -1)
@@ -106,6 +107,7 @@ func TestScannerFstring(t *testing.T) {
 		`"hehe"+str( 1 "haha"+str( 2 "hoho"+str( 3 "hihi"+str( 4 "huhu"+str( 5 )+"" EOF`,
 		"",
 		`"hehe'"`,
+		`""+str( { "x" : 3 } )+"" EOF`,
 	}
 	for id, target := range targets {
 		if len(target) == 0 {

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -238,6 +238,18 @@ func (*ParenExpr) expr()     {}
 func (*SliceExpr) expr()     {}
 func (*TupleExpr) expr()     {}
 func (*UnaryExpr) expr()     {}
+func (*FStringExpr) expr()   {}
+
+type FStringExpr struct{
+	commentsRef
+	TokenPos Position
+	Raw string
+	Args []Expr
+}
+
+func (x *FStringExpr) Span() (start,end Position){
+	return x.TokenPos, x.TokenPos.add(x.Raw)
+}
 
 // An Ident represents an identifier.
 type Ident struct {

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -240,14 +240,14 @@ func (*TupleExpr) expr()     {}
 func (*UnaryExpr) expr()     {}
 func (*FStringExpr) expr()   {}
 
-type FStringExpr struct{
+type FStringExpr struct {
 	commentsRef
 	TokenPos Position
-	Raw string
-	Args []Expr
+	Raw      string
+	Args     []Expr
 }
 
-func (x *FStringExpr) Span() (start,end Position){
+func (x *FStringExpr) Span() (start, end Position) {
 	return x.TokenPos, x.TokenPos.add(x.Raw)
 }
 

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -242,9 +242,11 @@ func (*FStringExpr) expr()   {}
 
 type FStringExpr struct {
 	commentsRef
-	TokenPos Position
-	Raw      string
-	Args     []Expr
+	TokenPos    Position
+	Raw         string
+	RawParts    []string
+	StringParts []string
+	Args        []Expr
 }
 
 func (x *FStringExpr) Span() (start, end Position) {


### PR DESCRIPTION
This change implements Python-style f-string literals for Starlark.  
An f-string such as `f"hello {name}"` is parsed as a single expression that evaluates to the string `"hello Starlark"` when `name = "Starlark"`.  
Only the interpolation syntax `{expr}` is supported; conversion flags (`!r`, `!s`), format specifiers (`:>10`, `:.2f`) and the raw+f combination (`rf"…"`) are left for future work.

Reasoning:
- Ergonomics: String concatenation or `.format()` calls are noisy and error-prone.
- Familiarity:  Every Python programmer already knows the syntax; no new learning curve for the dominant Starlark user base (Bazel, Buck, Tilt, etc.).
- Performance :  One parse-time rewrite plus a single `format` call is faster than creating intermediate strings for each `+` operator, and it avoids the temporary allocations that show up in macro-generated code.
- Future-proofing: The groundwork (scanner, parser, resolver) is now in place. Conversion flags (`!r`, `!s`) and format specifiers (`:>10`) can be added later without breaking existing programs.

What is new:
- Scanner: recognises `f'…'`, `f"…"`, `f'''…'''`, `f"""…"""`.
- Parser: builds an `FStringExpr` node that keeps the literal segments and the interpolated expressions.  
- Resolver: visits the interpolated expressions.  
- Compiler: emits code that at runtime concatenates the literal parts and the evaluated expressions via the built-in `format` method (same strategy Python uses).  
- Tests: extensive unit tests for scanner, parser, resolver and end-to-end execution; golden-file test-suite in `testdata/fstring.star`.

Breaking changes:
None – f-strings are purely additive.

Implementation notes:  
- `fcomp.args` signature changed from `(*syntax.CallExpr)` to `[]syntax.Expr` so it can be re-used for the implicit `format` call generated by f-strings.  
- The scanner uses a small stack to handle nested braces and triple quotes correctly. It is impossible to not use it if we want to allow nested fstrings.

Future work (not in this PR)  
- Support `!r`, `!s`, `:fmt` conversion / format specs.  
- Better error messages for unbalanced braces.  
- Disallow `rf"…"` combination.
