### PR TITLE
starlark: reduce escaping in argument unpacking

### DIFF
--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -946,17 +946,29 @@ func (b *badType) Freeze()               {}
 
 var _ starlark.Value = new(badType)
 
+type badType2 string
+
+func (b badType2) String() string        { return "badType2" }
+func (b badType2) Type() string          { return "badType2" }
+func (b badType2) Truth() starlark.Bool  { return true }
+func (b badType2) Hash() (uint32, error) { return 0, nil }
+func (b badType2) Freeze()               {}
+
+var _ starlark.Value = new(badType)
+
 // TestUnpackErrorBadType verifies that the Unpack functions fail
 // gracefully when a parameter's default value's Type method panics.
 func TestUnpackErrorBadType(t *testing.T) {
+	var v1 *badType
+	var v2 badType2
 	for _, test := range []struct {
-		x    *badType
+		ptr  any
 		want string
 	}{
-		{new(badType), "got NoneType, want badType"},       // Starlark type name
-		{nil, "got NoneType, want *starlark_test.badType"}, // Go type name
+		{&v1, "got NoneType, want *starlark_test.badType"}, // Go type name: (*badType)(nil).Type() panics
+		{&v2, "got NoneType, want badType"},                // Starlark type name: badType2{}.Type() works
 	} {
-		err := starlark.UnpackArgs("f", starlark.Tuple{starlark.None}, nil, "x", &test.x)
+		err := starlark.UnpackArgs("f", starlark.Tuple{starlark.None}, nil, "x", test.ptr)
 		if err == nil {
 			t.Errorf("UnpackArgs succeeded unexpectedly")
 			continue
@@ -1213,5 +1225,25 @@ func TestUnpackArgsOptionalInference(t *testing.T) {
 	want = "x=1 y=2 z=0"
 	if got != want {
 		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestUnpackArgNoEscape(t *testing.T) {
+	var s starlark.String
+
+	// The internal Unpack*NoEscape variants
+	// must not allocate in the common case (success).
+	n := testing.AllocsPerRun(100, func() {
+		var x string // must not escape
+
+		if err := starlark.UnpackArgNoEscape(s, &s); err != nil {
+			t.Fatal(err)
+		}
+		if err := starlark.UnpackPositionalArgsNoEscape("fn", starlark.Tuple{s}, nil, 1, &x); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if n > 0 {
+		t.Errorf("AllocsPerRun = %v, want none", n)
 	}
 }

--- a/starlark/export_test.go
+++ b/starlark/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file exposes internal declarations to tests.
+
+package starlark
+
+func UnpackArgNoEscape(v Value, ptr any) error {
+	return unpackArgNoEscape(v, ptr)
+}
+
+func UnpackPositionalArgsNoEscape(fnname string, args Tuple, kwargs []Tuple, min int, vars ...any) error {
+	return unpackPositionalArgsNoEscape(fnname, args, kwargs, min, vars...)
+}

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -377,7 +377,8 @@ func AsInt(x Value, ptr any) error {
 		return fmt.Errorf("got %s, want int", x.Type())
 	}
 
-	bits := reflect.TypeOf(ptr).Elem().Size() * 8
+	ptrt := reflect.TypeOf(ptr)
+	bits := ptrt.Elem().Size() * 8
 	switch ptr.(type) {
 	case *int, *int8, *int16, *int32, *int64:
 		i, ok := xint.Int64()
@@ -417,7 +418,8 @@ func AsInt(x Value, ptr any) error {
 			*ptr = uintptr(i)
 		}
 	default:
-		panic(fmt.Sprintf("invalid argument type: %T", ptr))
+		// Avoid %T, as it would cause *ptr to escape.
+		panic(fmt.Sprintf("invalid argument type: %s", ptrt))
 	}
 	return nil
 }

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -178,7 +178,7 @@ func builtinAttrNames(methods map[string]*Builtin) []string {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#abs
 func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
-	if err := UnpackPositionalArgs("abs", args, kwargs, 1, &x); err != nil {
+	if err := unpackPositionalArgsNoEscape("abs", args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
 	switch x := x.(type) {
@@ -197,7 +197,7 @@ func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#all
 func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	if err := UnpackPositionalArgs("all", args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape("all", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -214,7 +214,7 @@ func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#any
 func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	if err := UnpackPositionalArgs("any", args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape("any", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -231,7 +231,7 @@ func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#bool
 func bool_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value = False
-	if err := UnpackPositionalArgs("bool", args, kwargs, 0, &x); err != nil {
+	if err := unpackPositionalArgsNoEscape("bool", args, kwargs, 0, &x); err != nil {
 		return nil, err
 	}
 	return x.Truth(), nil
@@ -334,7 +334,7 @@ func dir(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 func enumerate(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	var start int
-	if err := UnpackPositionalArgs("enumerate", args, kwargs, 1, &iterable, &start); err != nil {
+	if err := unpackPositionalArgsNoEscape("enumerate", args, kwargs, 1, &iterable, &start); err != nil {
 		return nil, err
 	}
 
@@ -456,7 +456,7 @@ var (
 func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var object, dflt Value
 	var name string
-	if err := UnpackPositionalArgs("getattr", args, kwargs, 2, &object, &name, &dflt); err != nil {
+	if err := unpackPositionalArgsNoEscape("getattr", args, kwargs, 2, &object, &name, &dflt); err != nil {
 		return nil, err
 	}
 	if object, ok := object.(HasAttrs); ok {
@@ -484,7 +484,7 @@ func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var object Value
 	var name string
-	if err := UnpackPositionalArgs("hasattr", args, kwargs, 2, &object, &name); err != nil {
+	if err := unpackPositionalArgsNoEscape("hasattr", args, kwargs, 2, &object, &name); err != nil {
 		return nil, err
 	}
 	if object, ok := object.(HasAttrs); ok {
@@ -507,7 +507,7 @@ func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, err
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#hash
 func hash(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
-	if err := UnpackPositionalArgs("hash", args, kwargs, 1, &x); err != nil {
+	if err := unpackPositionalArgsNoEscape("hash", args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
 
@@ -665,7 +665,7 @@ func parseInt(s string, base int) Value {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#len
 func len_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
-	if err := UnpackPositionalArgs("len", args, kwargs, 1, &x); err != nil {
+	if err := unpackPositionalArgsNoEscape("len", args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
 	len := Len(x)
@@ -678,7 +678,7 @@ func len_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list
 func list(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	if err := UnpackPositionalArgs("list", args, kwargs, 0, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape("list", args, kwargs, 0, &iterable); err != nil {
 		return nil, err
 	}
 	var elems []Value
@@ -827,7 +827,7 @@ func print(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 func range_(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var start, stop, step int
 	step = 1
-	if err := UnpackPositionalArgs("range", args, kwargs, 1, &start, &stop, &step); err != nil {
+	if err := unpackPositionalArgsNoEscape("range", args, kwargs, 1, &start, &stop, &step); err != nil {
 		return nil, err
 	}
 
@@ -966,7 +966,7 @@ func (*rangeIterator) Done() {}
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#repr
 func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
-	if err := UnpackPositionalArgs("repr", args, kwargs, 1, &x); err != nil {
+	if err := unpackPositionalArgsNoEscape("repr", args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
 	return String(x.String()), nil
@@ -975,7 +975,7 @@ func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#reversed
 func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	if err := UnpackPositionalArgs("reversed", args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape("reversed", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -998,7 +998,7 @@ func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, er
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set
 func set(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	if err := UnpackPositionalArgs("set", args, kwargs, 0, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape("set", args, kwargs, 0, &iterable); err != nil {
 		return nil, err
 	}
 	set := new(Set)
@@ -1123,7 +1123,7 @@ func utf8Transcode(s string) string {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#tuple
 func tuple(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	if err := UnpackPositionalArgs("tuple", args, kwargs, 0, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape("tuple", args, kwargs, 0, &iterable); err != nil {
 		return nil, err
 	}
 	if len(args) == 0 {
@@ -1212,7 +1212,7 @@ func zip(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·get
 func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var key, dflt Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
 	}
 	if v, ok, err := b.Receiver().(*Dict).Get(key); err != nil {
@@ -1257,7 +1257,7 @@ func dict_keys(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·pop
 func dict_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var k, d Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k, &d); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &k, &d); err != nil {
 		return nil, err
 	}
 	if v, found, err := b.Receiver().(*Dict).Delete(k); err != nil {
@@ -1290,7 +1290,7 @@ func dict_popitem(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·setdefault
 func dict_setdefault(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var key, dflt Value = nil, None
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
 	}
 	dict := b.Receiver().(*Dict)
@@ -1332,7 +1332,7 @@ func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·append
 func list_append(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var object Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &object); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &object); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*List)
@@ -1358,7 +1358,7 @@ func list_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 func list_extend(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
 	var iterable Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("extend"); err != nil {
@@ -1371,7 +1371,7 @@ func list_extend(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·index
 func list_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var value, start_, end_ Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &value, &start_, &end_); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &value, &start_, &end_); err != nil {
 		return nil, err
 	}
 
@@ -1396,7 +1396,7 @@ func list_insert(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	recv := b.Receiver().(*List)
 	var index int
 	var object Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 2, &index, &object); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 2, &index, &object); err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("insert into"); err != nil {
@@ -1425,7 +1425,7 @@ func list_insert(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 func list_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := b.Receiver().(*List)
 	var value Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &value); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &value); err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("remove from"); err != nil {
@@ -1448,7 +1448,7 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	list := recv.(*List)
 	n := list.Len()
 	i := n - 1
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &i); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &i); err != nil {
 		return nil, err
 	}
 	origI := i
@@ -1543,7 +1543,7 @@ func (*bytesIterator) Done() {}
 func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var sub string
 	var start_, end_ Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
 		return nil, err
 	}
 
@@ -1853,7 +1853,7 @@ func string_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var iterable Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -1885,7 +1885,7 @@ func string_lower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var sep string
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sep); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &sep); err != nil {
 		return nil, err
 	}
 	if sep == "" {
@@ -1915,7 +1915,7 @@ func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 func string_removefix(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(b.Receiver().(String))
 	var fix string
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &fix); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &fix); err != nil {
 		return nil, err
 	}
 	if b.name[len("remove")] == 'p' {
@@ -1931,7 +1931,7 @@ func string_replace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 	recv := string(b.Receiver().(String))
 	var old, new string
 	count := -1
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 2, &old, &new, &count); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 2, &old, &new, &count); err != nil {
 		return nil, err
 	}
 	return String(strings.Replace(recv, old, new, count)), nil
@@ -1952,7 +1952,7 @@ func string_rindex(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, er
 func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	var start, end Value = None, None
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x, &start, &end); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &x, &start, &end); err != nil {
 		return nil, err
 	}
 
@@ -1996,7 +1996,7 @@ func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rstrip
 func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var chars string
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &chars); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &chars); err != nil {
 		return nil, err
 	}
 	recv := string(b.Receiver().(String))
@@ -2064,7 +2064,7 @@ func string_split(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 	recv := string(b.Receiver().(String))
 	var sep_ Value
 	maxsplit := -1
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &sep_, &maxsplit); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &sep_, &maxsplit); err != nil {
 		return nil, err
 	}
 
@@ -2165,7 +2165,7 @@ func splitspace(s string, max int) []string {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·splitlines
 func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var keepends bool
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &keepends); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &keepends); err != nil {
 		return nil, err
 	}
 	var lines []string
@@ -2190,7 +2190,7 @@ func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·add.
 func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var elem Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &elem); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &elem); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)
@@ -2228,7 +2228,7 @@ func set_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 func set_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	// TODO: support multiple others: s.difference(*others)
 	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2244,7 +2244,7 @@ func set_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 func set_intersection(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	// TODO: support multiple others: s.difference(*others)
 	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2259,7 +2259,7 @@ func set_intersection(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_issubset.
 func set_issubset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2274,7 +2274,7 @@ func set_issubset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_issuperset.
 func set_issuperset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2289,7 +2289,7 @@ func set_issuperset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·discard.
 func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var k Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &k); err != nil {
 		return nil, err
 	}
 	recv := b.Receiver().(*Set)
@@ -2329,7 +2329,7 @@ func set_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·remove.
 func set_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var k Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &k); err != nil {
 		return nil, err
 	}
 	if found, err := b.Receiver().(*Set).Delete(k); err != nil {
@@ -2343,7 +2343,7 @@ func set_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·symmetric_difference.
 func set_symmetric_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var other Iterable
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
@@ -2376,7 +2376,7 @@ func set_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 func string_find_impl(b *Builtin, args Tuple, kwargs []Tuple, allowError, last bool) (Value, error) {
 	var sub string
 	var start_, end_ Value
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
+	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
 		return nil, err
 	}
 

--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -165,3 +165,8 @@ def bench_issubset_duplicate_same(b):
     l = list(range(200)) * 5
     for _ in range(b.n):
         s.issubset(l)
+
+def bench_string_startswith(b):
+    "Benchmark string.startswith"
+    for _ in range(b.n):
+        "hello".startswith("hell")

--- a/starlark/unpack.go
+++ b/starlark/unpack.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"reflect"
 	"strings"
+	"unsafe"
 
 	"go.starlark.net/internal/spell"
 )
@@ -190,10 +191,35 @@ kwloop:
 //
 // See UnpackArgs for general comments.
 func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, vars ...any) error {
+	if err := checkPositionalArgs(fnname, args, kwargs, min, len(vars)); err != nil {
+		return err
+	}
+	for i, arg := range args {
+		if err := UnpackArg(arg, vars[i]); err != nil {
+			return fmt.Errorf("%s: for parameter %d: %s", fnname, i+1, err)
+		}
+	}
+	return nil
+}
+
+// unpackPositionalArgsNoEscape is an optimized version of [UnpackPositionalArgs].
+// However, it panics if any vars[i] pointer value implements Unpacker.
+func unpackPositionalArgsNoEscape(fnname string, args Tuple, kwargs []Tuple, min int, vars ...any) error {
+	if err := checkPositionalArgs(fnname, args, kwargs, min, len(vars)); err != nil {
+		return err
+	}
+	for i, arg := range args {
+		if err := unpackArgNoEscape(arg, vars[i]); err != nil {
+			return fmt.Errorf("%s: for parameter %d: %s", fnname, i+1, err)
+		}
+	}
+	return nil
+}
+
+func checkPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min, max int) error {
 	if len(kwargs) > 0 {
 		return fmt.Errorf("%s: unexpected keyword arguments", fnname)
 	}
-	max := len(vars)
 	if len(args) < min {
 		var atleast string
 		if min < max {
@@ -208,11 +234,6 @@ func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, va
 		}
 		return fmt.Errorf("%s: got %d arguments, want %s%d", fnname, len(args), atmost, max)
 	}
-	for i, arg := range args {
-		if err := UnpackArg(arg, vars[i]); err != nil {
-			return fmt.Errorf("%s: for parameter %d: %s", fnname, i+1, err)
-		}
-	}
 	return nil
 }
 
@@ -224,10 +245,21 @@ func UnpackPositionalArgs(fnname string, args Tuple, kwargs []Tuple, min int, va
 // [UnpackPositionalArgs] to unpack a sequence of positional and/or
 // keyword arguments.
 func UnpackArg(v Value, ptr any) error {
+	if ptr, ok := ptr.(Unpacker); ok {
+		return ptr.Unpack(v) // (causes *ptr to escape)
+	}
+	return unpackArgNoEscape(v, ptr)
+}
+
+// unpackArgNoEscape is an optimized version of [UnpackArg].
+// However, it panics if ptr implements Unpacker.
+func unpackArgNoEscape(v Value, ptr any) error {
+	// Caution: do not let *ptr escape,
+	// e.g. via reflection or dynamic calls.
+	// There is a test of this invariant.
+
 	// On failure, don't clobber *ptr.
 	switch ptr := ptr.(type) {
-	case Unpacker:
-		return ptr.Unpack(v)
 	case *Value:
 		*ptr = v
 	case *string:
@@ -277,19 +309,22 @@ func UnpackArg(v Value, ptr any) error {
 		*ptr = it
 	default:
 		// v must have type *V, where V is some subtype of starlark.Value.
-		ptrv := reflect.ValueOf(ptr)
-		if ptrv.Kind() != reflect.Pointer {
-			log.Panicf("internal error: not a pointer: %T", ptr)
+		ptrt := reflect.TypeOf(ptr)
+		if _, ok := ptr.(Unpacker); ok {
+			log.Panicf("unpackArgNoEscape does not support %s (Unpacker); use UnpackArg instead", ptrt)
 		}
-		paramVar := ptrv.Elem()
-		if !reflect.TypeOf(v).AssignableTo(paramVar.Type()) {
+		if ptrt.Kind() != reflect.Pointer {
+			log.Panicf("internal error: not a pointer: %s", ptrt)
+		}
+		paramVarType := ptrt.Elem()
+		if !reflect.TypeOf(v).AssignableTo(paramVarType) {
 			// The value is not assignable to the variable.
 
 			// Detect a possible bug in the Go program that called Unpack:
 			// If the variable *ptr is not a subtype of Value,
 			// no value of v can possibly work.
-			if !paramVar.Type().AssignableTo(reflect.TypeFor[Value]()) {
-				log.Panicf("pointer element type does not implement Value: %T", ptr)
+			if !paramVarType.AssignableTo(reflect.TypeFor[Value]()) {
+				log.Panicf("pointer element type does not implement Value: %s", ptrt)
 			}
 
 			// Report Starlark dynamic type error.
@@ -304,18 +339,22 @@ func UnpackArg(v Value, ptr any) error {
 			// recover.
 
 			// Default to Go reflect.Type name
-			paramType := paramVar.Type().String()
+			paramType := paramVarType.String()
 
-			// Attempt to call Value.Type method.
+			// Attempt to call Value.Type method on the zero
+			// value of the variable.
 			func() {
 				defer func() { recover() }()
-				if typer, _ := paramVar.Interface().(interface{ Type() string }); typer != nil {
-					paramType = typer.Type()
+
+				if v, _ := reflect.Zero(paramVarType).Interface().(Value); v != nil {
+					paramType = v.Type()
 				}
 			}()
 			return fmt.Errorf("got %s, want %s", v.Type(), paramType)
 		}
-		paramVar.Set(reflect.ValueOf(v))
+
+		// assign *ptr = v
+		reflectSetElem(ptr, reflect.ValueOf(v))
 	}
 	return nil
 }
@@ -361,4 +400,35 @@ func (is *intset) len() int {
 		return len
 	}
 	return len(is.large)
+}
+
+// reflectSetElem is equivalent to reflect.ValueOf(ptr).Elem().Set(v)
+// but does not let *ptr escape.
+//
+// ptr must be a non-nil pointer to a variable to which v may be assigned.
+func reflectSetElem(ptr any, v reflect.Value) {
+	typ := reflect.TypeOf(ptr)
+	if typ.Kind() != reflect.Pointer {
+		panic("reflect: call of SetElem on non-pointer")
+	}
+	type eface struct{ typ, data unsafe.Pointer }
+	p := noescape((*eface)(unsafe.Pointer(&ptr)).data)
+	reflect.NewAt(typ.Elem(), p).Elem().Set(v)
+}
+
+// -- copied verbatim from abi.NoEscape --
+
+// noescape hides the pointer p from escape analysis, preventing it
+// from escaping to the heap. It compiles down to nothing.
+//
+// WARNING: This is very subtle to use correctly. The caller must
+// ensure that it's truly safe for p to not escape to the heap by
+// maintaining runtime pointer invariants (for example, that globals
+// and the heap may not generally point into a stack).
+//
+//go:nosplit
+//go:nocheckptr
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0)
 }


### PR DESCRIPTION
The Unpack functions, which receive a ptr any value containing a *T pointer, all escape the T variable to which they point. Fundamentally this is because the Unpacker case makes a dynamic method call on the *T value, so the compiler cannot prove that the callee doesn't let the variable escape.

This CL creates a parallel set of internal functions,
 unpackArgsNoEscape
 unpackPositionalArgsNoEscape
that do not support the Unpacker case and take great care not to let *ptr escape in all the other cases.
For example, Sprintf("%T", ptr) entails reflect.ValueOf(ptr), which defeats escape analysis, so we must avoid that. TestUnpackArgNoEscape asserts the invariant.

Nearly all unpack operations from the interpreter's built-in functions now use these no-escape variant functions. Unfortunately these functions are not ideal for broader exposure.

The added benchmark, which just calls string.startswith in a loop, runs 20% faster due to reduced allocation.

For #641