### PR TITLE
fix: off-by-one in Opcode.String

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -297,7 +297,7 @@ var stackEffect = [...]int8{
 }
 
 func (op Opcode) String() string {
-	if op < OpcodeMax {
+	if op <= OpcodeMax {
 		if name := opcodeNames[op]; name != "" {
 			return name
 		}

--- a/internal/compile/opcode_test.go
+++ b/internal/compile/opcode_test.go
@@ -1,0 +1,23 @@
+package compile_test
+
+import (
+	"strings"
+	"testing"
+
+	"go.starlark.net/internal/compile"
+)
+
+// TestOpcodeNames checks that every opcode has a name, including the
+// highest-numbered one (a regression test for an off-by-one in
+// Opcode.String), and that out-of-range opcodes are reported as
+// illegal rather than out of bounds.
+func TestOpcodeNames(t *testing.T) {
+	for op := compile.Opcode(0); op <= compile.OpcodeMax; op++ {
+		if name := op.String(); strings.HasPrefix(name, "illegal op") {
+			t.Errorf("opcode %d has no name", op)
+		}
+	}
+	if name := (compile.OpcodeMax + 1).String(); !strings.HasPrefix(name, "illegal op") {
+		t.Errorf("Opcode(OpcodeMax+1).String() = %q, want illegal op", name)
+	}
+}


### PR DESCRIPTION
The highest-numbered opcode (`OpcodeMax`, currently `CALL_VAR_KW`) was reported as "illegal op" by `String()`.