### PR TITLE
syntax: reject excessively nested bracketed expressions

### DIFF
--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -143,6 +143,24 @@ type parser struct {
 	in      *scanner
 	tok     Token
 	tokval  tokenValue
+	depth   int
+}
+
+// enter increments the depth and checks the recursion limit.
+// It should be paired with a deferred call to [parser.leave].
+//
+// Every cycle in the parser's static call graph must include at
+// least one function that uses enter+leave to break cycles.
+// TestParserCallGraphCycles statically verifies this property.
+func (p *parser) enter() {
+	p.depth++
+	if p.depth > 1000 {
+		p.in.errorf(p.in.pos, "excessive nesting")
+	}
+}
+
+func (p *parser) leave() {
+	p.depth--
 }
 
 // nextToken advances the scanner and returns the position of the
@@ -409,6 +427,9 @@ func (p *parser) parseLoadStmt() *LoadStmt {
 // suite is typically what follows a COLON (e.g. after DEF or FOR).
 // suite = simple_stmt | NEWLINE INDENT stmt+ OUTDENT
 func (p *parser) parseSuite() []Stmt {
+	p.enter()
+	defer p.leave()
+
 	if p.tok == NEWLINE {
 		p.nextToken() // consume NEWLINE
 		p.consume(INDENT)
@@ -541,6 +562,9 @@ func (p *parser) parseExprs(exprs []Expr, allowTrailingComma bool) []Expr {
 
 // parseTest parses a 'test', a single-component expression.
 func (p *parser) parseTest() Expr {
+	p.enter()
+	defer p.leave()
+
 	if p.tok == LAMBDA {
 		return p.parseLambda(true)
 	}
@@ -574,6 +598,9 @@ func (p *parser) parseTestNoCond() Expr {
 // parseLambda parses a lambda expression.
 // The allowCond flag allows the body to be an 'a if b else c' conditional.
 func (p *parser) parseLambda(allowCond bool) Expr {
+	p.enter()
+	defer p.leave()
+
 	lambda := p.nextToken()
 	var params []Expr
 	if p.tok != COLON {
@@ -596,6 +623,9 @@ func (p *parser) parseLambda(allowCond bool) Expr {
 }
 
 func (p *parser) parseTestPrec(prec int) Expr {
+	p.enter()
+	defer p.leave()
+
 	if prec >= len(preclevels) {
 		return p.parsePrimaryWithSuffix()
 	}
@@ -809,6 +839,9 @@ func (p *parser) parseArgs() []Expr {
 //	| '(' ...                    // tuple or parenthesized expression
 //	| ('-'|'+'|'~') primary_with_suffix
 func (p *parser) parsePrimary() Expr {
+	p.enter()
+	defer p.leave()
+
 	switch p.tok {
 	case IDENT:
 		return p.parseIdent()

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -8,10 +8,14 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"go/ast"
 	"go/build"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -463,6 +467,29 @@ func TestFilePortion(t *testing.T) {
 	}
 }
 
+func TestDepthLimit(t *testing.T) {
+	// Rather than exceed the stack during parsing, deeply nested
+	// expressions and statements are rejected by the recursion
+	// counters in the scanner and/or parser.
+	for _, src := range []string{
+		strings.Repeat("(", 1e7), // (rejected in scanner)
+		strings.Repeat("not ", 1e7) + "0",
+		strings.Repeat("-", 1e7) + "0",
+		strings.Repeat("0 if a else ", 1e7) + "0",
+		strings.Repeat("lambda: ", 1e7) + "0",
+	} {
+		t.Run("", func(t *testing.T) {
+			t.Logf("%.65s...", src)
+			_, err := syntax.Parse("limit.star", src, 0)
+			if err == nil {
+				t.Errorf("Parse succeeded unexpectedly")
+			} else if !strings.Contains(err.Error(), "excessive nesting") {
+				t.Errorf("got error %q, want excessive nesting error", err)
+			}
+		})
+	}
+}
+
 // dataFile is the same as starlarktest.DataFile.
 // We make a copy to avoid a dependency cycle.
 var dataFile = func(pkgdir, filename string) string {
@@ -484,4 +511,122 @@ func BenchmarkParse(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// TestParserCallGraphCycles extracts a static call graph from every
+// function in parse.go then reports any cyclic path starting from
+// ParseFile that does not pass through a function that uses the
+// enter/leave mechanism to break cycles.
+func TestParserCallGraphCycles(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "parse.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// function is a node in static call graph.
+	type function struct {
+		name          string
+		callees       map[*function]bool
+		cyclebreaking bool
+	}
+	functions := make(map[string]*function)
+	node := func(name string) *function {
+		fn, ok := functions[name]
+		if !ok {
+			fn = &function{
+				name:    name,
+				callees: make(map[*function]bool),
+			}
+			t.Logf("node %q", name)
+			functions[name] = fn
+		}
+		return fn
+	}
+	addEdge := func(caller, callee *function) {
+		pre := len(caller.callees)
+		caller.callees[callee] = true
+		if len(caller.callees) > pre {
+			t.Logf("edge %q -> %q", caller.name, callee.name)
+		}
+	}
+
+	// Extract the functions and the static calls between them.
+	var current *function // (nil if uninteresting)
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.FuncDecl:
+			// decl of function or parser method
+			current = nil
+			name := n.Name.Name
+			if n.Recv != nil && len(n.Recv.List) > 0 {
+				if star, ok := n.Recv.List[0].Type.(*ast.StarExpr); ok {
+					if id, ok := star.X.(*ast.Ident); ok && id.Name == "parser" {
+						current = node("parser." + name)
+					}
+				}
+			} else {
+				current = node(name)
+			}
+
+		case *ast.CallExpr:
+			if current != nil {
+				// call within function of interest
+				switch fun := n.Fun.(type) {
+				case *ast.SelectorExpr:
+					// method call
+					// Assume p.method() is a method of parser.
+					// Ignore all other methods.
+					if id, ok := fun.X.(*ast.Ident); ok && id.Name == "p" {
+						callee := node("parser." + fun.Sel.Name)
+
+						// A call to p.enter indicates a cycle-breaking function.
+						if callee.name == "parser.enter" {
+							current.cyclebreaking = true
+						}
+
+						addEdge(current, callee)
+					}
+
+				case *ast.Ident:
+					// function call
+					// (incl. junk like: int, len, append, panic)
+					addEdge(current, node(fun.Name))
+				}
+			}
+		}
+		return true
+	})
+
+	// Check that no node belongs to an unbroken cycle.
+	// by doing a DFS rooted at each node in turn.
+	// (We cannot check once for the whole graph as a
+	// cycle may be reached through a cycle-breaking
+	// node, but that is not sufficient.)
+	for _, f := range functions {
+		color := make(map[*function]int) // 0=new, 1=on stack, 2=done
+		var stack []*function
+		var visit func(*function)
+		visit = func(f *function) {
+			switch color[f] {
+			case 0:
+				color[f] = 1
+				if !f.cyclebreaking {
+					stack = append(stack, f) // push
+					for callee := range f.callees {
+						visit(callee)
+					}
+					stack = stack[:len(stack)-1] // pop
+				}
+				color[f] = 2
+			case 1:
+				t.Errorf("cycle: %v", f.name)
+				for _, caller := range slices.Backward(stack) {
+					t.Logf("- %v", caller.name)
+				}
+			}
+		}
+		visit(f)
+	}
+
 }

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -712,6 +712,9 @@ start:
 	switch c {
 	case '[', '(', '{':
 		sc.depth++
+		if sc.depth > 1000 {
+			sc.errorf(sc.pos, "excessive nesting")
+		}
 		sc.readRune()
 		sc.endToken(val)
 		switch c {


### PR DESCRIPTION
Both the scanner and the parser contain recursions driven by user input, so an excessively nested input string can cause them to exceed the stack and crash the program.

This change rejects such inputs in both the scanner and parser, using the existing depth counter in the scanner and a new counter in the parser.

The interpreter already imposes a limit.

The tests include a static check that the call graph within the parser has no cycles except those including at least one use of p.enter/p.leave.

This commit addresses GHSA-wcqm-92f8-mh2v, which concerns a denial-of-service vulnerability since attacker-controlled inputss may cause a Starlark-based application to crash.