### PR TITLE
feat: fused CALL_ATTR opcode to avoid BindReceiver alloc

### DIFF
--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -72,6 +72,65 @@ func TestPlusFolding(t *testing.T) {
 	}
 }
 
+// TestCallAttrFusion ensures the compiler fuses x.method(pos...) into a
+// single CALL_ATTR, but falls back to ATTR+CALL for named, *args, or
+// **kwargs arguments, which CALL_ATTR does not support.
+func TestCallAttrFusion(t *testing.T) {
+	isPredeclared := func(name string) bool { return name == "x" || name == "a" || name == "b" }
+	isUniversal := func(name string) bool { return false }
+	for i, test := range []struct {
+		src  string // source expression
+		want string // disassembled code
+	}{
+		{
+			// no args: fused
+			`x.f()`,
+			`predeclared x; call_attr f/0; return`,
+		},
+		{
+			// positional args: fused
+			`x.f(a, b)`,
+			`predeclared x; predeclared a; predeclared b; call_attr f/2; return`,
+		},
+		{
+			// plain function call (not a method): not fused
+			`x(a)`,
+			`predeclared x; predeclared a; call<256>; return`,
+		},
+		{
+			// named argument: not fused (named pairs ride in CALL's operand)
+			`x.f(a, k=b)`,
+			`predeclared x; attr f; predeclared a; constant "k"; predeclared b; call<257>; return`,
+		},
+		{
+			// *args: not fused
+			`x.f(*a)`,
+			`predeclared x; attr f; predeclared a; call_var<0>; return`,
+		},
+		{
+			// **kwargs: not fused
+			`x.f(**a)`,
+			`predeclared x; attr f; predeclared a; call_kw <0>; return`,
+		},
+	} {
+		expr, err := syntax.ParseExpr("in.star", test.src, 0)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		locals, err := resolve.Expr(expr, isPredeclared, isUniversal)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		got := disassemble(Expr(syntax.LegacyFileOptions(), expr, "<expr>", locals).Toplevel)
+		if test.want != got {
+			t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
+				test.src, got, test.want)
+		}
+	}
+}
+
 // disassemble is a trivial disassembler tailored to the accumulator test.
 func disassemble(f *Funcode) string {
 	out := new(bytes.Buffer)
@@ -109,6 +168,10 @@ func disassemble(f *Funcode) string {
 				fmt.Fprintf(out, " %s", f.Locals[arg].Name)
 			case PREDECLARED:
 				fmt.Fprintf(out, " %s", f.Prog.Names[arg])
+			case ATTR:
+				fmt.Fprintf(out, " %s", f.Prog.Names[arg])
+			case CALL_ATTR:
+				fmt.Fprintf(out, " %s/%d", f.Prog.Names[arg>>8], arg&0xff)
 			default:
 				fmt.Fprintf(out, "<%d>", arg)
 			}

--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -72,9 +72,10 @@ func TestPlusFolding(t *testing.T) {
 	}
 }
 
