### PR TITLE
starlark: add maxAlloc guard to list, sorted, enumerate

### DIFF
--- a/starlark/library.go
+++ b/starlark/library.go
@@ -345,6 +345,9 @@ func enumerate(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, e
 	var x Value
 
 	if n := Len(iterable); n >= 0 {
+		if uint(n) >= maxAlloc/2 {
+			return nil, fmt.Errorf("enumerate: argument too large (%d elements)", n)
+		}
 		// common case: known length
 		pairs = make([]Value, 0, n)
 		array := make(Tuple, 2*n) // allocate a single backing array
@@ -686,6 +689,9 @@ func list(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 		iter := iterable.Iterate()
 		defer iter.Done()
 		if n := Len(iterable); n > 0 {
+			if uint(n) >= maxAlloc {
+				return nil, fmt.Errorf("list: argument too large (%d elements)", n)
+			}
 			elems = make([]Value, 0, n) // preallocate if length known
 		}
 		var x Value
@@ -1033,6 +1039,9 @@ func sorted(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	defer iter.Done()
 	var values []Value
 	if n := Len(iterable); n > 0 {
+		if uint(n) >= maxAlloc {
+			return nil, fmt.Errorf("sorted: argument too large (%d elements)", n)
+		}
 		values = make(Tuple, 0, n) // preallocate if length is known
 	}
 	var x Value


### PR DESCRIPTION
list(), sorted(), and enumerate() preallocate a backing slice using
Len(iterable) as the capacity with no upper-bound check. When called
with a large range() value (e.g. list(range(4611686018427387904))),
the resulting make([]Value, 0, 2^62) overflows and the Go runtime panics:

  panic: runtime error: makeslice: cap out of range
  go.starlark.net/starlark.list(...)
      starlark/library.go:689

The panic is unrecovered and kills the host process. Any application
evaluating untrusted Starlark is affected.

The *Repeat helpers in eval.go already define and enforce maxAlloc=1<<30
for string/bytes/tuple repetition. This PR applies the same guard to
list(), sorted(), and enumerate().

Fixes: https://issuetracker.google.com/issues/499639516