### PR TITLE
perf: add allocation-free fast path to string_startswith/endswith

### DIFF
--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -90,8 +90,8 @@ var Module = &starlarkstruct.Module{
 }
 
 func encode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var x starlark.Value
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x); err != nil {
+	x, err := starlark.UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -301,8 +301,8 @@ func indent(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 	); err != nil {
 		return nil, err
 	}
-	var str string // positional-only
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, nil, 1, &str); err != nil {
+	str, err := starlark.UnpackString1(b.Name(), args, nil)
+	if err != nil {
 		return nil, err
 	}
 

--- a/lib/math/math.go
+++ b/lib/math/math.go
@@ -163,9 +163,8 @@ func log(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwar
 }
 
 func ceil(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var x starlark.Value
-
-	if err := starlark.UnpackPositionalArgs("ceil", args, kwargs, 1, &x); err != nil {
+	x, err := starlark.UnpackPositional1("ceil", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 
@@ -180,9 +179,8 @@ func ceil(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwa
 }
 
 func floor(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var x starlark.Value
-
-	if err := starlark.UnpackPositionalArgs("floor", args, kwargs, 1, &x); err != nil {
+	x, err := starlark.UnpackPositional1("floor", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -173,8 +173,8 @@ var Module = &starlarkstruct.Module{
 // (Technically a pool may also have many FileDescriptors with the same
 // file name, but this can't happen with a single consistent snapshot.)
 func file(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var filename string
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &filename); err != nil {
+	filename, err := starlark.UnpackString1(fn.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -958,8 +958,8 @@ func (rf *RepeatedField) Attr(name string) (starlark.Value, error) {
 }
 
 func repeatedFieldAppend(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var object starlark.Value
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &object); err != nil {
+	object, err := starlark.UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	rf := b.Receiver().(*RepeatedField)
@@ -1432,8 +1432,8 @@ func (e EnumDescriptor) Name() string { return string(e.Desc.Name()) } // for Ca
 // The Call method implements the starlark.Callable interface.
 // A call to an enum descriptor converts its argument to a value of that enum type.
 func (e EnumDescriptor) CallInternal(_ *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var x starlark.Value
-	if err := starlark.UnpackPositionalArgs(string(e.Desc.Name()), args, kwargs, 1, &x); err != nil {
+	x, err := starlark.UnpackPositional1(string(e.Desc.Name()), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	v, err := enumValueOf(e.Desc, x)

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -99,11 +99,11 @@ func parseDuration(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 }
 
 func isValidTimezone(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var s string
-	if err := starlark.UnpackPositionalArgs("is_valid_timezone", args, kwargs, 1, &s); err != nil {
+	s, err := starlark.UnpackString1("is_valid_timezone", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
-	_, err := time.LoadLocation(s)
+	_, err = time.LoadLocation(s)
 	return starlark.Bool(err == nil), nil
 }
 
@@ -471,8 +471,8 @@ var timeMethods = map[string]builtinMethod{
 }
 
 func timeFormat(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var x string
-	if err := starlark.UnpackPositionalArgs("format", args, kwargs, 1, &x); err != nil {
+	x, err := starlark.UnpackString1("format", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 
@@ -481,8 +481,8 @@ func timeFormat(fnname string, recV starlark.Value, args starlark.Tuple, kwargs 
 }
 
 func timeIn(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var x string
-	if err := starlark.UnpackPositionalArgs("in_location", args, kwargs, 1, &x); err != nil {
+	x, err := starlark.UnpackString1("in_location", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	loc, err := time.LoadLocation(x)

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1950,21 +1950,31 @@ func string_rindex(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, er
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·startswith
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·endswith
 func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var x Value
-	var start, end Value = None, None
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x, &start, &end); err != nil {
-		return nil, err
-	}
-
-	// compute effective substring.
 	s := string(b.Receiver().(String))
-	if start, end, err := indices(start, end, len(s)); err != nil {
-		return nil, nameErr(b, err)
+
+	var x Value
+	if len(args) == 1 && len(kwargs) == 0 {
+		// Fast path for the common case, s.startswith(x):
+		// the variadic call to UnpackPositionalArgs would
+		// force x, start, and end to escape to the heap.
+		x = args[0]
 	} else {
-		if end < start {
-			end = start // => empty result
+		var xv Value
+		var start, end Value = None, None
+		if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &xv, &start, &end); err != nil {
+			return nil, err
 		}
-		s = s[start:end]
+		x = xv
+
+		// compute effective substring.
+		if start, end, err := indices(start, end, len(s)); err != nil {
+			return nil, nameErr(b, err)
+		} else {
+			if end < start {
+				end = start // => empty result
+			}
+			s = s[start:end]
+		}
 	}
 
 	f := strings.HasPrefix

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -177,8 +177,8 @@ func builtinAttrNames(methods map[string]*Builtin) []string {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#abs
 func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var x Value
-	if err := UnpackPositionalArgs("abs", args, kwargs, 1, &x); err != nil {
+	x, err := UnpackPositional1("abs", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	switch x := x.(type) {
@@ -506,8 +506,8 @@ func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#hash
 func hash(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var x Value
-	if err := UnpackPositionalArgs("hash", args, kwargs, 1, &x); err != nil {
+	x, err := UnpackPositional1("hash", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 
@@ -664,8 +664,8 @@ func parseInt(s string, base int) Value {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#len
 func len_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var x Value
-	if err := UnpackPositionalArgs("len", args, kwargs, 1, &x); err != nil {
+	x, err := UnpackPositional1("len", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	len := Len(x)
@@ -965,8 +965,8 @@ func (*rangeIterator) Done() {}
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#repr
 func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var x Value
-	if err := UnpackPositionalArgs("repr", args, kwargs, 1, &x); err != nil {
+	x, err := UnpackPositional1("repr", args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	return String(x.String()), nil
@@ -1211,8 +1211,8 @@ func zip(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·get
 func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var key, dflt Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
+	key, dflt, err := UnpackPositional2(b.Name(), args, kwargs, nil)
+	if err != nil {
 		return nil, err
 	}
 	if v, ok, err := b.Receiver().(*Dict).Get(key); err != nil {
@@ -1256,8 +1256,8 @@ func dict_keys(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·pop
 func dict_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var k, d Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k, &d); err != nil {
+	k, d, err := UnpackPositional2(b.Name(), args, kwargs, nil)
+	if err != nil {
 		return nil, err
 	}
 	if v, found, err := b.Receiver().(*Dict).Delete(k); err != nil {
@@ -1289,8 +1289,8 @@ func dict_popitem(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·setdefault
 func dict_setdefault(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var key, dflt Value = nil, None
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
+	key, dflt, err := UnpackPositional2(b.Name(), args, kwargs, None)
+	if err != nil {
 		return nil, err
 	}
 	dict := b.Receiver().(*Dict)
@@ -1331,8 +1331,8 @@ func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·append
 func list_append(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var object Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &object); err != nil {
+	object, err := UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*List)
@@ -1370,8 +1370,8 @@ func list_extend(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·index
 func list_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var value, start_, end_ Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &value, &start_, &end_); err != nil {
+	value, start_, end_, err := UnpackPositional3(b.Name(), args, kwargs, nil, nil)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1424,8 +1424,8 @@ func list_insert(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·remove
 func list_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
-	var value Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &value); err != nil {
+	value, err := UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("remove from"); err != nil {
@@ -2188,8 +2188,8 @@ func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·add.
 func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var elem Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &elem); err != nil {
+	elem, err := UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)
@@ -2203,8 +2203,7 @@ func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	} else if found {
 		return None, nil
 	}
-	err := recv.Insert(elem)
-	if err != nil {
+	if err = recv.Insert(elem); err != nil {
 		return nil, nameErr(b, err)
 	}
 	return None, nil
@@ -2287,8 +2286,8 @@ func set_issuperset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·discard.
 func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var k Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k); err != nil {
+	k, err := UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1227,7 +1227,7 @@ func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·clear
 func dict_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	return None, b.Receiver().(*Dict).Clear()
@@ -1235,7 +1235,7 @@ func dict_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·items
 func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	items := b.Receiver().(*Dict).Items()
@@ -1248,7 +1248,7 @@ func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·keys
 func dict_keys(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	return NewList(b.Receiver().(*Dict).Keys()), nil
@@ -1272,7 +1272,7 @@ func dict_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·popitem
 func dict_popitem(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Dict)
@@ -1318,7 +1318,7 @@ func dict_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
 func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	items := b.Receiver().(*Dict).Items()
@@ -1345,7 +1345,7 @@ func list_append(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·clear
 func list_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	if err := b.Receiver().(*List).Clear(); err != nil {
@@ -1468,7 +1468,7 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·capitalize
 func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	s := string(b.Receiver().(String))
@@ -1491,7 +1491,7 @@ func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // - elem_ords: numeric values of successive bytes
 // - codepoint_ords: numeric values of successive Unicode code points
 func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	s := b.Receiver().(String)
@@ -1507,7 +1507,7 @@ func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, 
 // bytes_elems returns an unspecified iterable value whose
 // iterator yields the int values of successive elements.
 func bytes_elems(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	return bytesIterable{b.Receiver().(Bytes)}, nil
@@ -1562,7 +1562,7 @@ func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalnum
 func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1576,7 +1576,7 @@ func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalpha
 func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1590,7 +1590,7 @@ func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isdigit
 func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1604,7 +1604,7 @@ func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·islower
 func string_islower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1629,7 +1629,7 @@ func isCasedRune(r rune) bool {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isspace
 func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1643,7 +1643,7 @@ func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·istitle
 func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1676,7 +1676,7 @@ func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isupper
 func string_isupper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1875,7 +1875,7 @@ func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lower
 func string_lower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	return String(strings.ToLower(string(b.Receiver().(String)))), nil
@@ -2025,7 +2025,7 @@ func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·title
 func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 
@@ -2051,7 +2051,7 @@ func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·upper
 func string_upper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	return String(strings.ToUpper(string(b.Receiver().(String)))), nil
@@ -2211,7 +2211,7 @@ func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·clear.
 func set_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	if b.Receiver().(*Set).Len() > 0 {
@@ -2309,7 +2309,7 @@ func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·pop.
 func set_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+	if err := NoArgs(b.Name(), args, kwargs); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -230,11 +230,16 @@ func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#bool
 func bool_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var x Value = False
-	if err := UnpackPositionalArgs("bool", args, kwargs, 0, &x); err != nil {
-		return nil, err
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("bool: unexpected keyword arguments")
 	}
-	return x.Truth(), nil
+	if len(args) > 1 {
+		return nil, fmt.Errorf("bool: got %d arguments, want at most 1", len(args))
+	}
+	if len(args) == 0 {
+		return False, nil
+	}
+	return args[0].Truth(), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#bytes
@@ -1463,9 +1468,18 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	recv := b.Receiver()
 	list := recv.(*List)
 	n := list.Len()
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("%s: unexpected keyword arguments", b.Name())
+	}
+	if len(args) > 1 {
+		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", b.Name(), len(args))
+	}
 	i := n - 1
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &i); err != nil {
-		return nil, err
+	if len(args) == 1 {
+		var err error
+		if i, err = AsInt32(args[0]); err != nil {
+			return nil, fmt.Errorf("%s: for parameter 1: %s", b.Name(), err)
+		}
 	}
 	origI := i
 	if i < 0 {
@@ -2013,9 +2027,18 @@ func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lstrip
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rstrip
 func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("%s: unexpected keyword arguments", b.Name())
+	}
+	if len(args) > 1 {
+		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", b.Name(), len(args))
+	}
 	var chars string
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &chars); err != nil {
-		return nil, err
+	if len(args) == 1 {
+		var ok bool
+		if chars, ok = AsString(args[0]); !ok {
+			return nil, fmt.Errorf("%s: for parameter 1: got %s, want string", b.Name(), args[0].Type())
+		}
 	}
 	recv := string(b.Receiver().(String))
 	var s string
@@ -2182,9 +2205,19 @@ func splitspace(s string, max int) []string {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·splitlines
 func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("%s: unexpected keyword arguments", b.Name())
+	}
+	if len(args) > 1 {
+		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", b.Name(), len(args))
+	}
 	var keepends bool
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &keepends); err != nil {
-		return nil, err
+	if len(args) == 1 {
+		b, ok := args[0].(Bool)
+		if !ok {
+			return nil, fmt.Errorf("splitlines: for parameter 1: got %s, want bool", args[0].Type())
+		}
+		keepends = bool(b)
 	}
 	var lines []string
 	if s := string(b.Receiver().(String)); s != "" {

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -454,10 +454,20 @@ var (
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#getattr
 func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var object, dflt Value
-	var name string
-	if err := UnpackPositionalArgs("getattr", args, kwargs, 2, &object, &name, &dflt); err != nil {
-		return nil, err
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("getattr: unexpected keyword arguments")
+	}
+	if len(args) < 2 || len(args) > 3 {
+		return nil, fmt.Errorf("getattr: got %d arguments, want 2 or 3", len(args))
+	}
+	object := args[0]
+	name, ok := AsString(args[1])
+	if !ok {
+		return nil, fmt.Errorf("getattr: for parameter 2: got %s, want string", args[1].Type())
+	}
+	var dflt Value
+	if len(args) == 3 {
+		dflt = args[2]
 	}
 	if object, ok := object.(HasAttrs); ok {
 		v, err := object.Attr(name)
@@ -482,10 +492,16 @@ func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#hasattr
 func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var object Value
-	var name string
-	if err := UnpackPositionalArgs("hasattr", args, kwargs, 2, &object, &name); err != nil {
-		return nil, err
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("hasattr: unexpected keyword arguments")
+	}
+	if len(args) != 2 {
+		return nil, fmt.Errorf("hasattr: got %d arguments, want 2", len(args))
+	}
+	object := args[0]
+	name, ok := AsString(args[1])
+	if !ok {
+		return nil, fmt.Errorf("hasattr: for parameter 2: got %s, want string", args[1].Type())
 	}
 	if object, ok := object.(HasAttrs); ok {
 		v, err := object.Attr(name)

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1950,31 +1950,20 @@ func string_rindex(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, er
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·startswith
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·endswith
 func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+	x, start, end, err := UnpackPositional3(b.Name(), args, kwargs, None, None)
+	if err != nil {
+		return nil, err
+	}
+
+	// compute effective substring.
 	s := string(b.Receiver().(String))
-
-	var x Value
-	if len(args) == 1 && len(kwargs) == 0 {
-		// Fast path for the common case, s.startswith(x):
-		// the variadic call to UnpackPositionalArgs would
-		// force x, start, and end to escape to the heap.
-		x = args[0]
+	if start, end, err := indices(start, end, len(s)); err != nil {
+		return nil, nameErr(b, err)
 	} else {
-		var xv Value
-		var start, end Value = None, None
-		if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &xv, &start, &end); err != nil {
-			return nil, err
+		if end < start {
+			end = start // => empty result
 		}
-		x = xv
-
-		// compute effective substring.
-		if start, end, err := indices(start, end, len(s)); err != nil {
-			return nil, nameErr(b, err)
-		} else {
-			if end < start {
-				end = start // => empty result
-			}
-			s = s[start:end]
-		}
+		s = s[start:end]
 	}
 
 	f := strings.HasPrefix

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -2326,8 +2326,8 @@ func set_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·remove.
 func set_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var k Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k); err != nil {
+	k, err := UnpackPositional1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	if found, err := b.Receiver().(*Set).Delete(k); err != nil {

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -196,8 +196,8 @@ func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#all
 func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var iterable Iterable
-	if err := UnpackPositionalArgs("all", args, kwargs, 1, &iterable); err != nil {
+	iterable, err := UnpackIterable("all", args, kwargs, true)
+	if err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -213,8 +213,8 @@ func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#any
 func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var iterable Iterable
-	if err := UnpackPositionalArgs("any", args, kwargs, 1, &iterable); err != nil {
+	iterable, err := UnpackIterable("any", args, kwargs, true)
+	if err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -677,8 +677,8 @@ func len_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list
 func list(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var iterable Iterable
-	if err := UnpackPositionalArgs("list", args, kwargs, 0, &iterable); err != nil {
+	iterable, err := UnpackIterable("list", args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	var elems []Value
@@ -974,8 +974,8 @@ func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#reversed
 func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var iterable Iterable
-	if err := UnpackPositionalArgs("reversed", args, kwargs, 1, &iterable); err != nil {
+	iterable, err := UnpackIterable("reversed", args, kwargs, true)
+	if err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -997,8 +997,8 @@ func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, er
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set
 func set(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var iterable Iterable
-	if err := UnpackPositionalArgs("set", args, kwargs, 0, &iterable); err != nil {
+	iterable, err := UnpackIterable("set", args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	set := new(Set)
@@ -1122,8 +1122,8 @@ func utf8Transcode(s string) string {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#tuple
 func tuple(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var iterable Iterable
-	if err := UnpackPositionalArgs("tuple", args, kwargs, 0, &iterable); err != nil {
+	iterable, err := UnpackIterable("tuple", args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	if len(args) == 0 {
@@ -1357,8 +1357,8 @@ func list_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·extend
 func list_extend(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
-	var iterable Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
+	iterable, err := UnpackIterable(b.Name(), args, kwargs, true)
+	if err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("extend"); err != nil {
@@ -1541,10 +1541,13 @@ func (*bytesIterator) Done() {}
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·count
 func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var sub string
-	var start_, end_ Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
+	x, start_, end_, err := UnpackPositional3(b.Name(), args, kwargs, None, None)
+	if err != nil {
 		return nil, err
+	}
+	sub, ok := AsString(x)
+	if !ok {
+		return nil, fmt.Errorf("%s: for parameter 1: got %s, want string", b.Name(), x.Type())
 	}
 
 	recv := string(b.Receiver().(String))
@@ -1852,8 +1855,8 @@ func string_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·join
 func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
-	var iterable Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
+	iterable, err := UnpackIterable(b.Name(), args, kwargs, true)
+	if err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -1884,8 +1887,8 @@ func string_lower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·partition
 func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
-	var sep string
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sep); err != nil {
+	sep, err := UnpackString1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	if sep == "" {
@@ -1914,8 +1917,8 @@ func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·removesuffix
 func string_removefix(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
-	var fix string
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &fix); err != nil {
+	fix, err := UnpackString1(b.Name(), args, kwargs)
+	if err != nil {
 		return nil, err
 	}
 	if b.name[len("remove")] == 'p' {
@@ -2225,8 +2228,8 @@ func set_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·difference.
 func set_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	// TODO: support multiple others: s.difference(*others)
-	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	other, err := UnpackIterable(b.Name(), args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2241,8 +2244,8 @@ func set_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_intersection.
 func set_intersection(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	// TODO: support multiple others: s.difference(*others)
-	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	other, err := UnpackIterable(b.Name(), args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2256,8 +2259,8 @@ func set_intersection(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_issubset.
 func set_issubset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	other, err := UnpackIterable(b.Name(), args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2271,8 +2274,8 @@ func set_issubset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_issuperset.
 func set_issuperset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	other, err := UnpackIterable(b.Name(), args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2340,8 +2343,8 @@ func set_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·symmetric_difference.
 func set_symmetric_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	other, err := UnpackIterable(b.Name(), args, kwargs, false)
+	if err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2372,10 +2375,13 @@ func set_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // Common implementation of string_{r}{find,index}.
 func string_find_impl(b *Builtin, args Tuple, kwargs []Tuple, allowError, last bool) (Value, error) {
-	var sub string
-	var start_, end_ Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
+	x, start_, end_, err := UnpackPositional3(b.Name(), args, kwargs, None, None)
+	if err != nil {
 		return nil, err
+	}
+	sub, ok := AsString(x)
+	if !ok {
+		return nil, fmt.Errorf("%s: for parameter 1: got %s, want string", b.Name(), x.Type())
 	}
 
 	s := string(b.Receiver().(String))

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -230,11 +230,8 @@ func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#bool
 func bool_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("bool: unexpected keyword arguments")
-	}
-	if len(args) > 1 {
-		return nil, fmt.Errorf("bool: got %d arguments, want at most 1", len(args))
+	if err := checkPositionalArgs("bool", args, kwargs, 0, 1); err != nil {
+		return nil, err
 	}
 	if len(args) == 0 {
 		return False, nil
@@ -283,11 +280,8 @@ func bytes_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#chr
 func chr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("chr does not accept keyword arguments")
-	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("chr: got %d arguments, want 1", len(args))
+	if err := checkPositionalArgs("chr", args, kwargs, 1, 1); err != nil {
+		return nil, err
 	}
 	i, err := AsInt32(args[0])
 	if err != nil {
@@ -316,11 +310,8 @@ func dict(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dir
 func dir(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("dir does not accept keyword arguments")
-	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("dir: got %d arguments, want 1", len(args))
+	if err := checkPositionalArgs("dir", args, kwargs, 1, 1); err != nil {
+		return nil, err
 	}
 
 	var names []string
@@ -459,11 +450,8 @@ var (
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#getattr
 func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("getattr: unexpected keyword arguments")
-	}
-	if len(args) < 2 || len(args) > 3 {
-		return nil, fmt.Errorf("getattr: got %d arguments, want 2 or 3", len(args))
+	if err := checkPositionalArgs("getattr", args, kwargs, 2, 3); err != nil {
+		return nil, err
 	}
 	object := args[0]
 	name, ok := AsString(args[1])
@@ -497,11 +485,8 @@ func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#hasattr
 func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("hasattr: unexpected keyword arguments")
-	}
-	if len(args) != 2 {
-		return nil, fmt.Errorf("hasattr: got %d arguments, want 2", len(args))
+	if err := checkPositionalArgs("hasattr", args, kwargs, 2, 2); err != nil {
+		return nil, err
 	}
 	object := args[0]
 	name, ok := AsString(args[1])
@@ -787,11 +772,8 @@ func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#ord
 func ord(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("ord does not accept keyword arguments")
-	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("ord: got %d arguments, want 1", len(args))
+	if err := checkPositionalArgs("ord", args, kwargs, 1, 1); err != nil {
+		return nil, err
 	}
 	switch x := args[0].(type) {
 	case String:
@@ -1110,11 +1092,8 @@ func (s *sortSlice) Swap(i, j int) {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#str
 func str(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("str does not accept keyword arguments")
-	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("str: got %d arguments, want exactly 1", len(args))
+	if err := checkPositionalArgs("str", args, kwargs, 1, 1); err != nil {
+		return nil, err
 	}
 	switch x := args[0].(type) {
 	case String:
@@ -1165,11 +1144,8 @@ func tuple(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#type
 func type_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("type does not accept keyword arguments")
-	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("type: got %d arguments, want exactly 1", len(args))
+	if err := checkPositionalArgs("type", args, kwargs, 1, 1); err != nil {
+		return nil, err
 	}
 	return String(args[0].Type()), nil
 }
@@ -1248,7 +1224,7 @@ func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·clear
 func dict_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	return None, b.Receiver().(*Dict).Clear()
@@ -1256,7 +1232,7 @@ func dict_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·items
 func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	items := b.Receiver().(*Dict).Items()
@@ -1269,7 +1245,7 @@ func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·keys
 func dict_keys(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	return NewList(b.Receiver().(*Dict).Keys()), nil
@@ -1293,7 +1269,7 @@ func dict_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·popitem
 func dict_popitem(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Dict)
@@ -1339,7 +1315,7 @@ func dict_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
 func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	items := b.Receiver().(*Dict).Items()
@@ -1366,7 +1342,7 @@ func list_append(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·clear
 func list_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	if err := b.Receiver().(*List).Clear(); err != nil {
@@ -1468,11 +1444,8 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	recv := b.Receiver()
 	list := recv.(*List)
 	n := list.Len()
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("%s: unexpected keyword arguments", b.Name())
-	}
-	if len(args) > 1 {
-		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", b.Name(), len(args))
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 1); err != nil {
+		return nil, err
 	}
 	i := n - 1
 	if len(args) == 1 {
@@ -1498,7 +1471,7 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·capitalize
 func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	s := string(b.Receiver().(String))
@@ -1521,7 +1494,7 @@ func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // - elem_ords: numeric values of successive bytes
 // - codepoint_ords: numeric values of successive Unicode code points
 func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	s := b.Receiver().(String)
@@ -1537,7 +1510,7 @@ func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, 
 // bytes_elems returns an unspecified iterable value whose
 // iterator yields the int values of successive elements.
 func bytes_elems(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	return bytesIterable{b.Receiver().(Bytes)}, nil
@@ -1595,7 +1568,7 @@ func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalnum
 func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1609,7 +1582,7 @@ func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalpha
 func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1623,7 +1596,7 @@ func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isdigit
 func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1637,7 +1610,7 @@ func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·islower
 func string_islower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1662,7 +1635,7 @@ func isCasedRune(r rune) bool {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isspace
 func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1676,7 +1649,7 @@ func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·istitle
 func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1709,7 +1682,7 @@ func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isupper
 func string_isupper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -1908,7 +1881,7 @@ func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lower
 func string_lower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	return String(strings.ToLower(string(b.Receiver().(String)))), nil
@@ -2027,11 +2000,8 @@ func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lstrip
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rstrip
 func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("%s: unexpected keyword arguments", b.Name())
-	}
-	if len(args) > 1 {
-		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", b.Name(), len(args))
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 1); err != nil {
+		return nil, err
 	}
 	var chars string
 	if len(args) == 1 {
@@ -2067,7 +2037,7 @@ func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·title
 func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 
@@ -2093,7 +2063,7 @@ func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·upper
 func string_upper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	return String(strings.ToUpper(string(b.Receiver().(String)))), nil
@@ -2205,11 +2175,8 @@ func splitspace(s string, max int) []string {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·splitlines
 func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("%s: unexpected keyword arguments", b.Name())
-	}
-	if len(args) > 1 {
-		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", b.Name(), len(args))
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 1); err != nil {
+		return nil, err
 	}
 	var keepends bool
 	if len(args) == 1 {
@@ -2263,7 +2230,7 @@ func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·clear.
 func set_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	if b.Receiver().(*Set).Len() > 0 {
@@ -2361,7 +2328,7 @@ func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·pop.
 func set_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := NoArgs(b.Name(), args, kwargs); err != nil {
+	if err := checkPositionalArgs(b.Name(), args, kwargs, 0, 0); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)

--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -34,6 +34,12 @@ def bench_builtin_method(b):
         for _ in range1000:
             emptydict.get(None)
 
+def bench_startswith(b):
+    s = "some/path/to/a/file.txt"
+    for _ in range(b.n):
+        for _ in range1000:
+            s.startswith("some/")
+
 def bench_int(b):
     for _ in range(b.n):
         a = 0

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -216,6 +216,22 @@ func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, va
 	return nil
 }
 
+// Unpack 1-3 positional args, def1 and def2 being the default values for arguments 2 and 3.
+func UnpackPositional3(fnname string, args Tuple, kwargs []Tuple, def1, def2 Value) (Value, Value, Value, error) {
+	if len(kwargs) > 0 {
+		return nil, nil, nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	switch len(args) {
+	case 1:
+		return args[0], def1, def2, nil
+	case 2:
+		return args[0], args[1], def2, nil
+	case 3:
+		return args[0], args[1], args[2], nil
+	}
+	return nil, nil, nil, fmt.Errorf("%s: got %d arguments, want 1 to 3", fnname, len(args))
+}
+
 // UnpackArg unpacks a Value v into the variable pointed to by ptr.
 // See [UnpackArgs] for details, including which types of variable are supported.
 //

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -227,6 +227,43 @@ func NoArgs(fnname string, args Tuple, kwargs []Tuple) error {
 	return nil
 }
 
+// Unpack one Iterable argument, no keyword args.
+// If required is true the argument must be present; otherwise it is optional.
+func UnpackIterable(fnname string, args Tuple, kwargs []Tuple, required bool) (Iterable, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	if len(args) > 1 {
+		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", fnname, len(args))
+	}
+	if len(args) == 0 {
+		if required {
+			return nil, fmt.Errorf("%s: got 0 arguments, want 1", fnname)
+		}
+		return nil, nil
+	}
+	iter, ok := args[0].(Iterable)
+	if !ok {
+		return nil, fmt.Errorf("%s: for parameter 1: got %s, want iterable", fnname, args[0].Type())
+	}
+	return iter, nil
+}
+
+// Unpack one positional string argument, no keyword args.
+func UnpackString1(fnname string, args Tuple, kwargs []Tuple) (string, error) {
+	if len(kwargs) > 0 {
+		return "", fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	if len(args) != 1 {
+		return "", fmt.Errorf("%s: got %d arguments, want 1", fnname, len(args))
+	}
+	s, ok := AsString(args[0])
+	if !ok {
+		return "", fmt.Errorf("%s: for parameter 1: got %s, want string", fnname, args[0].Type())
+	}
+	return s, nil
+}
+
 // Unpack one positional arg, no keyword args.
 func UnpackPositional1(fnname string, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -216,6 +216,17 @@ func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, va
 	return nil
 }
 
+// Assert zero args, no keyword args.
+func NoArgs(fnname string, args Tuple, kwargs []Tuple) error {
+	if len(args) > 0 {
+		return fmt.Errorf("%s: got %d arguments, want 0", fnname, len(args))
+	}
+	if len(kwargs) > 0 {
+		return fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	return nil
+}
+
 // Unpack one positional arg, no keyword args.
 func UnpackPositional1(fnname string, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -216,7 +216,34 @@ func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, va
 	return nil
 }
 
-// Unpack 1-3 positional args, def1 and def2 being the default values for arguments 2 and 3.
+// Unpack one positional arg, no keyword args.
+func UnpackPositional1(fnname string, args Tuple, kwargs []Tuple) (Value, error) {
+	if len(kwargs) > 0 {
+		return nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	if len(args) != 1 {
+		return nil, fmt.Errorf("%s: got %d arguments, want 1", fnname, len(args))
+	}
+	return args[0], nil
+}
+
+// Unpack two positional args, no keyword args. If the second argument is
+// absent, def is returned instead.
+func UnpackPositional2(fnname string, args Tuple, kwargs []Tuple, def Value) (Value, Value, error) {
+	if len(kwargs) > 0 {
+		return nil, nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	switch len(args) {
+	case 1:
+		return args[0], def, nil
+	case 2:
+		return args[0], args[1], nil
+	}
+	return nil, nil, fmt.Errorf("%s: got %d arguments, want 1 or 2", fnname, len(args))
+}
+
+// Unpack three positional args, no keyword args. If the second or third argument is
+// absent, def1 or def2 is returned instead.
 func UnpackPositional3(fnname string, args Tuple, kwargs []Tuple, def1, def2 Value) (Value, Value, Value, error) {
 	if len(kwargs) > 0 {
 		return nil, nil, nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -216,13 +216,21 @@ func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, va
 	return nil
 }
 
-// Assert zero args, no keyword args.
-func NoArgs(fnname string, args Tuple, kwargs []Tuple) error {
-	if len(args) > 0 {
-		return fmt.Errorf("%s: got %d arguments, want 0", fnname, len(args))
-	}
+// checkPositionalArgs validates that kwargs is empty and that the number of
+// positional arguments is between min and max inclusive. It produces the same
+// error messages as [UnpackPositionalArgs].
+func checkPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min, max int) error {
 	if len(kwargs) > 0 {
 		return fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	}
+	if len(args) < min || len(args) > max {
+		if min == max {
+			return fmt.Errorf("%s: got %d arguments, want %d", fnname, len(args), min)
+		}
+		if len(args) < min {
+			return fmt.Errorf("%s: got %d arguments, want at least %d", fnname, len(args), min)
+		}
+		return fmt.Errorf("%s: got %d arguments, want at most %d", fnname, len(args), max)
 	}
 	return nil
 }
@@ -230,16 +238,14 @@ func NoArgs(fnname string, args Tuple, kwargs []Tuple) error {
 // Unpack one Iterable argument, no keyword args.
 // If required is true the argument must be present; otherwise it is optional.
 func UnpackIterable(fnname string, args Tuple, kwargs []Tuple, required bool) (Iterable, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	min := 0
+	if required {
+		min = 1
 	}
-	if len(args) > 1 {
-		return nil, fmt.Errorf("%s: got %d arguments, want at most 1", fnname, len(args))
+	if err := checkPositionalArgs(fnname, args, kwargs, min, 1); err != nil {
+		return nil, err
 	}
 	if len(args) == 0 {
-		if required {
-			return nil, fmt.Errorf("%s: got 0 arguments, want 1", fnname)
-		}
 		return nil, nil
 	}
 	iter, ok := args[0].(Iterable)
@@ -251,11 +257,8 @@ func UnpackIterable(fnname string, args Tuple, kwargs []Tuple, required bool) (I
 
 // Unpack one positional string argument, no keyword args.
 func UnpackString1(fnname string, args Tuple, kwargs []Tuple) (string, error) {
-	if len(kwargs) > 0 {
-		return "", fmt.Errorf("%s: unexpected keyword arguments", fnname)
-	}
-	if len(args) != 1 {
-		return "", fmt.Errorf("%s: got %d arguments, want 1", fnname, len(args))
+	if err := checkPositionalArgs(fnname, args, kwargs, 1, 1); err != nil {
+		return "", err
 	}
 	s, ok := AsString(args[0])
 	if !ok {
@@ -266,11 +269,8 @@ func UnpackString1(fnname string, args Tuple, kwargs []Tuple) (string, error) {
 
 // Unpack one positional arg, no keyword args.
 func UnpackPositional1(fnname string, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
-	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("%s: got %d arguments, want 1", fnname, len(args))
+	if err := checkPositionalArgs(fnname, args, kwargs, 1, 1); err != nil {
+		return nil, err
 	}
 	return args[0], nil
 }
@@ -278,33 +278,29 @@ func UnpackPositional1(fnname string, args Tuple, kwargs []Tuple) (Value, error)
 // Unpack two positional args, no keyword args. If the second argument is
 // absent, def is returned instead.
 func UnpackPositional2(fnname string, args Tuple, kwargs []Tuple, def Value) (Value, Value, error) {
-	if len(kwargs) > 0 {
-		return nil, nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	if err := checkPositionalArgs(fnname, args, kwargs, 1, 2); err != nil {
+		return nil, nil, err
 	}
-	switch len(args) {
-	case 1:
+	if len(args) == 1 {
 		return args[0], def, nil
-	case 2:
-		return args[0], args[1], nil
 	}
-	return nil, nil, fmt.Errorf("%s: got %d arguments, want 1 or 2", fnname, len(args))
+	return args[0], args[1], nil
 }
 
 // Unpack three positional args, no keyword args. If the second or third argument is
 // absent, def1 or def2 is returned instead.
 func UnpackPositional3(fnname string, args Tuple, kwargs []Tuple, def1, def2 Value) (Value, Value, Value, error) {
-	if len(kwargs) > 0 {
-		return nil, nil, nil, fmt.Errorf("%s: unexpected keyword arguments", fnname)
+	if err := checkPositionalArgs(fnname, args, kwargs, 1, 3); err != nil {
+		return nil, nil, nil, err
 	}
 	switch len(args) {
 	case 1:
 		return args[0], def1, def2, nil
 	case 2:
 		return args[0], args[1], def2, nil
-	case 3:
+	default:
 		return args[0], args[1], args[2], nil
 	}
-	return nil, nil, nil, fmt.Errorf("%s: got %d arguments, want 1 to 3", fnname, len(args))
 }
 
 // UnpackArg unpacks a Value v into the variable pointed to by ptr.

--- a/starlarkstruct/module.go
+++ b/starlarkstruct/module.go
@@ -30,8 +30,8 @@ func (m *Module) Type() string                             { return "module" }
 // function, module(name, **kwargs). It returns a new module with the
 // specified name and members.
 func MakeModule(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var name string
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, nil, 1, &name); err != nil {
+	name, err := starlark.UnpackString1(b.Name(), args, nil)
+	if err != nil {
 		return nil, err
 	}
 	members := make(starlark.StringDict, len(kwargs))


### PR DESCRIPTION
In the simple case with a single positional argument (`s.startswith(x)`) the call to `UnpackPositionalArgs` forced `x`, `start`, and `end` to escape to the heap costing four allocations per call (three variables plus the varargs slice).

In a profile of a Starlark-heavy application, these allocations in `string_startswith` accounted for 4.7% of all allocated objects across the entire process.

BenchmarkStarlark/bench_startswith (1000 calls per op):
```
┌────────┬─────────┬─────────┬───────────┐
│        │  ns/op  │  B/op   │ allocs/op │
├────────┼─────────┼─────────┼───────────┤
│ before │ 140,949 │ 128,048 │ 6,001     │
├────────┼─────────┼─────────┼───────────┤
│ after  │ 90,988  │ 80,048  │ 3,001     │
└────────┴─────────┴─────────┴───────────┘
```