-// TestCallAttrFusion ensures the compiler fuses x.method(pos...) into a
-// single CALL_ATTR, but falls back to ATTR+CALL for named, *args, or
-// **kwargs arguments, which CALL_ATTR does not support.
+// TestCallAttrFusion ensures the compiler compiles x.method(pos...) to
+// ATTR_METHOD+CALL_METHOD (resolving the method before the arguments, to
+// preserve evaluation order), but falls back to ATTR+CALL for named, *args,
+// or **kwargs arguments, which CALL_METHOD does not support.
 func TestCallAttrFusion(t *testing.T) {
 	isPredeclared := func(name string) bool { return name == "x" || name == "a" || name == "b" }
 	isUniversal := func(name string) bool { return false }
@@ -85,12 +86,12 @@ func TestCallAttrFusion(t *testing.T) {
 		{
 			// no args: fused
 			`x.f()`,
-			`predeclared x; call_attr f/0; return`,
+			`predeclared x; attr_method f; call_method<0>; return`,
 		},
 		{
-			// positional args: fused
+			// positional args: fused; method resolved before args
 			`x.f(a, b)`,
-			`predeclared x; predeclared a; predeclared b; call_attr f/2; return`,
+			`predeclared x; attr_method f; predeclared a; predeclared b; call_method<2>; return`,
 		},
 		{
 			// plain function call (not a method): not fused
@@ -168,10 +169,8 @@ func disassemble(f *Funcode) string {
 				fmt.Fprintf(out, " %s", f.Locals[arg].Name)
 			case PREDECLARED:
 				fmt.Fprintf(out, " %s", f.Prog.Names[arg])
-			case ATTR:
+			case ATTR, ATTR_METHOD:
 				fmt.Fprintf(out, " %s", f.Prog.Names[arg])
-			case CALL_ATTR:
-				fmt.Fprintf(out, " %s/%d", f.Prog.Names[arg>>8], arg&0xff)
 			default:
 				fmt.Fprintf(out, "<%d>", arg)
 			}

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1660,7 +1660,7 @@ func (fcomp *fcomp) call(call *syntax.CallExpr) {
 	// opt: fuse x.method(pos...) to avoid materializing a closure.
 	if dot, ok := call.Fn.(*syntax.DotExpr); ok {
 		// plain positional args only for CALL_ATTR
-		if npos, ok := plainPositional(call); ok && npos < 0x100 {
+		if npos := len(call.Args); npos < 0x100 && plainPositional(call) {
 			if name := fcomp.pcomp.nameIndex(dot.Name.Name); name < 1<<24 {
 				fcomp.expr(dot.X) // receiver
 				for _, arg := range call.Args {
@@ -1680,18 +1680,18 @@ func (fcomp *fcomp) call(call *syntax.CallExpr) {
 	fcomp.emit1(op, arg)
 }
 
-// plainPositional reports whether all of call's args are plain positional (no name=value, *args, **kwargs), and their count.
-func plainPositional(call *syntax.CallExpr) (int, bool) {
+// plainPositional reports whether all of call's args are plain positional (no name=value, *args, **kwargs).
+func plainPositional(call *syntax.CallExpr) bool {
 	for _, arg := range call.Args {
 		if binary, ok := arg.(*syntax.BinaryExpr); ok && binary.Op == syntax.EQ {
-			return 0, false // named argument
+			return false // named argument
 		}
 		if unary, ok := arg.(*syntax.UnaryExpr); ok &&
 			(unary.Op == syntax.STAR || unary.Op == syntax.STARSTAR) {
-			return 0, false // *args or **kwargs
+			return false // *args or **kwargs
 		}
 	}
-	return len(call.Args), true
+	return true
 }
 
 // args emits code to push a tuple of positional arguments

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -46,7 +46,7 @@ var Disassemble = false
 const debug = false // make code generation verbose, for debugging the compiler
 
 // Increment this to force recompilation of saved bytecode files.
-const Version = 15
+const Version = 16
 
 type Opcode uint8
 
@@ -146,11 +146,14 @@ const (
 	CALL_KW     // fn positional named       **kwargs CALL_KW<n>     result
 	CALL_VAR_KW // fn positional named *args **kwargs CALL_VAR_KW<n> result
 
-	// n>>8 is the method-name index and n&0xff is #positional args.
-	CALL_ATTR // recv positional CALL_ATTR<n> result   (fused x.method(pos...))
+	// ATTR_METHOD+CALL_METHOD implement x.method(pos...) without materializing
+	// a bound-method closure. ATTR_METHOD resolves the method at the receiver
+	// (preserving evaluation order); CALL_METHOD calls it once args are pushed.
+	ATTR_METHOD //           recv ATTR_METHOD<name> method     (method bound to recv)
+	CALL_METHOD // method positional CALL_METHOD<npos> result
 
 	OpcodeArgMin = JMP
-	OpcodeMax    = CALL_ATTR
+	OpcodeMax    = CALL_METHOD
 )
 
 // TODO(adonovan): add dynamic checks for missing opcodes in the tables below.
@@ -159,8 +162,9 @@ var opcodeNames = [...]string{
 	AMP:          "amp",
 	APPEND:       "append",
 	ATTR:         "attr",
+	ATTR_METHOD:  "attr_method",
 	CALL:         "call",
-	CALL_ATTR:    "call_attr",
+	CALL_METHOD:  "call_method",
 	CALL_KW:      "call_kw ",
 	CALL_VAR:     "call_var",
 	CALL_VAR_KW:  "call_var_kw",
@@ -235,8 +239,9 @@ var stackEffect = [...]int8{
 	AMP:          -1,
 	APPEND:       -2,
 	ATTR:         0,
+	ATTR_METHOD:  0,
 	CALL:         variableStackEffect,
-	CALL_ATTR:    variableStackEffect,
+	CALL_METHOD:  variableStackEffect,
 	CALL_KW:      variableStackEffect,
 	CALL_VAR:     variableStackEffect,
 	CALL_VAR_KW:  variableStackEffect,
@@ -719,8 +724,8 @@ func (insn *insn) stackeffect() int {
 			if insn.op == CALL_VAR_KW {
 				se--
 			}
-		case CALL_ATTR:
-			se = -int(insn.arg & 0xff) // pop receiver + npos args, push result
+		case CALL_METHOD:
+			se = -int(insn.arg) // pop method + npos args, push result
 		case ITERJMP:
 			// Stack effect differs by successor:
 			// +1 for jmp/false/ok
@@ -891,14 +896,14 @@ func PrintOp(fn *Funcode, pc uint32, op Opcode, arg uint32) {
 		comment = fn.Locals[arg].Name
 	case SETGLOBAL, GLOBAL:
 		comment = fn.Prog.Globals[arg].Name
-	case ATTR, SETFIELD, PREDECLARED, UNIVERSAL:
+	case ATTR, ATTR_METHOD, SETFIELD, PREDECLARED, UNIVERSAL:
 		comment = fn.Prog.Names[arg]
 	case FREE:
 		comment = fn.FreeVars[arg].Name
 	case CALL, CALL_VAR, CALL_KW, CALL_VAR_KW:
 		comment = fmt.Sprintf("%d pos, %d named", arg>>8, arg&0xff)
-	case CALL_ATTR:
-		comment = fmt.Sprintf("%s, %d pos", fn.Prog.Names[arg>>8], arg&0xff)
+	case CALL_METHOD:
+		comment = fmt.Sprintf("%d pos", arg)
 	default:
 		// JMP, CJMP, ITERJMP, MAKETUPLE, MAKELIST, LOAD, UNPACK:
 		// arg is just a number
@@ -1657,20 +1662,19 @@ func (fcomp *fcomp) binop(pos syntax.Position, op syntax.Token) {
 }
 
 func (fcomp *fcomp) call(call *syntax.CallExpr) {
-	// opt: fuse x.method(pos...) to avoid materializing a closure.
-	if dot, ok := call.Fn.(*syntax.DotExpr); ok {
-		// plain positional args only for CALL_ATTR
-		if npos := len(call.Args); npos < 0x100 && plainPositional(call) {
-			if name := fcomp.pcomp.nameIndex(dot.Name.Name); name < 1<<24 {
-				fcomp.expr(dot.X) // receiver
-				for _, arg := range call.Args {
-					fcomp.expr(arg)
-				}
-				fcomp.setPos(call.Lparen)
-				fcomp.emit1(CALL_ATTR, name<<8|uint32(npos))
-				return
-			}
+	// opt: compile x.method(pos...) to ATTR_METHOD+CALL_METHOD, avoiding a
+	// bound-method closure. ATTR_METHOD resolves the method at the receiver,
+	// so evaluation order (receiver, method, args) is preserved.
+	if dot, ok := call.Fn.(*syntax.DotExpr); ok && plainPositional(call) {
+		fcomp.expr(dot.X) // receiver
+		fcomp.setPos(dot.Dot)
+		fcomp.emit1(ATTR_METHOD, fcomp.pcomp.nameIndex(dot.Name.Name))
+		for _, arg := range call.Args {
+			fcomp.expr(arg)
 		}
+		fcomp.setPos(call.Lparen)
+		fcomp.emit1(CALL_METHOD, uint32(len(call.Args)))
+		return
 	}
 
 	// usual case

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -46,7 +46,7 @@ var Disassemble = false
 const debug = false // make code generation verbose, for debugging the compiler
 
 // Increment this to force recompilation of saved bytecode files.
-const Version = 14
+const Version = 15
 
 type Opcode uint8
 
@@ -146,8 +146,11 @@ const (
 	CALL_KW     // fn positional named       **kwargs CALL_KW<n>     result
 	CALL_VAR_KW // fn positional named *args **kwargs CALL_VAR_KW<n> result
 
+	// n>>8 is the method-name index and n&0xff is #positional args.
+	CALL_ATTR // recv positional CALL_ATTR<n> result   (fused x.method(pos...))
+
 	OpcodeArgMin = JMP
-	OpcodeMax    = CALL_VAR_KW
+	OpcodeMax    = CALL_ATTR
 )
 
 // TODO(adonovan): add dynamic checks for missing opcodes in the tables below.
@@ -157,6 +160,7 @@ var opcodeNames = [...]string{
 	APPEND:       "append",
 	ATTR:         "attr",
 	CALL:         "call",
+	CALL_ATTR:    "call_attr",
 	CALL_KW:      "call_kw ",
 	CALL_VAR:     "call_var",
 	CALL_VAR_KW:  "call_var_kw",
@@ -232,6 +236,7 @@ var stackEffect = [...]int8{
 	APPEND:       -2,
 	ATTR:         0,
 	CALL:         variableStackEffect,
+	CALL_ATTR:    variableStackEffect,
 	CALL_KW:      variableStackEffect,
 	CALL_VAR:     variableStackEffect,
 	CALL_VAR_KW:  variableStackEffect,
@@ -714,6 +719,8 @@ func (insn *insn) stackeffect() int {
 			if insn.op == CALL_VAR_KW {
 				se--
 			}
+		case CALL_ATTR:
+			se = -int(insn.arg & 0xff) // pop receiver + npos args, push result
 		case ITERJMP:
 			// Stack effect differs by successor:
 			// +1 for jmp/false/ok
@@ -890,6 +897,8 @@ func PrintOp(fn *Funcode, pc uint32, op Opcode, arg uint32) {
 		comment = fn.FreeVars[arg].Name
 	case CALL, CALL_VAR, CALL_KW, CALL_VAR_KW:
 		comment = fmt.Sprintf("%d pos, %d named", arg>>8, arg&0xff)
+	case CALL_ATTR:
+		comment = fmt.Sprintf("%s, %d pos", fn.Prog.Names[arg>>8], arg&0xff)
 	default:
 		// JMP, CJMP, ITERJMP, MAKETUPLE, MAKELIST, LOAD, UNPACK:
 		// arg is just a number
@@ -1648,20 +1657,41 @@ func (fcomp *fcomp) binop(pos syntax.Position, op syntax.Token) {
 }
 
 func (fcomp *fcomp) call(call *syntax.CallExpr) {
-	// TODO(adonovan): opt: Use optimized path for calling methods
-	// of built-ins: x.f(...) to avoid materializing a closure.
-	// if dot, ok := call.Fcomp.(*syntax.DotExpr); ok {
-	// 	fcomp.expr(dot.X)
-	// 	fcomp.args(call)
-	// 	fcomp.emit1(CALL_ATTR, fcomp.name(dot.Name.Name))
-	// 	return
-	// }
+	// opt: fuse x.method(pos...) to avoid materializing a closure.
+	if dot, ok := call.Fn.(*syntax.DotExpr); ok {
+		// plain positional args only for CALL_ATTR
+		if npos, ok := plainPositional(call); ok && npos < 0x100 {
+			if name := fcomp.pcomp.nameIndex(dot.Name.Name); name < 1<<24 {
+				fcomp.expr(dot.X) // receiver
+				for _, arg := range call.Args {
+					fcomp.expr(arg)
+				}
+				fcomp.setPos(call.Lparen)
+				fcomp.emit1(CALL_ATTR, name<<8|uint32(npos))
+				return
+			}
+		}
+	}
 
 	// usual case
 	fcomp.expr(call.Fn)
 	op, arg := fcomp.args(call)
 	fcomp.setPos(call.Lparen)
 	fcomp.emit1(op, arg)
+}
+
+// plainPositional reports whether all of call's args are plain positional (no name=value, *args, **kwargs), and their count.
+func plainPositional(call *syntax.CallExpr) (int, bool) {
+	for _, arg := range call.Args {
+		if binary, ok := arg.(*syntax.BinaryExpr); ok && binary.Op == syntax.EQ {
+			return 0, false // named argument
+		}
+		if unary, ok := arg.(*syntax.UnaryExpr); ok &&
+			(unary.Op == syntax.STAR || unary.Op == syntax.STARSTAR) {
+			return 0, false // *args or **kwargs
+		}
+	}
+	return len(call.Args), true
 }
 
 // args emits code to push a tuple of positional arguments

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -73,7 +73,7 @@ type Thread struct {
 }
 
 // acquireBoundBuiltin returns a *Builtin (pooled if possible) bound to fn and recv.
-// Pair with releaseBoundBuiltin; the *Builtin must not escape the call (as in CALL_ATTR).
+// Pair with releaseBoundBuiltin; the *Builtin must not escape the call (as in CALL_METHOD).
 func (thread *Thread) acquireBoundBuiltin(fn *Builtin, recv Value) *Builtin {
 	var b *Builtin
 	if n := len(thread.builtinPool); n > 0 {
@@ -83,11 +83,13 @@ func (thread *Thread) acquireBoundBuiltin(fn *Builtin, recv Value) *Builtin {
 		b = new(Builtin)
 	}
 	b.bind(fn, recv)
+	b.pooled = true
 	return b
 }
 
 func (thread *Thread) releaseBoundBuiltin(b *Builtin) {
 	b.unbind() // don't pin the receiver
+	b.pooled = false
 	thread.builtinPool = append(thread.builtinPool, b)
 }
 

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -67,6 +67,28 @@ type Thread struct {
 
 	// proftime holds the accumulated execution time since the last profile event.
 	proftime time.Duration
+
+	// builtinPool is a LIFO free list of *Builtin reused by CALL_ATTR to bind receivers without allocating.
+	builtinPool []*Builtin
+}
+
+// acquireBoundBuiltin returns a *Builtin (pooled if possible) bound to fn and recv.
+// Pair with releaseBoundBuiltin; the *Builtin must not escape the call (as in CALL_ATTR).
+func (thread *Thread) acquireBoundBuiltin(fn *Builtin, recv Value) *Builtin {
+	var b *Builtin
+	if n := len(thread.builtinPool); n > 0 {
+		b = thread.builtinPool[n-1]
+		thread.builtinPool = thread.builtinPool[:n-1]
+	} else {
+		b = new(Builtin)
+	}
+	b.bind(fn, recv)
+	return b
+}
+
+func (thread *Thread) releaseBoundBuiltin(b *Builtin) {
+	b.unbind() // don't pin the receiver
+	thread.builtinPool = append(thread.builtinPool, b)
 }
 
 // ExecutionSteps returns the current value of Steps.

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -384,6 +384,45 @@ loop:
 			}
 			stack[sp-1] = z
 
+		case compile.CALL_ATTR:
+			// fused x.method(pos...): receiver then npos args on top of stack
+			name := f.Prog.Names[arg>>8]
+			npos := int(arg & 0xff)
+			recv := stack[sp-npos-1]
+
+			// Copy args: the callee (a built-in) can't be trusted not to mutate them.
+			var positional Tuple
+			if npos > 0 {
+				positional = slices.Clone(stack[sp-npos : sp])
+			}
+
+			var z Value
+			var err2 error
+			if method := builtinMethod(recv, name); method != nil {
+				// Bind recv in a pooled *Builtin to avoid a BindReceiver alloc.
+				b := thread.acquireBoundBuiltin(method, recv)
+				thread.endProfSpan()
+				z, err2 = Call(thread, b, positional, nil)
+				thread.beginProfSpan()
+				thread.releaseBoundBuiltin(b)
+			} else {
+				// Not a built-in method: general attribute access then call.
+				var y Value
+				y, err2 = getAttr(recv, name)
+				if err2 == nil {
+					thread.endProfSpan()
+					z, err2 = Call(thread, y, positional, nil)
+					thread.beginProfSpan()
+				}
+			}
+
+			sp -= npos
+			if err2 != nil {
+				err = err2
+				break loop
+			}
+			stack[sp-1] = z
+
 		case compile.ITERPUSH:
 			x := stack[sp-1]
 			sp--

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -384,39 +384,43 @@ loop:
 			}
 			stack[sp-1] = z
 
-		case compile.CALL_ATTR:
-			// fused x.method(pos...): receiver then npos args on top of stack
-			name := f.Prog.Names[arg>>8]
-			npos := int(arg & 0xff)
-			recv := stack[sp-npos-1]
+		case compile.ATTR_METHOD:
+			// Resolve x.method at the receiver, before the arguments, so
+			// evaluation order matches the ordinary ATTR+CALL sequence.
+			recv := stack[sp-1]
+			name := f.Prog.Names[arg]
+			if method := builtinMethod(recv, name); method != nil {
+				// Bind recv in a pooled *Builtin to avoid a BindReceiver
+				// alloc; CALL_METHOD releases it after the call.
+				stack[sp-1] = thread.acquireBoundBuiltin(method, recv)
+			} else {
+				// Not a built-in method: ordinary attribute access.
+				y, err2 := getAttr(recv, name)
+				if err2 != nil {
+					err = err2
+					break loop
+				}
+				stack[sp-1] = y
+			}
+
+		case compile.CALL_METHOD:
+			// Call a method resolved by ATTR_METHOD: method then npos args.
+			npos := int(arg)
+			fn := stack[sp-npos-1]
 
 			// Copy args: the callee (a built-in) can't be trusted not to mutate them.
 			var positional Tuple
 			if npos > 0 {
 				positional = slices.Clone(stack[sp-npos : sp])
 			}
-
-			var z Value
-			var err2 error
-			if method := builtinMethod(recv, name); method != nil {
-				// Bind recv in a pooled *Builtin to avoid a BindReceiver alloc.
-				b := thread.acquireBoundBuiltin(method, recv)
-				thread.endProfSpan()
-				z, err2 = Call(thread, b, positional, nil)
-				thread.beginProfSpan()
-				thread.releaseBoundBuiltin(b)
-			} else {
-				// Not a built-in method: general attribute access then call.
-				var y Value
-				y, err2 = getAttr(recv, name)
-				if err2 == nil {
-					thread.endProfSpan()
-					z, err2 = Call(thread, y, positional, nil)
-					thread.beginProfSpan()
-				}
-			}
-
 			sp -= npos
+
+			thread.endProfSpan()
+			z, err2 := Call(thread, fn, positional, nil)
+			thread.beginProfSpan()
+			if b, ok := fn.(*Builtin); ok && b.pooled {
+				thread.releaseBoundBuiltin(b)
+			}
 			if err2 != nil {
 				err = err2
 				break loop

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -164,6 +164,27 @@ func builtinAttr(recv Value, name string, methods map[string]*Builtin) (Value, e
 	return b.BindReceiver(recv), nil
 }
 
+// builtinMethod returns recv's unbound method of the given name, or nil if none.
+// Unlike builtinAttr it does not allocate a bound-method closure.
+func builtinMethod(recv Value, name string) *Builtin {
+	var methods map[string]*Builtin
+	switch recv.(type) {
+	case String:
+		methods = stringMethods
+	case *Dict:
+		methods = dictMethods
+	case *List:
+		methods = listMethods
+	case *Set:
+		methods = setMethods
+	case Bytes:
+		methods = bytesMethods
+	default:
+		return nil
+	}
+	return methods[name]
+}
+
 func builtinAttrNames(methods map[string]*Builtin) []string {
 	names := make([]string, 0, len(methods))
 	for name := range methods {

--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -34,6 +34,15 @@ def bench_builtin_method(b):
         for _ in range1000:
             emptydict.get(None)
 
+def bench_method_mix(b):
+    "Benchmark of a simple mix of built-in method calls (string, list, dict)."
+    s = "hello.go"
+    for _ in range(b.n):
+        d = {}
+        for i in range1000:
+            if s.endswith(".go"):
+                d.setdefault("go", []).append(i)
+
 def bench_int(b):
     for _ in range(b.n):
         a = 0

--- a/starlark/testdata/misc.star
+++ b/starlark/testdata/misc.star
@@ -136,21 +136,29 @@ assert.fails(lambda: [] + [] + 1 + [], "unknown binary op: list \\+ int")
 
 
 ---
-# Method calls: the fused CALL_ATTR path must agree with the ATTR path
-# (retained method value) and with the *args/**kwargs fallback path.
+# Method calls: the ATTR_METHOD+CALL_METHOD path must agree with the ATTR
+# path (retained method value) and with the *args/**kwargs fallback path.
 load("assert.star", "assert")
 
 s = "hello"
-assert.eq(s.startswith("he"), True)         # fused CALL_ATTR
-assert.eq(s.startswith("he", 1), False)     # fused, multiple positional
+assert.eq(s.startswith("he"), True)         # method call
+assert.eq(s.startswith("he", 1), False)     # multiple positional
 bound = s.startswith                        # retained method value (ATTR path)
 assert.eq(bound("he"), True)
 assert.eq(s.startswith(*["he"]), True)      # *args: not fused
 assert.eq(s.startswith(*["he"], **{}), True)  # *args + **kwargs: not fused
-assert.eq({"k": 1}.get("k"), 1)             # dict method, fused
-assert.eq([1, 2, 3].index(2), 1)            # list method, fused
+assert.eq({"k": 1}.get("k"), 1)             # dict method
+assert.eq([1, 2, 3].index(2), 1)            # list method
 assert.eq("HELLO".lower().startswith("he"), True)  # chained: pool reuse
 assert.fails(lambda: s.nonexistent(), "no .nonexistent field or method")
+
+# Evaluation order: x.method is resolved *before* the arguments, matching the
+# ordinary ATTR+CALL sequence. A missing method must therefore be reported
+# even when evaluating an argument would itself fail or have side effects.
+# (A fused resolve-after-args opcode would instead report the argument error.)
+assert.fails(lambda: [].nonesuch(1 // 0), "no .nonesuch field or method")
+assert.fails(lambda: [].nonesuch(fail("arg evaluated")), "no .nonesuch field or method")
+assert.fails(lambda: "".nonesuch([][0]), "no .nonesuch field or method")
 
 ---
 load('assert.star', 'froze') ### `name froze not found .*did you mean freeze`

--- a/starlark/testdata/misc.star
+++ b/starlark/testdata/misc.star
@@ -136,4 +136,21 @@ assert.fails(lambda: [] + [] + 1 + [], "unknown binary op: list \\+ int")
 
 
 ---
+# Method calls: the fused CALL_ATTR path must agree with the ATTR path
+# (retained method value) and with the *args/**kwargs fallback path.
+load("assert.star", "assert")
+
+s = "hello"
+assert.eq(s.startswith("he"), True)         # fused CALL_ATTR
+assert.eq(s.startswith("he", 1), False)     # fused, multiple positional
+bound = s.startswith                        # retained method value (ATTR path)
+assert.eq(bound("he"), True)
+assert.eq(s.startswith(*["he"]), True)      # *args: not fused
+assert.eq(s.startswith(*["he"], **{}), True)  # *args + **kwargs: not fused
+assert.eq({"k": 1}.get("k"), 1)             # dict method, fused
+assert.eq([1, 2, 3].index(2), 1)            # list method, fused
+assert.eq("HELLO".lower().startswith("he"), True)  # chained: pool reuse
+assert.fails(lambda: s.nonexistent(), "no .nonexistent field or method")
+
+---
 load('assert.star', 'froze') ### `name froze not found .*did you mean freeze`

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -872,7 +872,23 @@ func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kw
 //
 //	"abc".index("a")
 func (b *Builtin) BindReceiver(recv Value) *Builtin {
-	return &Builtin{name: b.name, fn: b.fn, recv: recv}
+	bound := new(Builtin)
+	bound.bind(b, recv)
+	return bound
+}
+
+// bind sets b to method fn bound to recv.
+func (b *Builtin) bind(fn *Builtin, recv Value) {
+	b.name = fn.name
+	b.fn = fn.fn
+	b.recv = recv
+}
+
+// unbind clears b's binding so it retains no receiver or method.
+func (b *Builtin) unbind() {
+	b.name = ""
+	b.fn = nil
+	b.recv = nil
 }
 
 // A *Dict represents a Starlark dictionary.

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -827,9 +827,10 @@ func (fn *Function) FreeVar(i int) (Binding, Value) {
 
 // A Builtin is a function implemented in Go.
 type Builtin struct {
-	name string
-	fn   func(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)
-	recv Value // for bound methods (e.g. "".startswith)
+	name   string
+	fn     func(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)
+	recv   Value // for bound methods (e.g. "".startswith)
+	pooled bool  // from Thread.builtinPool; released by CALL_METHOD after the call
 }
 
 func (b *Builtin) Name() string { return b.name }


### PR DESCRIPTION
This fulfills a TOOD for creating a fast-path `Opcode` for simple method invocations, especially for builtin methods.

This removes all `(*Builtin).BindReceiver` invocations from my profiling of a large app:

```
┌───────────────────────────────────┬──────────────────┬───────────────────────┐
│ Metric (built-in method binding)  │   Before         │     After             │
├───────────────────────────────────┼──────────────────┼───────────────────────┤
│ (*Builtin).BindReceiver — bytes   │ 51.5 MB          │ 0 (gone from profile) │
├───────────────────────────────────┼──────────────────┼───────────────────────┤
│ (*Builtin).BindReceiver — objects │ 1,125,084 allocs │ 0                     │
└───────────────────────────────────┴──────────────────┴───────────────────────┘
```
