### PR TITLE
Fix a typo in hashString() that caused poor hash distribution.

### DIFF
--- a/starlark/hashtable.go
+++ b/starlark/hashtable.go
@@ -434,7 +434,7 @@ func hashString(s string) uint32 {
 		// Call the Go runtime's optimized hash implementation,
 		// which uses the AES instructions on amd64 and arm64 machines.
 		h := maphash.String(seed, s)
-		return uint32(h>>32) | uint32(h)
+		return uint32(h>>32) ^ uint32(h)
 	}
 	return softHashString(s)
 }


### PR DESCRIPTION
When reducing the 64-bit hash returned by maphash.String() to the needed 32-bit hash, a bitwise OR was used to combine the upper and lower halves of the 64-bit hash. This commit changes it to use a bitwise XOR instead, which should better preserve the uniform distribution of the hash values.

Fixes https://github.com/google/starlark-go/issues/633