### PR TITLE
starlark: optimized dispatch of built-in methods

### DIFF
--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -72,6 +72,65 @@ func TestPlusFolding(t *testing.T) {
 	}
 }
 
+// TestCallAttrFusion ensures the compiler compiles x.method(...) to
+// ATTR_METHOD+CALL with the HasRecv bit set (resolving the method before
+// the arguments, to preserve evaluation order) across all call forms.
+func TestCallAttrFusion(t *testing.T) {
+	isPredeclared := func(name string) bool { return name == "x" || name == "a" || name == "b" }
+	isUniversal := func(name string) bool { return false }
+	for i, test := range []struct {
+		src  string // source expression
+		want string // disassembled code
+	}{
+		{
+			// no args: fused
+			`x.f()`,
+			`predeclared x; attr_method f; call<method 0>; return`,
+		},
+		{
+			// positional args: fused; method resolved before args
+			`x.f(a, b)`,
+			`predeclared x; attr_method f; predeclared a; predeclared b; call<method 512>; return`,
+		},
+		{
+			// plain function call (not a method): not fused
+			`x(a)`,
+			`predeclared x; predeclared a; call<256>; return`,
+		},
+		{
+			// named argument: fused
+			`x.f(a, k=b)`,
+			`predeclared x; attr_method f; predeclared a; constant "k"; predeclared b; call<method 257>; return`,
+		},
+		{
+			// *args: fused
+			`x.f(*a)`,
+			`predeclared x; attr_method f; predeclared a; call_var<method 0>; return`,
+		},
+		{
+			// **kwargs: fused
+			`x.f(**a)`,
+			`predeclared x; attr_method f; predeclared a; call_kw <method 0>; return`,
+		},
+	} {
+		expr, err := syntax.ParseExpr("in.star", test.src, 0)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		locals, err := resolve.Expr(expr, isPredeclared, isUniversal)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		got := disassemble(Expr(syntax.LegacyFileOptions(), expr, "<expr>", locals).Toplevel)
+		if test.want != got {
+			t.Errorf("expression <<%s>> generated <<%s>>, want <<%s>>",
+				test.src, got, test.want)
+		}
+	}
+}
+
 // disassemble is a trivial disassembler tailored to the accumulator test.
 func disassemble(f *Funcode) string {
 	out := new(bytes.Buffer)
@@ -109,6 +168,14 @@ func disassemble(f *Funcode) string {
 				fmt.Fprintf(out, " %s", f.Locals[arg].Name)
 			case PREDECLARED:
 				fmt.Fprintf(out, " %s", f.Prog.Names[arg])
+			case ATTR, ATTR_METHOD:
+				fmt.Fprintf(out, " %s", f.Prog.Names[arg])
+			case CALL, CALL_VAR, CALL_KW, CALL_VAR_KW:
+				if arg&HasRecv != 0 {
+					fmt.Fprintf(out, "<method %d>", arg&^HasRecv)
+				} else {
+					fmt.Fprintf(out, "<%d>", arg)
+				}
 			default:
 				fmt.Fprintf(out, "<%d>", arg)
 			}

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -46,7 +46,7 @@ var Disassemble = false
 const debug = false // make code generation verbose, for debugging the compiler
 
 // Increment this to force recompilation of saved bytecode files.
-const Version = 14
+const Version = 15
 
 type Opcode uint8
 
@@ -141,14 +141,26 @@ const (
 	UNPACK       //          iterable UNPACK<n>           vn ... v1
 
 	// n>>8 is #positional args and n&0xff is #named args (pairs).
+	// If HasRecv is set in n, the function call is a method call
+	// resolved by ATTR_METHOD, and pops recv (stack[sp-2]) and fn (stack[sp-1])
+	// instead of just fn (stack[sp-1]).
 	CALL        // fn positional named                CALL<n>        result
 	CALL_VAR    // fn positional named *args          CALL_VAR<n>    result
 	CALL_KW     // fn positional named       **kwargs CALL_KW<n>     result
 	CALL_VAR_KW // fn positional named *args **kwargs CALL_VAR_KW<n> result
 
+	// ATTR_METHOD resolves the method at the receiver without materializing
+	// a bound-method closure (preserving evaluation order); a CALL instruction
+	// with the HasRecv bit set calls it once args are pushed.
+	ATTR_METHOD //           recv ATTR_METHOD<name> recv method   (method bound to recv)
+
 	OpcodeArgMin = JMP
-	OpcodeMax    = CALL_VAR_KW
+	OpcodeMax    = ATTR_METHOD
 )
+
+// HasRecv is set in CALL instruction operands when the callee is a method
+// resolved by ATTR_METHOD.
+const HasRecv = 1 << 31
 
 // TODO(adonovan): add dynamic checks for missing opcodes in the tables below.
 
@@ -156,6 +168,7 @@ var opcodeNames = [...]string{
 	AMP:          "amp",
 	APPEND:       "append",
 	ATTR:         "attr",
+	ATTR_METHOD:  "attr_method",
 	CALL:         "call",
 	CALL_KW:      "call_kw ",
 	CALL_VAR:     "call_var",
@@ -231,6 +244,7 @@ var stackEffect = [...]int8{
 	AMP:          -1,
 	APPEND:       -2,
 	ATTR:         0,
+	ATTR_METHOD:  +1,
 	CALL:         variableStackEffect,
 	CALL_KW:      variableStackEffect,
 	CALL_VAR:     variableStackEffect,
@@ -707,11 +721,14 @@ func (insn *insn) stackeffect() int {
 		arg := int(insn.arg)
 		switch insn.op {
 		case CALL, CALL_KW, CALL_VAR, CALL_VAR_KW:
-			se = -int(2*(insn.arg&0xff) + insn.arg>>8)
+			se = -int(2*(insn.arg&0xff) + (insn.arg&^HasRecv)>>8)
 			if insn.op != CALL {
 				se--
 			}
 			if insn.op == CALL_VAR_KW {
+				se--
+			}
+			if insn.arg&HasRecv != 0 {
 				se--
 			}
 		case ITERJMP:
@@ -884,12 +901,15 @@ func PrintOp(fn *Funcode, pc uint32, op Opcode, arg uint32) {
 		comment = fn.Locals[arg].Name
 	case SETGLOBAL, GLOBAL:
 		comment = fn.Prog.Globals[arg].Name
-	case ATTR, SETFIELD, PREDECLARED, UNIVERSAL:
+	case ATTR, ATTR_METHOD, SETFIELD, PREDECLARED, UNIVERSAL:
 		comment = fn.Prog.Names[arg]
 	case FREE:
 		comment = fn.FreeVars[arg].Name
 	case CALL, CALL_VAR, CALL_KW, CALL_VAR_KW:
-		comment = fmt.Sprintf("%d pos, %d named", arg>>8, arg&0xff)
+		comment = fmt.Sprintf("%d pos, %d named", (arg&^HasRecv)>>8, arg&0xff)
+		if arg&HasRecv != 0 {
+			comment = "method, " + comment
+		}
 	default:
 		// JMP, CJMP, ITERJMP, MAKETUPLE, MAKELIST, LOAD, UNPACK:
 		// arg is just a number
@@ -1648,14 +1668,18 @@ func (fcomp *fcomp) binop(pos syntax.Position, op syntax.Token) {
 }
 
 func (fcomp *fcomp) call(call *syntax.CallExpr) {
-	// TODO(adonovan): opt: Use optimized path for calling methods
-	// of built-ins: x.f(...) to avoid materializing a closure.
-	// if dot, ok := call.Fcomp.(*syntax.DotExpr); ok {
-	// 	fcomp.expr(dot.X)
-	// 	fcomp.args(call)
-	// 	fcomp.emit1(CALL_ATTR, fcomp.name(dot.Name.Name))
-	// 	return
-	// }
+	// opt: compile x.method(...) to ATTR_METHOD+CALL, avoiding a
+	// bound-method closure. ATTR_METHOD resolves the method at the receiver,
+	// so evaluation order (receiver, method, args) is preserved.
+	if dot, ok := call.Fn.(*syntax.DotExpr); ok {
+		fcomp.expr(dot.X) // receiver
+		fcomp.setPos(dot.Dot)
+		fcomp.emit1(ATTR_METHOD, fcomp.pcomp.nameIndex(dot.Name.Name))
+		op, arg := fcomp.args(call)
+		fcomp.setPos(call.Lparen)
+		fcomp.emit1(op, arg|HasRecv)
+		return
+	}
 
 	// usual case
 	fcomp.expr(call.Fn)

--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -82,16 +82,16 @@ import (
 var Module = &starlarkstruct.Module{
 	Name: "json",
 	Members: starlark.StringDict{
-		"encode":        starlark.NewBuiltin("json.encode", encode),
-		"encode_indent": starlark.NewBuiltin("json.encode_indent", encodeIndent),
-		"decode":        starlark.NewBuiltin("json.decode", decode),
-		"indent":        starlark.NewBuiltin("json.indent", indent),
+		"encode":        starlark.NewBuiltinMethod("json.encode", encode),
+		"encode_indent": starlark.NewBuiltinMethod("json.encode_indent", encodeIndent),
+		"decode":        starlark.NewBuiltinMethod("json.decode", decode),
+		"indent":        starlark.NewBuiltinMethod("json.indent", indent),
 	},
 }
 
-func encode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func encode(thread *starlark.Thread, fnname string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var x starlark.Value
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &x); err != nil {
+	if err := starlark.UnpackPositionalArgs(fnname, args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
 
@@ -235,14 +235,14 @@ func encode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 	}
 
 	if err := emit(x); err != nil {
-		return nil, fmt.Errorf("%s: %v", b.Name(), err)
+		return nil, fmt.Errorf("%s: %v", fnname, err)
 	}
 	return starlark.String(buf.String()), nil
 }
 
-func encodeIndent(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func encodeIndent(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	prefix, indent := "", "\t" // keyword-only
-	if err := starlark.UnpackArgs(b.Name(), nil, kwargs,
+	if err := starlark.UnpackArgs(name, nil, kwargs,
 		"prefix?", &prefix,
 		"indent?", &indent,
 	); err != nil {
@@ -250,13 +250,13 @@ func encodeIndent(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tu
 	}
 	// Rely on encode() to parse the positional parameter (since the signature matches); use our b so
 	// error messages are attributed to json.encode_indent.
-	str, err := encode(thread, b, args, nil)
+	str, err := encode(thread, name, nil, args, nil)
 	if err != nil {
 		return nil, err
 	}
 	var buf bytes.Buffer
 	if err := json.Indent(&buf, []byte(str.(starlark.String)), prefix, indent); err != nil {
-		return nil, fmt.Errorf("%s: %v", b.Name(), err)
+		return nil, fmt.Errorf("%s: %v", name, err)
 	}
 	return starlark.String(buf.String()), nil
 }
@@ -293,36 +293,36 @@ func isFinite(f float64) bool {
 	return math.Abs(f) <= math.MaxFloat64
 }
 
-func indent(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func indent(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	prefix, indent := "", "\t" // keyword-only
-	if err := starlark.UnpackArgs(b.Name(), nil, kwargs,
+	if err := starlark.UnpackArgs(name, nil, kwargs,
 		"prefix?", &prefix,
 		"indent?", &indent,
 	); err != nil {
 		return nil, err
 	}
 	var str string // positional-only
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, nil, 1, &str); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, nil, 1, &str); err != nil {
 		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	if err := json.Indent(buf, []byte(str), prefix, indent); err != nil {
-		return nil, fmt.Errorf("%s: %v", b.Name(), err)
+		return nil, fmt.Errorf("%s: %v", name, err)
 	}
 	return starlark.String(buf.String()), nil
 }
 
-func decode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+func decode(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
 	var s string
 	var d starlark.Value
-	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "x", &s, "default?", &d); err != nil {
+	if err := starlark.UnpackArgs(name, args, kwargs, "x", &s, "default?", &d); err != nil {
 		return nil, err
 	}
 	if len(args) < 1 {
 		// "x" parameter is positional only; UnpackArgs does not allow us to
 		// directly express "def decode(x, *, default)"
-		return nil, fmt.Errorf("%s: unexpected keyword argument x", b.Name())
+		return nil, fmt.Errorf("%s: unexpected keyword argument x", name)
 	}
 
 	// The decoder necessarily makes certain representation choices

--- a/lib/math/math.go
+++ b/lib/math/math.go
@@ -66,10 +66,10 @@ import (
 var Module = &starlarkstruct.Module{
 	Name: "math",
 	Members: starlark.StringDict{
-		"ceil":      starlark.NewBuiltin("ceil", ceil),
+		"ceil":      starlark.NewBuiltinMethod("ceil", ceil),
 		"copysign":  newBinaryBuiltin("copysign", math.Copysign),
 		"fabs":      newUnaryBuiltin("fabs", math.Abs),
-		"floor":     starlark.NewBuiltin("floor", floor),
+		"floor":     starlark.NewBuiltinMethod("floor", floor),
 		"mod":       newBinaryBuiltin("mod", math.Mod),
 		"pow":       newBinaryBuiltin("pow", math.Pow),
 		"remainder": newBinaryBuiltin("remainder", math.Remainder),
@@ -97,7 +97,7 @@ var Module = &starlarkstruct.Module{
 		"sinh":  newUnaryBuiltin("sinh", math.Sinh),
 		"tanh":  newUnaryBuiltin("tanh", math.Tanh),
 
-		"log": starlark.NewBuiltin("log", log),
+		"log": starlark.NewBuiltinMethod("log", log),
 
 		"gamma": newUnaryBuiltin("gamma", math.Gamma),
 
@@ -124,7 +124,7 @@ func (p *floatOrInt) Unpack(v starlark.Value) error {
 // newUnaryBuiltin wraps a unary floating-point Go function
 // as a Starlark built-in that accepts int or float arguments.
 func newUnaryBuiltin(name string, fn func(float64) float64) *starlark.Builtin {
-	return starlark.NewBuiltin(name, func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.NewBuiltinMethod(name, func(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var x floatOrInt
 		if err := starlark.UnpackPositionalArgs(name, args, kwargs, 1, &x); err != nil {
 			return nil, err
@@ -136,7 +136,7 @@ func newUnaryBuiltin(name string, fn func(float64) float64) *starlark.Builtin {
 // newBinaryBuiltin wraps a binary floating-point Go function
 // as a Starlark built-in that accepts int or float arguments.
 func newBinaryBuiltin(name string, fn func(float64, float64) float64) *starlark.Builtin {
-	return starlark.NewBuiltin(name, func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.NewBuiltinMethod(name, func(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var x, y floatOrInt
 		if err := starlark.UnpackPositionalArgs(name, args, kwargs, 2, &x, &y); err != nil {
 			return nil, err
@@ -148,7 +148,7 @@ func newBinaryBuiltin(name string, fn func(float64, float64) float64) *starlark.
 //	log wraps the Log function
 //
 // as a Starlark built-in that accepts int or float arguments.
-func log(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func log(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		x    floatOrInt
 		base floatOrInt = math.E
@@ -162,7 +162,7 @@ func log(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwar
 	return starlark.Float(math.Log(float64(x)) / math.Log(float64(base))), nil
 }
 
-func ceil(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func ceil(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var x starlark.Value
 
 	if err := starlark.UnpackPositionalArgs("ceil", args, kwargs, 1, &x); err != nil {
@@ -179,7 +179,7 @@ func ceil(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwa
 	return nil, fmt.Errorf("got %s, want float or int", x.Type())
 }
 
-func floor(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func floor(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var x starlark.Value
 
 	if err := starlark.UnpackPositionalArgs("floor", args, kwargs, 1, &x); err != nil {

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -146,14 +146,14 @@ type DescriptorPool interface {
 var Module = &starlarkstruct.Module{
 	Name: "proto",
 	Members: starlark.StringDict{
-		"file":           starlark.NewBuiltin("proto.file", file),
-		"has":            starlark.NewBuiltin("proto.has", has),
-		"marshal":        starlark.NewBuiltin("proto.marshal", marshal),
-		"marshal_text":   starlark.NewBuiltin("proto.marshal_text", marshal),
-		"set_field":      starlark.NewBuiltin("proto.set_field", setFieldStarlark),
-		"get_field":      starlark.NewBuiltin("proto.get_field", getFieldStarlark),
-		"unmarshal":      starlark.NewBuiltin("proto.unmarshal", unmarshal),
-		"unmarshal_text": starlark.NewBuiltin("proto.unmarshal_text", unmarshal_text),
+		"file":           starlark.NewBuiltinMethod("proto.file", file),
+		"has":            starlark.NewBuiltinMethod("proto.has", has),
+		"marshal":        starlark.NewBuiltinMethod("proto.marshal", marshal),
+		"marshal_text":   starlark.NewBuiltinMethod("proto.marshal_text", marshal),
+		"set_field":      starlark.NewBuiltinMethod("proto.set_field", setFieldStarlark),
+		"get_field":      starlark.NewBuiltinMethod("proto.get_field", getFieldStarlark),
+		"unmarshal":      starlark.NewBuiltinMethod("proto.unmarshal", unmarshal),
+		"unmarshal_text": starlark.NewBuiltinMethod("proto.unmarshal_text", unmarshal_text),
 
 		// TODO(adonovan):
 		// - merge(msg, msg) -> msg
@@ -172,9 +172,9 @@ var Module = &starlarkstruct.Module{
 // for the same package name, and there is no "package descriptor".
 // (Technically a pool may also have many FileDescriptors with the same
 // file name, but this can't happen with a single consistent snapshot.)
-func file(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func file(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var filename string
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &filename); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 1, &filename); err != nil {
 		return nil, err
 	}
 
@@ -194,14 +194,14 @@ func file(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 // has(msg, field) reports whether the specified field of the message is present.
 // A field may be specified by name (string) or FieldDescriptor.
 // has reports an error if the message type has no such field.
-func has(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func has(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var x, field starlark.Value
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 2, &x, &field); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 2, &x, &field); err != nil {
 		return nil, err
 	}
 	msg, ok := x.(*Message)
 	if !ok {
-		return nil, fmt.Errorf("%s: got %s, want proto.Message", fn.Name(), x.Type())
+		return nil, fmt.Errorf("%s: got %s, want proto.Message", name, x.Type())
 	}
 
 	var fdesc protoreflect.FieldDescriptor
@@ -215,7 +215,7 @@ func has(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwa
 
 	case FieldDescriptor:
 		if field.Desc.ContainingMessage() != msg.desc() {
-			return nil, fmt.Errorf("%s: %v does not have field %v", fn.Name(), msg.desc().FullName(), field)
+			return nil, fmt.Errorf("%s: %v does not have field %v", name, msg.desc().FullName(), field)
 		}
 		fdesc = field.Desc
 		if fdesc.IsExtension() {
@@ -231,48 +231,48 @@ func has(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwa
 		}
 
 	default:
-		return nil, fmt.Errorf("%s: for field argument, got %s, want string or proto.FieldDescriptor", fn.Name(), field.Type())
+		return nil, fmt.Errorf("%s: for field argument, got %s, want string or proto.FieldDescriptor", name, field.Type())
 	}
 
 	return starlark.Bool(msg.msg.Has(fdesc)), nil
 }
 
 // marshal{,_text}(msg) encodes a Message value to binary or text form.
-func marshal(_ *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func marshal(_ *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var m *Message
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &m); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 1, &m); err != nil {
 		return nil, err
 	}
-	if fn.Name() == "proto.marshal" {
+	if name == "proto.marshal" {
 		data, err := proto.Marshal(m.Message())
 		if err != nil {
-			return nil, fmt.Errorf("%s: %v", fn.Name(), err)
+			return nil, fmt.Errorf("%s: %v", name, err)
 		}
 		return starlark.Bytes(data), nil
 	} else {
 		text, err := prototext.MarshalOptions{Indent: "  "}.Marshal(m.Message())
 		if err != nil {
-			return nil, fmt.Errorf("%s: %v", fn.Name(), err)
+			return nil, fmt.Errorf("%s: %v", name, err)
 		}
 		return starlark.String(text), nil
 	}
 }
 
 // unmarshal(msg) decodes a binary protocol message to a Message.
-func unmarshal(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func unmarshal(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var desc MessageDescriptor
 	var data starlark.Bytes
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 2, &desc, &data); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 2, &desc, &data); err != nil {
 		return nil, err
 	}
 	return unmarshalData(desc.Desc, []byte(data), true)
 }
 
 // unmarshal_text(msg) decodes a text protocol message to a Message.
-func unmarshal_text(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func unmarshal_text(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var desc MessageDescriptor
 	var data string
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 2, &desc, &data); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 2, &desc, &data); err != nil {
 		return nil, err
 	}
 	return unmarshalData(desc.Desc, []byte(data), false)
@@ -280,21 +280,21 @@ func unmarshal_text(thread *starlark.Thread, fn *starlark.Builtin, args starlark
 
 // set_field(msg, field, value) updates the value of a field.
 // It is typically used for extensions, which cannot be updated using msg.field = v notation.
-func setFieldStarlark(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func setFieldStarlark(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	// TODO(adonovan): allow field to be specified by name (for non-extension fields), like has?
 	var m *Message
 	var field FieldDescriptor
 	var v starlark.Value
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 3, &m, &field, &v); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 3, &m, &field, &v); err != nil {
 		return nil, err
 	}
 
 	if *m.frozen {
-		return nil, fmt.Errorf("%s: cannot set %v field of frozen %v message", fn.Name(), field, m.desc().FullName())
+		return nil, fmt.Errorf("%s: cannot set %v field of frozen %v message", name, field, m.desc().FullName())
 	}
 
 	if field.Desc.ContainingMessage() != m.desc() {
-		return nil, fmt.Errorf("%s: %v does not have field %v", fn.Name(), m.desc().FullName(), field)
+		return nil, fmt.Errorf("%s: %v does not have field %v", name, m.desc().FullName(), field)
 	}
 
 	return starlark.None, setField(m.msg, field.Desc, v)
@@ -302,16 +302,16 @@ func setFieldStarlark(thread *starlark.Thread, fn *starlark.Builtin, args starla
 
 // get_field(msg, field) retrieves the value of a field.
 // It is typically used for extension fields, which cannot be accessed using msg.field notation.
-func getFieldStarlark(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func getFieldStarlark(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	// TODO(adonovan): allow field to be specified by name (for non-extension fields), like has?
 	var msg *Message
 	var field FieldDescriptor
-	if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 2, &msg, &field); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 2, &msg, &field); err != nil {
 		return nil, err
 	}
 
 	if field.Desc.ContainingMessage() != msg.desc() {
-		return nil, fmt.Errorf("%s: %v does not have field %v", fn.Name(), msg.desc().FullName(), field)
+		return nil, fmt.Errorf("%s: %v does not have field %v", name, msg.desc().FullName(), field)
 	}
 
 	return msg.getField(field.Desc), nil
@@ -941,28 +941,36 @@ type RepeatedField struct {
 var (
 	_ starlark.Iterable    = (*RepeatedField)(nil)
 	_ starlark.HasSetIndex = (*RepeatedField)(nil)
-	_ starlark.HasAttrs    = (*RepeatedField)(nil)
+	_ starlark.HasAttrs          = (*RepeatedField)(nil)
+	_ starlark.HasBuiltinMethods = (*RepeatedField)(nil)
 )
+
+var repeatedFieldAppendMethod = starlark.NewBuiltinMethod("append", repeatedFieldAppend)
 
 func (rf *RepeatedField) AttrNames() []string {
 	return []string{"append"}
 }
 
-func (rf *RepeatedField) Attr(name string) (starlark.Value, error) {
-	switch name {
-	case "append":
-		return starlark.NewBuiltin("append", repeatedFieldAppend).BindReceiver(rf), nil
-	default:
-		return nil, nil
+func (rf *RepeatedField) BuiltinMethod(name string) *starlark.Builtin {
+	if name == "append" {
+		return repeatedFieldAppendMethod
 	}
+	return nil
 }
 
-func repeatedFieldAppend(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (rf *RepeatedField) Attr(name string) (starlark.Value, error) {
+	if b := rf.BuiltinMethod(name); b != nil {
+		return b.BindReceiver(rf), nil
+	}
+	return nil, nil
+}
+
+func repeatedFieldAppend(_ *starlark.Thread, name string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var object starlark.Value
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &object); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 1, &object); err != nil {
 		return nil, err
 	}
-	rf := b.Receiver().(*RepeatedField)
+	rf := recv.(*RepeatedField)
 
 	if err := rf.checkMutable("append to"); err != nil {
 		return nil, err

--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -53,12 +53,12 @@ import (
 var Module = &starlarkstruct.Module{
 	Name: "time",
 	Members: starlark.StringDict{
-		"from_timestamp":    starlark.NewBuiltin("from_timestamp", fromTimestamp),
-		"is_valid_timezone": starlark.NewBuiltin("is_valid_timezone", isValidTimezone),
-		"now":               starlark.NewBuiltin("now", now),
-		"parse_duration":    starlark.NewBuiltin("parse_duration", parseDuration),
-		"parse_time":        starlark.NewBuiltin("parse_time", parseTime),
-		"time":              starlark.NewBuiltin("time", newTime),
+		"from_timestamp":    starlark.NewBuiltinMethod("from_timestamp", fromTimestamp),
+		"is_valid_timezone": starlark.NewBuiltinMethod("is_valid_timezone", isValidTimezone),
+		"now":               starlark.NewBuiltinMethod("now", now),
+		"parse_duration":    starlark.NewBuiltinMethod("parse_duration", parseDuration),
+		"parse_time":        starlark.NewBuiltinMethod("parse_time", parseTime),
+		"time":              starlark.NewBuiltinMethod("time", newTime),
 
 		"nanosecond":  Duration(time.Nanosecond),
 		"microsecond": Duration(time.Microsecond),
@@ -92,13 +92,13 @@ func Now(thread *starlark.Thread) func() (time.Time, error) {
 	return nowFunc
 }
 
-func parseDuration(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func parseDuration(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var d Duration
 	err := starlark.UnpackPositionalArgs("parse_duration", args, kwargs, 1, &d)
 	return d, err
 }
 
-func isValidTimezone(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func isValidTimezone(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var s string
 	if err := starlark.UnpackPositionalArgs("is_valid_timezone", args, kwargs, 1, &s); err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func isValidTimezone(thread *starlark.Thread, _ *starlark.Builtin, args starlark
 	return starlark.Bool(err == nil), nil
 }
 
-func parseTime(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func parseTime(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		x        string
 		location = "UTC"
@@ -136,7 +136,7 @@ func parseTime(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	return Time(t), nil
 }
 
-func fromTimestamp(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func fromTimestamp(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		sec  int64
 		nsec int64 = 0
@@ -147,7 +147,7 @@ func fromTimestamp(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	return Time(time.Unix(sec, nsec)), nil
 }
 
-func now(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func now(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	nowErrFunc := Now(thread)
 	if nowErrFunc != nil {
 		t, err := nowErrFunc()
@@ -333,7 +333,7 @@ func (d Duration) Binary(op syntax.Token, y starlark.Value, side starlark.Side) 
 // Time is a Starlark representation of a moment in time.
 type Time time.Time
 
-func newTime(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func newTime(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
 		year, month, day, hour, min, sec, nsec int
 		loc                                    string
@@ -503,10 +503,10 @@ func builtinAttr(recv starlark.Value, name string, methods map[string]builtinMet
 	}
 
 	// Allocate a closure over 'method'.
-	impl := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		return method(b.Name(), b.Receiver(), args, kwargs)
+	impl := func(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		return method(name, recv, args, kwargs)
 	}
-	return starlark.NewBuiltin(name, impl).BindReceiver(recv), nil
+	return starlark.NewBuiltinMethod(name, impl).BindReceiver(recv), nil
 }
 
 func builtinAttrNames(methods map[string]builtinMethod) []string {

--- a/starlark/bench_test.go
+++ b/starlark/bench_test.go
@@ -82,38 +82,48 @@ func (benchmark) Type() string          { return "benchmark" }
 func (benchmark) String() string        { return "<benchmark>" }
 func (benchmark) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: benchmark") }
 func (benchmark) AttrNames() []string   { return []string{"n", "restart", "start", "stop"} }
-func (b benchmark) Attr(name string) (starlark.Value, error) {
+var _ starlark.HasBuiltinMethods = benchmark{}
+
+func (b benchmark) BuiltinMethod(name string) *starlark.Builtin {
 	switch name {
-	case "n":
-		return starlark.MakeInt(b.b.N), nil
 	case "restart":
-		return benchmarkRestart.BindReceiver(b), nil
+		return benchmarkRestart
 	case "start":
-		return benchmarkStart.BindReceiver(b), nil
+		return benchmarkStart
 	case "stop":
-		return benchmarkStop.BindReceiver(b), nil
+		return benchmarkStop
+	}
+	return nil
+}
+
+func (b benchmark) Attr(name string) (starlark.Value, error) {
+	if name == "n" {
+		return starlark.MakeInt(b.b.N), nil
+	}
+	if method := b.BuiltinMethod(name); method != nil {
+		return method.BindReceiver(b), nil
 	}
 	return nil, nil
 }
 
 var (
-	benchmarkRestart = starlark.NewBuiltin("restart", benchmarkRestartImpl)
-	benchmarkStart   = starlark.NewBuiltin("start", benchmarkStartImpl)
-	benchmarkStop    = starlark.NewBuiltin("stop", benchmarkStopImpl)
+	benchmarkRestart = starlark.NewBuiltinMethod("restart", benchmarkRestartImpl)
+	benchmarkStart   = starlark.NewBuiltinMethod("start", benchmarkStartImpl)
+	benchmarkStop    = starlark.NewBuiltinMethod("stop", benchmarkStopImpl)
 )
 
-func benchmarkRestartImpl(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	b.Receiver().(benchmark).b.ResetTimer()
+func benchmarkRestartImpl(thread *starlark.Thread, name string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	recv.(benchmark).b.ResetTimer()
 	return starlark.None, nil
 }
 
-func benchmarkStartImpl(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	b.Receiver().(benchmark).b.StartTimer()
+func benchmarkStartImpl(thread *starlark.Thread, name string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	recv.(benchmark).b.StartTimer()
 	return starlark.None, nil
 }
 
-func benchmarkStopImpl(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	b.Receiver().(benchmark).b.StopTimer()
+func benchmarkStopImpl(thread *starlark.Thread, name string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	recv.(benchmark).b.StopTimer()
 	return starlark.None, nil
 }
 

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -634,6 +634,12 @@ func listExtend(x *List, y Iterable) {
 
 // getAttr implements x.dot.
 func getAttr(x Value, name string) (Value, error) {
+	if hm, ok := x.(HasBuiltinMethods); ok {
+		if b := hm.BuiltinMethod(name); b != nil {
+			return b.BindReceiver(x), nil
+		}
+	}
+
 	hasAttr, ok := x.(HasAttrs)
 	if !ok {
 		return nil, fmt.Errorf("%s has no .%s field or method", x.Type(), name)
@@ -1192,11 +1198,42 @@ func stringRepeat(s String, n Int) (String, error) {
 
 // Call calls the function fn with the specified positional and keyword arguments.
 func Call(thread *Thread, fn Value, args Tuple, kwargs []Tuple) (Value, error) {
-	c, ok := fn.(Callable)
-	if !ok {
+	return call0(thread, fn, nil, args, kwargs)
+}
+
+// call0 calls the function fn with the specified positional and keyword arguments.
+//
+// If fn is an unbound method *Builtin (from ATTR_METHOD), recv is used as the receiver.
+// This avoids allocation via [Builtin.BindReceiver] when calling built-in methods.
+func call0(thread *Thread, fn Value, recv Value, args Tuple, kwargs []Tuple) (result Value, err error) {
+	if b, ok := fn.(*Builtin); ok && b.recv == nil {
+		fr := thread.pushFrame(b) // NOTE: lacks recv!
+		defer thread.popFrame(fr)
+		result, err = b.fn(thread, b.name, recv, args, kwargs)
+
+	} else if c, ok := fn.(Callable); ok {
+		fr := thread.pushFrame(c)
+		defer thread.popFrame(fr)
+		result, err = c.CallInternal(thread, args, kwargs)
+
+	} else {
 		return nil, fmt.Errorf("invalid call of non-function (%s)", fn.Type())
 	}
 
+	// Sanity check: nil is not a valid Starlark value.
+	if result == nil && err == nil {
+		err = fmt.Errorf("internal error: nil (not None) returned from %s", fn)
+	}
+
+	// Always return an EvalError with an accurate frame.
+	if err != nil && !is[*EvalError](err) {
+		err = thread.evalError(err)
+	}
+
+	return result, err
+}
+
+func (thread *Thread) pushFrame(c Callable) *frame {
 	// Allocate and push a new frame.
 	var fr *frame
 	// Optimization: use slack portion of thread.stack
@@ -1216,38 +1253,18 @@ func Call(thread *Thread, fn Value, args Tuple, kwargs []Tuple) (Value, error) {
 	}
 
 	thread.stack = append(thread.stack, fr) // push
-
 	fr.callable = c
-
 	thread.beginProfSpan()
+	return fr
+}
 
-	// Use defer to ensure that panics from built-ins
-	// pass through the interpreter without leaving
-	// it in a bad state.
-	defer func() {
-		thread.endProfSpan()
-
-		// clear out any references
-		// TODO(adonovan): opt: zero fr.Locals and
-		// reuse it if it is large enough.
-		*fr = frame{}
-
-		thread.stack = thread.stack[:len(thread.stack)-1] // pop
-	}()
-
-	result, err := c.CallInternal(thread, args, kwargs)
-
-	// Sanity check: nil is not a valid Starlark value.
-	if result == nil && err == nil {
-		err = fmt.Errorf("internal error: nil (not None) returned from %s", fn)
-	}
-
-	// Always return an EvalError with an accurate frame.
-	if err != nil && !is[*EvalError](err) {
-		err = thread.evalError(err)
-	}
-
-	return result, err
+func (thread *Thread) popFrame(fr *frame) {
+	thread.endProfSpan()
+	// clear out any references
+	// TODO(adonovan): opt: zero fr.Locals and
+	// reuse it if it is large enough.
+	*fr = frame{}
+	thread.stack = thread.stack[:len(thread.stack)-1] // pop
 }
 
 func slice(x, lo, hi, step_ Value) (Value, error) {

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -160,9 +160,9 @@ func TestExecFile(t *testing.T) {
 		filename := filepath.Join(testdata, file)
 		for _, chunk := range chunkedfile.Read(filename, t) {
 			predeclared := starlark.StringDict{
-				"hasfields": starlark.NewBuiltin("hasfields", newHasFields),
+				"hasfields": starlark.NewBuiltinMethod("hasfields", newHasFields),
 				"fibonacci": fib{},
-				"struct":    starlark.NewBuiltin("struct", starlarkstruct.Make),
+				"struct":    starlark.NewBuiltinMethod("struct", starlarkstruct.Make),
 			}
 
 			opts := getOptions(chunk.Source)
@@ -233,9 +233,9 @@ func load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	return starlark.ExecFile(thread, filename, nil, nil)
 }
 
-func newHasFields(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func newHasFields(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args)+len(kwargs) > 0 {
-		return nil, fmt.Errorf("%s: unexpected arguments", b.Name())
+		return nil, fmt.Errorf("%s: unexpected arguments", name)
 	}
 	return &hasfields{attrs: make(map[string]starlark.Value)}, nil
 }
@@ -909,12 +909,12 @@ func TestFrameLocals(t *testing.T) {
 	}
 
 	var got string
-	builtin := func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	builtin := func(thread *starlark.Thread, _ string, _ starlark.Value, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 		got = trace(thread)
 		return starlark.None, nil
 	}
 	predeclared := starlark.StringDict{
-		"builtin": starlark.NewBuiltin("builtin", builtin),
+		"builtin": starlark.NewBuiltinMethod("builtin", builtin),
 	}
 	_, err := starlark.ExecFile(&starlark.Thread{}, "foo.star", `
 def f(x, y): builtin()
@@ -1024,7 +1024,7 @@ func TestCancel(t *testing.T) {
 	{
 		thread := new(starlark.Thread)
 		predeclared := starlark.StringDict{
-			"stopit": starlark.NewBuiltin("stopit", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+			"stopit": starlark.NewBuiltinMethod("stopit", func(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 				thread.Cancel(fmt.Sprint(args[0]))
 				return starlark.None, nil
 			}),
@@ -1098,7 +1098,7 @@ func TestDeps(t *testing.T) {
 // built-in may traverse the interpreter safely; see issue #411.
 func TestPanicSafety(t *testing.T) {
 	predeclared := starlark.StringDict{
-		"panic": starlark.NewBuiltin("panic", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		"panic": starlark.NewBuiltinMethod("panic", func(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 			panic(args[0])
 		}),
 		"list": starlark.NewList([]starlark.Value{starlark.MakeInt(0)}),
@@ -1145,7 +1145,7 @@ main()
 
 func TestDebugFrame(t *testing.T) {
 	predeclared := starlark.StringDict{
-		"env": starlark.NewBuiltin("env", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		"env": starlark.NewBuiltinMethod("env", func(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 			if thread.CallStackDepth() < 2 {
 				return nil, fmt.Errorf("env must not be called directly")
 			}
@@ -1245,5 +1245,84 @@ func TestUnpackArgNoEscape(t *testing.T) {
 	})
 	if n > 0 {
 		t.Errorf("AllocsPerRun = %v, want none", n)
+	}
+}
+
+// legacy uses the old form of built-in methods.
+type legacy struct {
+	name string
+}
+
+var _ starlark.HasAttrs = (*legacy)(nil)
+
+func (r *legacy) String() string        { return r.name }
+func (r *legacy) Type() string          { return "legacy" }
+func (r *legacy) Truth() starlark.Bool  { return true }
+func (r *legacy) Hash() (uint32, error) { return 0, nil }
+func (r *legacy) Freeze()               {}
+func (r *legacy) AttrNames() []string   { return []string{"greet"} }
+func (r *legacy) Attr(name string) (starlark.Value, error) {
+	if b := legacyMethods[name]; b != nil {
+		return b.BindReceiver(r), nil
+	}
+	return nil, nil
+}
+
+var legacyMethods = map[string]*starlark.Builtin{
+	"greet": starlark.NewBuiltin("greet", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var arg string
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "arg", &arg); err != nil {
+			return nil, err
+		}
+		recv, ok := b.Receiver().(*legacy)
+		if !ok || recv == nil {
+			return nil, fmt.Errorf("expected legacyMethodReceiver receiver, got %v", b.Receiver())
+		}
+		return starlark.String(fmt.Sprintf("%s: hello %s", recv.name, arg)), nil
+	}),
+}
+
+func TestLegacyBuiltinMethod(t *testing.T) {
+	thread := new(starlark.Thread)
+
+	predeclared := starlark.StringDict{
+		"r": &legacy{name: "Alice"},
+		"standalone": starlark.NewBuiltin("standalone", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+			return starlark.String(b.Name()), nil
+		}),
+	}
+
+	{
+		// fused mode: r.greet("world")
+		got, err := starlark.Eval(thread, "fused.star", `r.greet("world")`, predeclared)
+		if err != nil {
+			t.Fatalf("fused call failed: %v", err)
+		}
+		if want := starlark.String("Alice: hello world"); got != want {
+			t.Errorf("fused call: got %s, want %s", got, want)
+		}
+	}
+
+	// bound mode: bound = r.greet; bound("world")
+	{
+		_, err := starlark.ExecFile(thread, "bound.star", `
+def check():
+	bound = r.greet
+	res = bound("world")
+	if res != "Alice: hello world":
+		fail("bound call: got %s, want Alice: hello world" % res)
+check()
+`, predeclared)
+		if err != nil {
+			t.Fatalf("bound call failed: %v", err)
+		}
+	}
+
+	// legacy standalone function
+	{
+		_, err := starlark.Eval(thread, "test.star", `fail('oops') if standalone() != 'standalone' else None`, predeclared)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }

--- a/starlark/example_test.go
+++ b/starlark/example_test.go
@@ -30,10 +30,10 @@ squares = [x*x for x in range(10)]
 
 	// repeat(str, n=1) is a Go function called from Starlark.
 	// It behaves like the 'string * int' operation.
-	repeat := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	repeat := func(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var s string
 		var n int = 1
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "s", &s, "n?", &n); err != nil {
+		if err := starlark.UnpackArgs(name, args, kwargs, "s", &s, "n?", &n); err != nil {
 			return nil, err
 		}
 		return starlark.String(strings.Repeat(s, n)), nil
@@ -48,7 +48,7 @@ squares = [x*x for x in range(10)]
 	// This dictionary defines the pre-declared environment.
 	predeclared := starlark.StringDict{
 		"greeting": starlark.String("hello"),
-		"repeat":   starlark.NewBuiltin("repeat", repeat),
+		"repeat":   starlark.NewBuiltinMethod("repeat", repeat),
 	}
 
 	// Execute a program.

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -340,7 +340,7 @@ loop:
 
 			// positional args
 			var positional Tuple
-			if npos := int(arg >> 8); npos > 0 {
+			if npos := int((arg &^ compile.HasRecv) >> 8); npos > 0 {
 				positional = stack[sp-npos : sp]
 				sp -= npos
 
@@ -366,6 +366,13 @@ loop:
 			}
 
 			function := stack[sp-1]
+			var recv Value
+			if arg&compile.HasRecv != 0 {
+				recv = stack[sp-2]
+				sp -= 2
+			} else {
+				sp--
+			}
 
 			if vmdebug {
 				fmt.Printf("VM call %s args=%s kwargs=%s @%s\n",
@@ -373,7 +380,7 @@ loop:
 			}
 
 			thread.endProfSpan()
-			z, err2 := Call(thread, function, positional, kvpairs)
+			z, err2 := call0(thread, function, recv, positional, kvpairs)
 			thread.beginProfSpan()
 			if err2 != nil {
 				err = err2
@@ -382,7 +389,34 @@ loop:
 			if vmdebug {
 				fmt.Printf("Resuming %s @ %s\n", f.Name, f.Position(0))
 			}
-			stack[sp-1] = z
+			stack[sp] = z
+			sp++
+
+		case compile.ATTR_METHOD:
+			// Resolve x.method at the receiver, before the arguments, so
+			// evaluation order matches the ordinary ATTR+CALL sequence.
+			recv := stack[sp-1]
+			name := f.Prog.Names[arg]
+
+			// Allocation-free fast path for types
+			// that can return unbound Builtins.
+			var method Value
+			if recv, ok := recv.(HasBuiltinMethods); ok {
+				if b := recv.BuiltinMethod(name); b != nil {
+					method = b
+				}
+			}
+			if method == nil {
+				// general case: recv.Attr(name) allocates in Builtin.BindReceiver.
+				var err2 error
+				method, err2 = getAttr(recv, name)
+				if err2 != nil {
+					err = err2
+					break loop
+				}
+			}
+			stack[sp] = method
+			sp++
 
 		case compile.ITERPUSH:
 			x := stack[sp-1]

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -40,36 +40,36 @@ func init() {
 		"None":      None,
 		"True":      True,
 		"False":     False,
-		"abs":       NewBuiltin("abs", abs),
-		"any":       NewBuiltin("any", any_),
-		"all":       NewBuiltin("all", all),
-		"bool":      NewBuiltin("bool", bool_),
-		"bytes":     NewBuiltin("bytes", bytes_),
-		"chr":       NewBuiltin("chr", chr),
-		"dict":      NewBuiltin("dict", dict),
-		"dir":       NewBuiltin("dir", dir),
-		"enumerate": NewBuiltin("enumerate", enumerate),
-		"fail":      NewBuiltin("fail", fail),
-		"float":     NewBuiltin("float", float),
-		"getattr":   NewBuiltin("getattr", getattr),
-		"hasattr":   NewBuiltin("hasattr", hasattr),
-		"hash":      NewBuiltin("hash", hash),
-		"int":       NewBuiltin("int", int_),
-		"len":       NewBuiltin("len", len_),
-		"list":      NewBuiltin("list", list),
-		"max":       NewBuiltin("max", minmax),
-		"min":       NewBuiltin("min", minmax),
-		"ord":       NewBuiltin("ord", ord),
-		"print":     NewBuiltin("print", print),
-		"range":     NewBuiltin("range", range_),
-		"repr":      NewBuiltin("repr", repr),
-		"reversed":  NewBuiltin("reversed", reversed),
-		"set":       NewBuiltin("set", set),
-		"sorted":    NewBuiltin("sorted", sorted),
-		"str":       NewBuiltin("str", str),
-		"tuple":     NewBuiltin("tuple", tuple),
-		"type":      NewBuiltin("type", type_),
-		"zip":       NewBuiltin("zip", zip),
+		"abs":       NewBuiltinMethod("abs", abs),
+		"any":       NewBuiltinMethod("any", any_),
+		"all":       NewBuiltinMethod("all", all),
+		"bool":      NewBuiltinMethod("bool", bool_),
+		"bytes":     NewBuiltinMethod("bytes", bytes_),
+		"chr":       NewBuiltinMethod("chr", chr),
+		"dict":      NewBuiltinMethod("dict", dict),
+		"dir":       NewBuiltinMethod("dir", dir),
+		"enumerate": NewBuiltinMethod("enumerate", enumerate),
+		"fail":      NewBuiltinMethod("fail", fail),
+		"float":     NewBuiltinMethod("float", float),
+		"getattr":   NewBuiltinMethod("getattr", getattr),
+		"hasattr":   NewBuiltinMethod("hasattr", hasattr),
+		"hash":      NewBuiltinMethod("hash", hash),
+		"int":       NewBuiltinMethod("int", int_),
+		"len":       NewBuiltinMethod("len", len_),
+		"list":      NewBuiltinMethod("list", list),
+		"max":       NewBuiltinMethod("max", minmax),
+		"min":       NewBuiltinMethod("min", minmax),
+		"ord":       NewBuiltinMethod("ord", ord),
+		"print":     NewBuiltinMethod("print", print),
+		"range":     NewBuiltinMethod("range", range_),
+		"repr":      NewBuiltinMethod("repr", repr),
+		"reversed":  NewBuiltinMethod("reversed", reversed),
+		"set":       NewBuiltinMethod("set", set),
+		"sorted":    NewBuiltinMethod("sorted", sorted),
+		"str":       NewBuiltinMethod("str", str),
+		"tuple":     NewBuiltinMethod("tuple", tuple),
+		"type":      NewBuiltinMethod("type", type_),
+		"zip":       NewBuiltinMethod("zip", zip),
 	}
 }
 
@@ -77,91 +77,90 @@ func init() {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#built-in-methods
 var (
 	bytesMethods = map[string]*Builtin{
-		"elems": NewBuiltin("elems", bytes_elems),
+		"elems": NewBuiltinMethod("elems", bytes_elems),
 	}
 
 	dictMethods = map[string]*Builtin{
-		"clear":      NewBuiltin("clear", dict_clear),
-		"get":        NewBuiltin("get", dict_get),
-		"items":      NewBuiltin("items", dict_items),
-		"keys":       NewBuiltin("keys", dict_keys),
-		"pop":        NewBuiltin("pop", dict_pop),
-		"popitem":    NewBuiltin("popitem", dict_popitem),
-		"setdefault": NewBuiltin("setdefault", dict_setdefault),
-		"update":     NewBuiltin("update", dict_update),
-		"values":     NewBuiltin("values", dict_values),
+		"clear":      NewBuiltinMethod("clear", dict_clear),
+		"get":        NewBuiltinMethod("get", dict_get),
+		"items":      NewBuiltinMethod("items", dict_items),
+		"keys":       NewBuiltinMethod("keys", dict_keys),
+		"pop":        NewBuiltinMethod("pop", dict_pop),
+		"popitem":    NewBuiltinMethod("popitem", dict_popitem),
+		"setdefault": NewBuiltinMethod("setdefault", dict_setdefault),
+		"update":     NewBuiltinMethod("update", dict_update),
+		"values":     NewBuiltinMethod("values", dict_values),
 	}
 
 	listMethods = map[string]*Builtin{
-		"append": NewBuiltin("append", list_append),
-		"clear":  NewBuiltin("clear", list_clear),
-		"extend": NewBuiltin("extend", list_extend),
-		"index":  NewBuiltin("index", list_index),
-		"insert": NewBuiltin("insert", list_insert),
-		"pop":    NewBuiltin("pop", list_pop),
-		"remove": NewBuiltin("remove", list_remove),
+		"append": NewBuiltinMethod("append", list_append),
+		"clear":  NewBuiltinMethod("clear", list_clear),
+		"extend": NewBuiltinMethod("extend", list_extend),
+		"index":  NewBuiltinMethod("index", list_index),
+		"insert": NewBuiltinMethod("insert", list_insert),
+		"pop":    NewBuiltinMethod("pop", list_pop),
+		"remove": NewBuiltinMethod("remove", list_remove),
 	}
 
 	stringMethods = map[string]*Builtin{
-		"capitalize":     NewBuiltin("capitalize", string_capitalize),
-		"codepoint_ords": NewBuiltin("codepoint_ords", string_iterable),
-		"codepoints":     NewBuiltin("codepoints", string_iterable), // sic
-		"count":          NewBuiltin("count", string_count),
-		"elem_ords":      NewBuiltin("elem_ords", string_iterable),
-		"elems":          NewBuiltin("elems", string_iterable),      // sic
-		"endswith":       NewBuiltin("endswith", string_startswith), // sic
-		"find":           NewBuiltin("find", string_find),
-		"format":         NewBuiltin("format", string_format),
-		"index":          NewBuiltin("index", string_index),
-		"isalnum":        NewBuiltin("isalnum", string_isalnum),
-		"isalpha":        NewBuiltin("isalpha", string_isalpha),
-		"isdigit":        NewBuiltin("isdigit", string_isdigit),
-		"islower":        NewBuiltin("islower", string_islower),
-		"isspace":        NewBuiltin("isspace", string_isspace),
-		"istitle":        NewBuiltin("istitle", string_istitle),
-		"isupper":        NewBuiltin("isupper", string_isupper),
-		"join":           NewBuiltin("join", string_join),
-		"lower":          NewBuiltin("lower", string_lower),
-		"lstrip":         NewBuiltin("lstrip", string_strip), // sic
-		"partition":      NewBuiltin("partition", string_partition),
-		"removeprefix":   NewBuiltin("removeprefix", string_removefix),
-		"removesuffix":   NewBuiltin("removesuffix", string_removefix),
-		"replace":        NewBuiltin("replace", string_replace),
-		"rfind":          NewBuiltin("rfind", string_rfind),
-		"rindex":         NewBuiltin("rindex", string_rindex),
-		"rpartition":     NewBuiltin("rpartition", string_partition), // sic
-		"rsplit":         NewBuiltin("rsplit", string_split),         // sic
-		"rstrip":         NewBuiltin("rstrip", string_strip),         // sic
-		"split":          NewBuiltin("split", string_split),
-		"splitlines":     NewBuiltin("splitlines", string_splitlines),
-		"startswith":     NewBuiltin("startswith", string_startswith),
-		"strip":          NewBuiltin("strip", string_strip),
-		"title":          NewBuiltin("title", string_title),
-		"upper":          NewBuiltin("upper", string_upper),
+		"capitalize":     NewBuiltinMethod("capitalize", string_capitalize),
+		"codepoint_ords": NewBuiltinMethod("codepoint_ords", string_iterable),
+		"codepoints":     NewBuiltinMethod("codepoints", string_iterable), // sic
+		"count":          NewBuiltinMethod("count", string_count),
+		"elem_ords":      NewBuiltinMethod("elem_ords", string_iterable),
+		"elems":          NewBuiltinMethod("elems", string_iterable),      // sic
+		"endswith":       NewBuiltinMethod("endswith", string_startswith), // sic
+		"find":           NewBuiltinMethod("find", string_find),
+		"format":         NewBuiltinMethod("format", string_format),
+		"index":          NewBuiltinMethod("index", string_index),
+		"isalnum":        NewBuiltinMethod("isalnum", string_isalnum),
+		"isalpha":        NewBuiltinMethod("isalpha", string_isalpha),
+		"isdigit":        NewBuiltinMethod("isdigit", string_isdigit),
+		"islower":        NewBuiltinMethod("islower", string_islower),
+		"isspace":        NewBuiltinMethod("isspace", string_isspace),
+		"istitle":        NewBuiltinMethod("istitle", string_istitle),
+		"isupper":        NewBuiltinMethod("isupper", string_isupper),
+		"join":           NewBuiltinMethod("join", string_join),
+		"lower":          NewBuiltinMethod("lower", string_lower),
+		"lstrip":         NewBuiltinMethod("lstrip", string_strip), // sic
+		"partition":      NewBuiltinMethod("partition", string_partition),
+		"removeprefix":   NewBuiltinMethod("removeprefix", string_removefix),
+		"removesuffix":   NewBuiltinMethod("removesuffix", string_removefix),
+		"replace":        NewBuiltinMethod("replace", string_replace),
+		"rfind":          NewBuiltinMethod("rfind", string_rfind),
+		"rindex":         NewBuiltinMethod("rindex", string_rindex),
+		"rpartition":     NewBuiltinMethod("rpartition", string_partition), // sic
+		"rsplit":         NewBuiltinMethod("rsplit", string_split),         // sic
+		"rstrip":         NewBuiltinMethod("rstrip", string_strip),         // sic
+		"split":          NewBuiltinMethod("split", string_split),
+		"splitlines":     NewBuiltinMethod("splitlines", string_splitlines),
+		"startswith":     NewBuiltinMethod("startswith", string_startswith),
+		"strip":          NewBuiltinMethod("strip", string_strip),
+		"title":          NewBuiltinMethod("title", string_title),
+		"upper":          NewBuiltinMethod("upper", string_upper),
 	}
 
 	setMethods = map[string]*Builtin{
-		"add":                  NewBuiltin("add", set_add),
-		"clear":                NewBuiltin("clear", set_clear),
-		"difference":           NewBuiltin("difference", set_difference),
-		"discard":              NewBuiltin("discard", set_discard),
-		"intersection":         NewBuiltin("intersection", set_intersection),
-		"issubset":             NewBuiltin("issubset", set_issubset),
-		"issuperset":           NewBuiltin("issuperset", set_issuperset),
-		"pop":                  NewBuiltin("pop", set_pop),
-		"remove":               NewBuiltin("remove", set_remove),
-		"symmetric_difference": NewBuiltin("symmetric_difference", set_symmetric_difference),
-		"union":                NewBuiltin("union", set_union),
-		"update":               NewBuiltin("update", set_update),
+		"add":                  NewBuiltinMethod("add", set_add),
+		"clear":                NewBuiltinMethod("clear", set_clear),
+		"difference":           NewBuiltinMethod("difference", set_difference),
+		"discard":              NewBuiltinMethod("discard", set_discard),
+		"intersection":         NewBuiltinMethod("intersection", set_intersection),
+		"issubset":             NewBuiltinMethod("issubset", set_issubset),
+		"issuperset":           NewBuiltinMethod("issuperset", set_issuperset),
+		"pop":                  NewBuiltinMethod("pop", set_pop),
+		"remove":               NewBuiltinMethod("remove", set_remove),
+		"symmetric_difference": NewBuiltinMethod("symmetric_difference", set_symmetric_difference),
+		"union":                NewBuiltinMethod("union", set_union),
+		"update":               NewBuiltinMethod("update", set_update),
 	}
 )
 
-func builtinAttr(recv Value, name string, methods map[string]*Builtin) (Value, error) {
-	b := methods[name]
-	if b == nil {
-		return nil, nil // no such method
+func builtinAttr(recv HasBuiltinMethods, name string) (Value, error) {
+	if b := recv.BuiltinMethod(name); b != nil {
+		return b.BindReceiver(recv), nil
 	}
-	return b.BindReceiver(recv), nil
+	return nil, nil // no such method
 }
 
 func builtinAttrNames(methods map[string]*Builtin) []string {
@@ -176,7 +175,7 @@ func builtinAttrNames(methods map[string]*Builtin) []string {
 // ---- built-in functions ----
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#abs
-func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func abs(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	if err := unpackPositionalArgsNoEscape("abs", args, kwargs, 1, &x); err != nil {
 		return nil, err
@@ -195,7 +194,7 @@ func abs(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#all
-func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func all(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := unpackPositionalArgsNoEscape("all", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
@@ -212,7 +211,7 @@ func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#any
-func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func any_(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := unpackPositionalArgsNoEscape("any", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
@@ -229,7 +228,7 @@ func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#bool
-func bool_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func bool_(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value = False
 	if err := unpackPositionalArgsNoEscape("bool", args, kwargs, 0, &x); err != nil {
 		return nil, err
@@ -238,7 +237,7 @@ func bool_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#bytes
-func bytes_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func bytes_(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("bytes does not accept keyword arguments")
 	}
@@ -277,7 +276,7 @@ func bytes_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#chr
-func chr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func chr(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("chr does not accept keyword arguments")
 	}
@@ -298,7 +297,7 @@ func chr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict
-func dict(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(args) > 1 {
 		return nil, fmt.Errorf("dict: got %d arguments, want at most 1", len(args))
 	}
@@ -310,7 +309,7 @@ func dict(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dir
-func dir(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dir(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("dir does not accept keyword arguments")
 	}
@@ -331,7 +330,7 @@ func dir(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#enumerate
-func enumerate(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func enumerate(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	var start int
 	if err := unpackPositionalArgsNoEscape("enumerate", args, kwargs, 1, &iterable, &start); err != nil {
@@ -367,7 +366,7 @@ func enumerate(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, e
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#fail
-func fail(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func fail(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	sep := " "
 	if err := UnpackArgs("fail", nil, kwargs, "sep?", &sep); err != nil {
 		return nil, err
@@ -388,7 +387,7 @@ func fail(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 	return nil, errors.New(buf.String())
 }
 
-func float(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func float(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("float does not accept keyword arguments")
 	}
@@ -453,7 +452,7 @@ var (
 )
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#getattr
-func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func getattr(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var object, dflt Value
 	var name string
 	if err := unpackPositionalArgsNoEscape("getattr", args, kwargs, 2, &object, &name, &dflt); err != nil {
@@ -467,7 +466,7 @@ func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 			if dflt != nil {
 				return dflt, nil
 			}
-			return nil, nameErr(b, err)
+			return nil, nameErr("getattr", err)
 		}
 		if v != nil {
 			return v, nil
@@ -481,7 +480,7 @@ func getattr(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#hasattr
-func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func hasattr(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var object Value
 	var name string
 	if err := unpackPositionalArgsNoEscape("hasattr", args, kwargs, 2, &object, &name); err != nil {
@@ -505,7 +504,7 @@ func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, err
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#hash
-func hash(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func hash(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	if err := unpackPositionalArgsNoEscape("hash", args, kwargs, 1, &x); err != nil {
 		return nil, err
@@ -547,7 +546,7 @@ func javaStringHash(s string) (h int32) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#int
-func int_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func int_(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value = zero
 	var base Value
 	if err := UnpackArgs("int", args, kwargs, "x", &x, "base?", &base); err != nil {
@@ -663,7 +662,7 @@ func parseInt(s string, base int) Value {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#len
-func len_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func len_(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	if err := unpackPositionalArgsNoEscape("len", args, kwargs, 1, &x); err != nil {
 		return nil, err
@@ -676,7 +675,7 @@ func len_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list
-func list(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := unpackPositionalArgsNoEscape("list", args, kwargs, 0, &iterable); err != nil {
 		return nil, err
@@ -697,16 +696,16 @@ func list(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#min
-func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func minmax(thread *Thread, name string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("%s requires at least one positional argument", b.Name())
+		return nil, fmt.Errorf("%s requires at least one positional argument", name)
 	}
 	var keyFunc Callable
-	if err := UnpackArgs(b.Name(), nil, kwargs, "key?", &keyFunc); err != nil {
+	if err := UnpackArgs(name, nil, kwargs, "key?", &keyFunc); err != nil {
 		return nil, err
 	}
 	var op syntax.Token
-	if b.Name() == "max" {
+	if name == "max" {
 		op = syntax.GT
 	} else {
 		op = syntax.LT
@@ -719,12 +718,12 @@ func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	}
 	iter := Iterate(iterable)
 	if iter == nil {
-		return nil, fmt.Errorf("%s: %s value is not iterable", b.Name(), iterable.Type())
+		return nil, fmt.Errorf("%s: %s value is not iterable", name, iterable.Type())
 	}
 	defer iter.Done()
 	var extremum Value
 	if !iter.Next(&extremum) {
-		return nil, nameErr(b, "argument is an empty sequence")
+		return nil, nameErr(name, "argument is an empty sequence")
 	}
 
 	var extremeKey Value
@@ -755,7 +754,7 @@ func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 		}
 
 		if ok, err := Compare(op, key, extremeKey); err != nil {
-			return nil, nameErr(b, err)
+			return nil, nameErr(name, err)
 		} else if ok {
 			extremum = x
 			extremeKey = key
@@ -765,7 +764,7 @@ func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#ord
-func ord(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func ord(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("ord does not accept keyword arguments")
 	}
@@ -795,7 +794,7 @@ func ord(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#print
-func print(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func print(thread *Thread, name string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	sep := " "
 	if err := UnpackArgs("print", nil, kwargs, "sep?", &sep); err != nil {
 		return nil, err
@@ -824,7 +823,7 @@ func print(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#range
-func range_(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func range_(thread *Thread, name string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var start, stop, step int
 	step = 1
 	if err := unpackPositionalArgsNoEscape("range", args, kwargs, 1, &start, &stop, &step); err != nil {
@@ -837,7 +836,7 @@ func range_(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	}
 	if step == 0 {
 		// we were given range(start, stop, 0)
-		return nil, nameErr(b, "step argument must not be zero")
+		return nil, nameErr(name, "step argument must not be zero")
 	}
 
 	return rangeValue{start: start, stop: stop, step: step, len: rangeLen(start, stop, step)}, nil
@@ -964,7 +963,7 @@ func (it *rangeIterator) Next(p *Value) bool {
 func (*rangeIterator) Done() {}
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#repr
-func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func repr(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	if err := unpackPositionalArgsNoEscape("repr", args, kwargs, 1, &x); err != nil {
 		return nil, err
@@ -973,7 +972,7 @@ func repr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#reversed
-func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func reversed(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := unpackPositionalArgsNoEscape("reversed", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
@@ -996,7 +995,7 @@ func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, er
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set
-func set(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set(thread *Thread, name string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := unpackPositionalArgsNoEscape("set", args, kwargs, 0, &iterable); err != nil {
 		return nil, err
@@ -1008,7 +1007,7 @@ func set(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 		var x Value
 		for iter.Next(&x) {
 			if err := set.Insert(x); err != nil {
-				return nil, nameErr(b, err)
+				return nil, nameErr(name, err)
 			}
 		}
 	}
@@ -1016,7 +1015,7 @@ func set(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#sorted
-func sorted(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func sorted(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	// Oddly, Python's sorted permits all arguments to be positional, thus so do we.
 	var iterable Iterable
 	var key Callable
@@ -1088,7 +1087,7 @@ func (s *sortSlice) Swap(i, j int) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#str
-func str(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func str(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("str does not accept keyword arguments")
 	}
@@ -1121,7 +1120,7 @@ func utf8Transcode(s string) string {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#tuple
-func tuple(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func tuple(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	if err := unpackPositionalArgsNoEscape("tuple", args, kwargs, 0, &iterable); err != nil {
 		return nil, err
@@ -1143,7 +1142,7 @@ func tuple(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#type
-func type_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func type_(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("type does not accept keyword arguments")
 	}
@@ -1154,7 +1153,7 @@ func type_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#zip
-func zip(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func zip(thread *Thread, _ string, _ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("zip does not accept keyword arguments")
 	}
@@ -1210,13 +1209,13 @@ func zip(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 // ---- methods of built-in types ---
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·get
-func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_get(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var key, dflt Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
 	}
-	if v, ok, err := b.Receiver().(*Dict).Get(key); err != nil {
-		return nil, nameErr(b, err)
+	if v, ok, err := r.(*Dict).Get(key); err != nil {
+		return nil, nameErr(name, err)
 	} else if ok {
 		return v, nil
 	} else if dflt != nil {
@@ -1226,19 +1225,19 @@ func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·clear
-func dict_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func dict_clear(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	return None, b.Receiver().(*Dict).Clear()
+	return None, r.(*Dict).Clear()
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·items
-func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func dict_items(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	items := b.Receiver().(*Dict).Items()
+	items := r.(*Dict).Items()
 	res := make([]Value, len(items))
 	for i, item := range items {
 		res[i] = item // convert [2]Value to Value
@@ -1247,81 +1246,81 @@ func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·keys
-func dict_keys(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func dict_keys(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	return NewList(b.Receiver().(*Dict).Keys()), nil
+	return NewList(r.(*Dict).Keys()), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·pop
-func dict_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_pop(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var k, d Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &k, &d); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &k, &d); err != nil {
 		return nil, err
 	}
-	if v, found, err := b.Receiver().(*Dict).Delete(k); err != nil {
-		return nil, nameErr(b, err) // dict is frozen or key is unhashable
+	if v, found, err := r.(*Dict).Delete(k); err != nil {
+		return nil, nameErr(name, err) // dict is frozen or key is unhashable
 	} else if found {
 		return v, nil
 	} else if d != nil {
 		return d, nil
 	}
-	return nil, nameErr(b, "missing key")
+	return nil, nameErr(name, "missing key")
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·popitem
-func dict_popitem(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func dict_popitem(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := b.Receiver().(*Dict)
+	recv := r.(*Dict)
 	k, ok := recv.ht.first()
 	if !ok {
-		return nil, nameErr(b, "empty dict")
+		return nil, nameErr(name, "empty dict")
 	}
 	v, _, err := recv.Delete(k)
 	if err != nil {
-		return nil, nameErr(b, err) // dict is frozen
+		return nil, nameErr(name, err) // dict is frozen
 	}
 	return Tuple{k, v}, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·setdefault
-func dict_setdefault(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_setdefault(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var key, dflt Value = nil, None
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
 	}
-	dict := b.Receiver().(*Dict)
+	dict := r.(*Dict)
 	if v, ok, err := dict.Get(key); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	} else if ok {
 		return v, nil
 	} else if err := dict.SetKey(key, dflt); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	} else {
 		return dflt, nil
 	}
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
-func dict_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func dict_update(_ *Thread, _ string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(args) > 1 {
 		return nil, fmt.Errorf("update: got %d arguments, want at most 1", len(args))
 	}
-	if err := updateDict(b.Receiver().(*Dict), args, kwargs); err != nil {
+	if err := updateDict(r.(*Dict), args, kwargs); err != nil {
 		return nil, fmt.Errorf("update: %v", err)
 	}
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
-func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func dict_values(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	items := b.Receiver().(*Dict).Items()
+	items := r.(*Dict).Items()
 	res := make([]Value, len(items))
 	for i, item := range items {
 		res[i] = item[1]
@@ -1330,77 +1329,77 @@ func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·append
-func list_append(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_append(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var object Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &object); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &object); err != nil {
 		return nil, err
 	}
-	recv := b.Receiver().(*List)
+	recv := r.(*List)
 	if err := recv.checkMutable("append to"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	recv.elems = append(recv.elems, object)
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·clear
-func list_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func list_clear(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	if err := b.Receiver().(*List).Clear(); err != nil {
-		return nil, nameErr(b, err)
+	if err := r.(*List).Clear(); err != nil {
+		return nil, nameErr(name, err)
 	}
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·extend
-func list_extend(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := b.Receiver().(*List)
+func list_extend(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := r.(*List)
 	var iterable Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("extend"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	listExtend(recv, iterable)
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·index
-func list_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func list_index(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var value, start_, end_ Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &value, &start_, &end_); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &value, &start_, &end_); err != nil {
 		return nil, err
 	}
 
-	recv := b.Receiver().(*List)
+	recv := r.(*List)
 	start, end, err := indices(start_, end_, recv.Len())
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 
 	for i := start; i < end; i++ {
 		if eq, err := Equal(recv.elems[i], value); err != nil {
-			return nil, nameErr(b, err)
+			return nil, nameErr(name, err)
 		} else if eq {
 			return MakeInt(i), nil
 		}
 	}
-	return nil, nameErr(b, "value not in list")
+	return nil, nameErr(name, "value not in list")
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·insert
-func list_insert(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := b.Receiver().(*List)
+func list_insert(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := r.(*List)
 	var index int
 	var object Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 2, &index, &object); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 2, &index, &object); err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("insert into"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 
 	if index < 0 {
@@ -1422,14 +1421,14 @@ func list_insert(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·remove
-func list_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := b.Receiver().(*List)
+func list_remove(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := r.(*List)
 	var value Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &value); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &value); err != nil {
 		return nil, err
 	}
 	if err := recv.checkMutable("remove from"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	for i, elem := range recv.elems {
 		if eq, err := Equal(elem, value); err != nil {
@@ -1443,12 +1442,12 @@ func list_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#list·pop
-func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := b.Receiver()
+func list_pop(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := r
 	list := recv.(*List)
 	n := list.Len()
 	i := n - 1
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &i); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &i); err != nil {
 		return nil, err
 	}
 	origI := i
@@ -1456,10 +1455,10 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 		i += n
 	}
 	if i < 0 || i >= n {
-		return nil, nameErr(b, outOfRange(origI, n, list))
+		return nil, nameErr(name, outOfRange(origI, n, list))
 	}
 	if err := list.checkMutable("pop from"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	res := list.elems[i]
 	list.elems = append(list.elems[:i], list.elems[i+1:]...)
@@ -1467,11 +1466,11 @@ func list_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·capitalize
-func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_capitalize(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	s := string(b.Receiver().(String))
+	s := string(r.(String))
 	res := new(strings.Builder)
 	res.Grow(len(s))
 	for i, r := range s {
@@ -1490,13 +1489,13 @@ func string_capitalize(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 // - codepoints: successive substrings that encode a single Unicode code point.
 // - elem_ords: numeric values of successive bytes
 // - codepoint_ords: numeric values of successive Unicode code points
-func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_iterable(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	s := b.Receiver().(String)
-	ords := b.Name()[len(b.Name())-2] == 'd'
-	codepoints := b.Name()[0] == 'c'
+	s := r.(String)
+	ords := name[len(name)-2] == 'd'
+	codepoints := name[0] == 'c'
 	if codepoints {
 		return stringCodepoints{s, ords}, nil
 	} else {
@@ -1506,11 +1505,11 @@ func string_iterable(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, 
 
 // bytes_elems returns an unspecified iterable value whose
 // iterator yields the int values of successive elements.
-func bytes_elems(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func bytes_elems(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	return bytesIterable{b.Receiver().(Bytes)}, nil
+	return bytesIterable{r.(Bytes)}, nil
 }
 
 // A bytesIterable is an iterable returned by bytes.elems(),
@@ -1540,17 +1539,17 @@ func (it *bytesIterator) Next(p *Value) bool {
 func (*bytesIterator) Done() {}
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·count
-func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_count(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var sub string
 	var start_, end_ Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &sub, &start_, &end_); err != nil {
 		return nil, err
 	}
 
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	start, end, err := indices(start_, end_, len(recv))
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 
 	var slice string
@@ -1561,11 +1560,11 @@ func string_count(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalnum
-func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_isalnum(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	for _, r := range recv {
 		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
 			return False, nil
@@ -1575,11 +1574,11 @@ func string_isalnum(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isalpha
-func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_isalpha(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	for _, r := range recv {
 		if !unicode.IsLetter(r) {
 			return False, nil
@@ -1589,11 +1588,11 @@ func string_isalpha(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isdigit
-func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_isdigit(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	for _, r := range recv {
 		if !unicode.IsDigit(r) {
 			return False, nil
@@ -1603,11 +1602,11 @@ func string_isdigit(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·islower
-func string_islower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_islower(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	return Bool(isCasedString(recv) && recv == strings.ToLower(recv)), nil
 }
 
@@ -1628,11 +1627,11 @@ func isCasedRune(r rune) bool {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isspace
-func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_isspace(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	for _, r := range recv {
 		if !unicode.IsSpace(r) {
 			return False, nil
@@ -1642,11 +1641,11 @@ func string_isspace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·istitle
-func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_istitle(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 
 	// Python semantics differ from x==strings.{To,}Title(x) in Go:
 	// "uppercase characters may only follow uncased characters and
@@ -1675,22 +1674,22 @@ func string_istitle(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·isupper
-func string_isupper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_isupper(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	return Bool(isCasedString(recv) && recv == strings.ToUpper(recv)), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·find
-func string_find(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	return string_find_impl(b, args, kwargs, true, false)
+func string_find(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	return string_find_impl(name, r, args, kwargs, true, false)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·format
-func string_format(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	format := string(b.Receiver().(String))
+func string_format(_ *Thread, _ string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	format := string(r.(String))
 	var auto, manual bool // kinds of positional indexing used
 	buf := new(strings.Builder)
 	index := 0
@@ -1845,15 +1844,15 @@ func decimal(s string) (x int, ok bool) {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·index
-func string_index(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	return string_find_impl(b, args, kwargs, false, false)
+func string_index(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	return string_find_impl(name, r, args, kwargs, false, false)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·join
-func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := string(b.Receiver().(String))
+func string_join(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := string(r.(String))
 	var iterable Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &iterable); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
 	iter := iterable.Iterate()
@@ -1874,32 +1873,32 @@ func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lower
-func string_lower(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_lower(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	return String(strings.ToLower(string(b.Receiver().(String)))), nil
+	return String(strings.ToLower(string(r.(String)))), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·partition
-func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := string(b.Receiver().(String))
+func string_partition(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := string(r.(String))
 	var sep string
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &sep); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &sep); err != nil {
 		return nil, err
 	}
 	if sep == "" {
-		return nil, nameErr(b, "empty separator")
+		return nil, nameErr(name, "empty separator")
 	}
 	var i int
-	if b.Name()[0] == 'p' {
+	if name[0] == 'p' {
 		i = strings.Index(recv, sep) // partition
 	} else {
 		i = strings.LastIndex(recv, sep) // rpartition
 	}
 	tuple := make(Tuple, 0, 3)
 	if i < 0 {
-		if b.Name()[0] == 'p' {
+		if name[0] == 'p' {
 			tuple = append(tuple, String(recv), String(""), String(""))
 		} else {
 			tuple = append(tuple, String(""), String(""), String(recv))
@@ -1912,13 +1911,13 @@ func string_partition(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·removeprefix
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·removesuffix
-func string_removefix(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := string(b.Receiver().(String))
+func string_removefix(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := string(r.(String))
 	var fix string
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &fix); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &fix); err != nil {
 		return nil, err
 	}
-	if b.name[len("remove")] == 'p' {
+	if name[len("remove")] == 'p' {
 		recv = strings.TrimPrefix(recv, fix)
 	} else {
 		recv = strings.TrimSuffix(recv, fix)
@@ -1927,39 +1926,39 @@ func string_removefix(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·replace
-func string_replace(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := string(b.Receiver().(String))
+func string_replace(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := string(r.(String))
 	var old, new string
 	count := -1
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 2, &old, &new, &count); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 2, &old, &new, &count); err != nil {
 		return nil, err
 	}
 	return String(strings.Replace(recv, old, new, count)), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rfind
-func string_rfind(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	return string_find_impl(b, args, kwargs, true, true)
+func string_rfind(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	return string_find_impl(name, r, args, kwargs, true, true)
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rindex
-func string_rindex(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	return string_find_impl(b, args, kwargs, false, true)
+func string_rindex(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	return string_find_impl(name, r, args, kwargs, false, true)
 }
 
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·startswith
 // https://github.com/google/starlark-go/starlark/blob/master/doc/spec.md#string·endswith
-func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_startswith(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value
 	var start, end Value = None, None
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &x, &start, &end); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &x, &start, &end); err != nil {
 		return nil, err
 	}
 
 	// compute effective substring.
-	s := string(b.Receiver().(String))
+	s := string(r.(String))
 	if start, end, err := indices(start, end, len(s)); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	} else {
 		if end < start {
 			end = start // => empty result
@@ -1968,7 +1967,7 @@ func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 	}
 
 	f := strings.HasPrefix
-	if b.Name()[0] == 'e' { // endswith
+	if name[0] == 'e' { // endswith
 		f = strings.HasSuffix
 	}
 
@@ -1978,7 +1977,7 @@ func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 			prefix, ok := AsString(x)
 			if !ok {
 				return nil, fmt.Errorf("%s: want string, got %s, for element %d",
-					b.Name(), x.Type(), i)
+					name, x.Type(), i)
 			}
 			if f(s, prefix) {
 				return True, nil
@@ -1988,20 +1987,20 @@ func string_startswith(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 	case String:
 		return Bool(f(s, string(x))), nil
 	}
-	return nil, fmt.Errorf("%s: got %s, want string or tuple of string", b.Name(), x.Type())
+	return nil, fmt.Errorf("%s: got %s, want string or tuple of string", name, x.Type())
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·strip
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·lstrip
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rstrip
-func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_strip(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var chars string
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &chars); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &chars); err != nil {
 		return nil, err
 	}
-	recv := string(b.Receiver().(String))
+	recv := string(r.(String))
 	var s string
-	switch b.Name()[0] {
+	switch name[0] {
 	case 's': // strip
 		if chars != "" {
 			s = strings.Trim(recv, chars)
@@ -2025,12 +2024,12 @@ func string_strip(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·title
-func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_title(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
 
-	s := string(b.Receiver().(String))
+	s := string(r.(String))
 
 	// Python semantics differ from x==strings.{To,}Title(x) in Go:
 	// "uppercase characters may only follow uncased characters and
@@ -2051,20 +2050,20 @@ func string_title(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·upper
-func string_upper(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func string_upper(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	return String(strings.ToUpper(string(b.Receiver().(String)))), nil
+	return String(strings.ToUpper(string(r.(String)))), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·split
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·rsplit
-func string_split(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := string(b.Receiver().(String))
+func string_split(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	recv := string(r.(String))
 	var sep_ Value
 	maxsplit := -1
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &sep_, &maxsplit); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &sep_, &maxsplit); err != nil {
 		return nil, err
 	}
 
@@ -2074,7 +2073,7 @@ func string_split(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 		// special case: split on whitespace
 		if maxsplit < 0 {
 			res = strings.Fields(recv)
-		} else if b.Name() == "split" {
+		} else if name == "split" {
 			res = splitspace(recv, maxsplit)
 		} else { // rsplit
 			res = rsplitspace(recv, maxsplit)
@@ -2087,7 +2086,7 @@ func string_split(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 		// usual case: split on non-empty separator
 		if maxsplit < 0 {
 			res = strings.Split(recv, sep)
-		} else if b.Name() == "split" {
+		} else if name == "split" {
 			res = strings.SplitN(recv, sep, maxsplit+1)
 		} else { // rsplit
 			res = strings.Split(recv, sep)
@@ -2163,13 +2162,13 @@ func splitspace(s string, max int) []string {
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#string·splitlines
-func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func string_splitlines(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var keepends bool
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &keepends); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &keepends); err != nil {
 		return nil, err
 	}
 	var lines []string
-	if s := string(b.Receiver().(String)); s != "" {
+	if s := string(r.(String)); s != "" {
 		// TODO(adonovan): handle CRLF correctly.
 		if keepends {
 			lines = strings.SplitAfter(s, "\n")
@@ -2188,202 +2187,202 @@ func string_splitlines(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·add.
-func set_add(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_add(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var elem Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &elem); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &elem); err != nil {
 		return nil, err
 	}
-	recv := b.Receiver().(*Set)
+	recv := r.(*Set)
 	// It is always an error to attempt to mutate a set that cannot be mutated
 	if err := recv.ht.checkMutable("insert into"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	// TODO(adonovan): opt: combine Has+Insert. (e.g. use Insert and re-check Len)
 	if found, err := recv.Has(elem); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	} else if found {
 		return None, nil
 	}
 	err := recv.Insert(elem)
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·clear.
-func set_clear(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func set_clear(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	if b.Receiver().(*Set).Len() > 0 {
-		if err := b.Receiver().(*Set).Clear(); err != nil {
-			return nil, nameErr(b, err)
+	if r.(*Set).Len() > 0 {
+		if err := r.(*Set).Clear(); err != nil {
+			return nil, nameErr(name, err)
 		}
 	}
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·difference.
-func set_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_difference(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	// TODO: support multiple others: s.difference(*others)
 	var other Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
 	defer iter.Done()
-	diff, err := b.Receiver().(*Set).Difference(iter)
+	diff, err := r.(*Set).Difference(iter)
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return diff, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_intersection.
-func set_intersection(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_intersection(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	// TODO: support multiple others: s.difference(*others)
 	var other Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
 	defer iter.Done()
-	diff, err := b.Receiver().(*Set).Intersection(iter)
+	diff, err := r.(*Set).Intersection(iter)
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return diff, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_issubset.
-func set_issubset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_issubset(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var other Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
 	defer iter.Done()
-	diff, err := b.Receiver().(*Set).IsSubset(iter)
+	diff, err := r.(*Set).IsSubset(iter)
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return Bool(diff), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set_issuperset.
-func set_issuperset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_issuperset(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var other Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
 	defer iter.Done()
-	diff, err := b.Receiver().(*Set).IsSuperset(iter)
+	diff, err := r.(*Set).IsSuperset(iter)
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return Bool(diff), nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·discard.
-func set_discard(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_discard(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var k Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &k); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &k); err != nil {
 		return nil, err
 	}
-	recv := b.Receiver().(*Set)
+	recv := r.(*Set)
 	// It is always an error to attempt to mutate a set that cannot be mutated
 	if err := recv.ht.checkMutable("delete from"); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	// TODO(adonovan): opt: combine Has+Delete (e.g. use Delete and re-check Len)
 	if found, err := recv.Has(k); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	} else if !found {
 		return None, nil
 	}
 	if _, err := recv.Delete(k); err != nil {
-		return nil, nameErr(b, err) // set is frozen
+		return nil, nameErr(name, err) // set is frozen
 	}
 	return None, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·pop.
-func set_pop(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
+func set_pop(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := UnpackPositionalArgs(name, args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	recv := b.Receiver().(*Set)
+	recv := r.(*Set)
 	k, ok := recv.ht.first()
 	if !ok {
-		return nil, nameErr(b, "empty set")
+		return nil, nameErr(name, "empty set")
 	}
 	_, err := recv.Delete(k)
 	if err != nil {
-		return nil, nameErr(b, err) // set is frozen
+		return nil, nameErr(name, err) // set is frozen
 	}
 	return k, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·remove.
-func set_remove(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_remove(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var k Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &k); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &k); err != nil {
 		return nil, err
 	}
-	if found, err := b.Receiver().(*Set).Delete(k); err != nil {
-		return nil, nameErr(b, err) // dict is frozen or key is unhashable
+	if found, err := r.(*Set).Delete(k); err != nil {
+		return nil, nameErr(name, err) // dict is frozen or key is unhashable
 	} else if found {
 		return None, nil
 	}
-	return nil, nameErr(b, "missing key")
+	return nil, nameErr(name, "missing key")
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·symmetric_difference.
-func set_symmetric_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func set_symmetric_difference(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
 	var other Iterable
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 0, &other); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
 	iter := other.Iterate()
 	defer iter.Done()
-	diff, err := b.Receiver().(*Set).SymmetricDifference(iter)
+	diff, err := r.(*Set).SymmetricDifference(iter)
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return diff, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·union.
-func set_union(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	receiverSet := b.Receiver().(*Set).clone()
+func set_union(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	receiverSet := r.(*Set).clone()
 	if err := setUpdate(receiverSet, args, kwargs); err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	return receiverSet, nil
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#set·update.
-func set_update(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if err := setUpdate(b.Receiver().(*Set), args, kwargs); err != nil {
-		return nil, nameErr(b, err)
+func set_update(_ *Thread, name string, r Value, args Tuple, kwargs []Tuple) (Value, error) {
+	if err := setUpdate(r.(*Set), args, kwargs); err != nil {
+		return nil, nameErr(name, err)
 	}
 	return None, nil
 }
 
 // Common implementation of string_{r}{find,index}.
-func string_find_impl(b *Builtin, args Tuple, kwargs []Tuple, allowError, last bool) (Value, error) {
+func string_find_impl(name string, r Value, args Tuple, kwargs []Tuple, allowError, last bool) (Value, error) {
 	var sub string
 	var start_, end_ Value
-	if err := unpackPositionalArgsNoEscape(b.Name(), args, kwargs, 1, &sub, &start_, &end_); err != nil {
+	if err := unpackPositionalArgsNoEscape(name, args, kwargs, 1, &sub, &start_, &end_); err != nil {
 		return nil, err
 	}
 
-	s := string(b.Receiver().(String))
+	s := string(r.(String))
 	start, end, err := indices(start_, end_, len(s))
 	if err != nil {
-		return nil, nameErr(b, err)
+		return nil, nameErr(name, err)
 	}
 	var slice string
 	if start < end {
@@ -2398,7 +2397,7 @@ func string_find_impl(b *Builtin, args Tuple, kwargs []Tuple, allowError, last b
 	}
 	if i < 0 {
 		if !allowError {
-			return nil, nameErr(b, "substring not found")
+			return nil, nameErr(name, "substring not found")
 		}
 		return MakeInt(-1), nil
 	}
@@ -2494,7 +2493,7 @@ func setUpdate(s *Set, args Tuple, kwargs []Tuple) error {
 }
 
 // nameErr returns an error message of the form "name: msg"
-// where name is b.Name() and msg is a string or error.
-func nameErr(b *Builtin, msg any) error {
-	return fmt.Errorf("%s: %v", b.Name(), msg)
+// where name is the function and msg is a string or error.
+func nameErr(name string, msg any) error {
+	return fmt.Errorf("%s: %v", name, msg)
 }

--- a/starlark/testdata/benchmark.star
+++ b/starlark/testdata/benchmark.star
@@ -34,6 +34,15 @@ def bench_builtin_method(b):
         for _ in range1000:
             emptydict.get(None)
 
+def bench_method_mix(b):
+    "Benchmark of a simple mix of built-in method calls (string, list, dict)."
+    s = "hello.go"
+    for _ in range(b.n):
+        d = {}
+        for i in range1000:
+            if s.endswith(".go"):
+                d.setdefault("go", []).append(i)
+
 def bench_int(b):
     for _ in range(b.n):
         a = 0

--- a/starlark/testdata/misc.star
+++ b/starlark/testdata/misc.star
@@ -136,4 +136,29 @@ assert.fails(lambda: [] + [] + 1 + [], "unknown binary op: list \\+ int")
 
 
 ---
+# Method calls: the ATTR_METHOD+CALL path must agree with the ATTR
+# path (retained method value) and with the *args/**kwargs path.
+load("assert.star", "assert")
+
+s = "hello"
+assert.eq(s.startswith("he"), True)         # method call
+assert.eq(s.startswith("he", 1), False)     # multiple positional
+bound = s.startswith                        # retained method value (ATTR path)
+assert.eq(bound("he"), True)
+assert.eq(s.startswith(*["he"]), True)      # *args: fused
+assert.eq(s.startswith(*["he"], **{}), True)  # *args + **kwargs: fused
+assert.eq({"k": 1}.get("k"), 1)             # dict method
+assert.eq([1, 2, 3].index(2), 1)            # list method
+assert.eq("HELLO".lower().startswith("he"), True)  # chained: pool reuse
+assert.fails(lambda: s.nonexistent(), "no .nonexistent field or method")
+
+# Evaluation order: x.method is resolved *before* the arguments, matching the
+# ordinary ATTR+CALL sequence. A missing method must therefore be reported
+# even when evaluating an argument would itself fail or have side effects.
+# (A fused resolve-after-args opcode would instead report the argument error.)
+assert.fails(lambda: [].nonesuch(1 // 0), "no .nonesuch field or method")
+assert.fails(lambda: [].nonesuch(fail("arg evaluated")), "no .nonesuch field or method")
+assert.fails(lambda: "".nonesuch([][0]), "no .nonesuch field or method")
+
+---
 load('assert.star', 'froze') ### `name froze not found .*did you mean freeze`

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -33,6 +33,7 @@
 //	Mapping         -- value maps from keys to values, like a dictionary
 //	HasBinary       -- value defines binary operations such as * and +
 //	HasAttrs        -- value has readable fields or methods x.f
+//	HasBuiltinMethods  value supports efficient calling of built-in methods
 //	HasSetField     -- value has settable fields x.f
 //	HasSetIndex     -- value supports element update using x[i]=y
 //	HasSetKey       -- value supports map update using x[k]=v
@@ -374,6 +375,36 @@ var (
 	_ HasAttrs = new(Set)
 )
 
+// A HasBuiltinMethods value is a HasAttrs that additionally provides
+// optimized calling of built-in methods.
+//
+// BuiltinMethod returns a unbound method (with a nil Receiver),
+// avoiding the usual [Builtin.BindReceiver] allocation implied by a
+// [HasAttrs.Attr] call when the method is immediately called, as in
+// recv.name().
+//
+// The Attr method of a HasBuiltinMethods type Foo typically has the form:
+//
+//	func (recv *Foo) Attr(name string) (Value, error) {
+//		if b := recv.BuiltinMethod(name); b != nil {
+//			return b.BindReceiver(recv), nil
+//		}
+//		// ... handle any other attributes ...
+//		return nil, nil // no such attribute
+//	}
+type HasBuiltinMethods interface {
+	HasAttrs
+	BuiltinMethod(name string) *Builtin
+}
+
+var (
+	_ HasBuiltinMethods = String("")
+	_ HasBuiltinMethods = new(List)
+	_ HasBuiltinMethods = new(Dict)
+	_ HasBuiltinMethods = new(Set)
+	_ HasBuiltinMethods = Bytes("")
+)
+
 // A HasSetField value has fields that may be written by a dot expression (x.f = y).
 //
 // An implementation of SetField may return a NoSuchAttrError,
@@ -391,6 +422,8 @@ type HasSetField interface {
 type NoSuchAttrError string
 
 func (e NoSuchAttrError) Error() string { return string(e) }
+
+var _ error = NoSuchAttrError("")
 
 // NoneType is the type of None.  Its only legal value is None.
 // (We represent it as a number, not struct{}, so that None may be constant.)
@@ -594,8 +627,9 @@ func (s String) Slice(start, end, step int) Value {
 	return String(str)
 }
 
-func (s String) Attr(name string) (Value, error) { return builtinAttr(s, name, stringMethods) }
-func (s String) AttrNames() []string             { return builtinAttrNames(stringMethods) }
+func (s String) Attr(name string) (Value, error)    { return builtinAttr(s, name) }
+func (s String) BuiltinMethod(name string) *Builtin { return stringMethods[name] }
+func (s String) AttrNames() []string                { return builtinAttrNames(stringMethods) }
 
 func (x String) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(String)
@@ -825,10 +859,29 @@ func (fn *Function) FreeVar(i int) (Binding, Value) {
 	return Binding(fn.funcode.FreeVars[i]), fn.freevars[i].(*cell).v
 }
 
-// A Builtin is a function implemented in Go.
+// A Builtin is a function or method implemented in Go.
+//
+// For methods, Builtins exist in two flavors: unbound and bound.
+// An unbound method (Receiver == nil) is a static method descriptor
+// shared across all instances of a type. It represents the method
+// itself without reference to a specific target object. When a method
+// call is fused in syntax (x.method(args...)), the compiler emits
+// ATTR_METHOD and a CALL instruction with the HasRecv bit set. The
+// interpreter resolves the unbound method descriptor directly from the type
+// ([HasBuiltinMethods]) and passes both the unbound descriptor and
+// the explicit receiver x on the operand stack. The underlying Go
+// function fn is invoked without allocating a method closure on the
+// heap.
+//
+// A bound method (recv != nil) represents a method closure (x.method)
+// that has been bound to a specific receiver value (x). Bound methods
+// are created by calling [Builtin.BindReceiver] when a Starlark dot
+// expression (g = x.method) is evaluated without an immediate call
+// (ATTR). When a bound method is subsequently invoked (g(args...)),
+// its stored recv value is passed to fn.
 type Builtin struct {
 	name string
-	fn   func(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)
+	fn   func(thread *Thread, name string, recv Value, args Tuple, kwargs []Tuple) (Value, error)
 	recv Value // for bound methods (e.g. "".startswith)
 }
 
@@ -845,17 +898,35 @@ func (b *Builtin) Hash() (uint32, error) {
 	}
 	return h, nil
 }
+
+// Deprecated: use [NewBuiltinMethod] instead of [NewBuiltin] so this method becomes irrelevant.
 func (b *Builtin) Receiver() Value { return b.recv }
 func (b *Builtin) String() string  { return toString(b) }
 func (b *Builtin) Type() string    { return "builtin_function_or_method" }
 func (b *Builtin) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
-	return b.fn(thread, b, args, kwargs)
+	return b.fn(thread, b.name, b.recv, args, kwargs)
 }
 func (b *Builtin) Truth() Bool { return true }
 
 // NewBuiltin returns a new 'builtin_function_or_method' value with the specified name
-// and implementation.  It compares unequal with all other values.
+// and legacy-style implementation.  It compares unequal with all other values.
+//
+// Deprecated: use [NewBuiltinMethod], which avoids allocating a Builtin for method calls.
 func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)) *Builtin {
+	var unbound *Builtin
+	unbound = NewBuiltinMethod(name, func(thread *Thread, _ string, recv Value, args Tuple, kwargs []Tuple) (Value, error) {
+		b := unbound
+		if recv != b.recv {
+			b = b.BindReceiver(recv)
+		}
+		return fn(thread, b, args, kwargs)
+	})
+	return unbound
+}
+
+// NewBuiltinMethod returns a new 'builtin_function_or_method' value with the specified name
+// and implementation. It compares unequal with all other values.
+func NewBuiltinMethod(name string, fn func(thread *Thread, name string, recv Value, args Tuple, kwargs []Tuple) (Value, error)) *Builtin {
 	return &Builtin{name: name, fn: fn}
 }
 
@@ -867,10 +938,9 @@ func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kw
 //
 //	f = "abc".index; f("a"); f("b")
 //
-// In the common case, the receiver is bound only during the call,
-// but this still results in the creation of a temporary method closure:
-//
-//	"abc".index("a")
+// For fused method calls ("abc".index("a")), the compiler and interpreter
+// bypass BindReceiver using [HasBuiltinMethods] to invoke the unbound method
+// without allocating a temporary method closure.
 func (b *Builtin) BindReceiver(recv Value) *Builtin {
 	return &Builtin{name: b.name, fn: b.fn, recv: recv}
 }
@@ -913,8 +983,9 @@ func (x *Dict) Union(y *Dict) *Dict {
 	return z
 }
 
-func (d *Dict) Attr(name string) (Value, error) { return builtinAttr(d, name, dictMethods) }
-func (d *Dict) AttrNames() []string             { return builtinAttrNames(dictMethods) }
+func (d *Dict) Attr(name string) (Value, error)    { return builtinAttr(d, name) }
+func (d *Dict) BuiltinMethod(name string) *Builtin { return dictMethods[name] }
+func (d *Dict) AttrNames() []string                { return builtinAttrNames(dictMethods) }
 
 func (x *Dict) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Dict)
@@ -1001,8 +1072,9 @@ func (l *List) Slice(start, end, step int) Value {
 	return NewList(list)
 }
 
-func (l *List) Attr(name string) (Value, error) { return builtinAttr(l, name, listMethods) }
-func (l *List) AttrNames() []string             { return builtinAttrNames(listMethods) }
+func (l *List) Attr(name string) (Value, error)    { return builtinAttr(l, name) }
+func (l *List) BuiltinMethod(name string) *Builtin { return listMethods[name] }
+func (l *List) AttrNames() []string                { return builtinAttrNames(listMethods) }
 
 func (l *List) Iterate() Iterator {
 	if !l.frozen {
@@ -1202,8 +1274,9 @@ func (s *Set) Freeze()                                { s.ht.freeze() }
 func (s *Set) Hash() (uint32, error)                  { return 0, fmt.Errorf("unhashable type: set") }
 func (s *Set) Truth() Bool                            { return s.Len() > 0 }
 
-func (s *Set) Attr(name string) (Value, error) { return builtinAttr(s, name, setMethods) }
-func (s *Set) AttrNames() []string             { return builtinAttrNames(setMethods) }
+func (s *Set) Attr(name string) (Value, error)    { return builtinAttr(s, name) }
+func (s *Set) BuiltinMethod(name string) *Builtin { return setMethods[name] }
+func (s *Set) AttrNames() []string                { return builtinAttrNames(setMethods) }
 
 func (x *Set) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Set)
@@ -1665,8 +1738,9 @@ func (b Bytes) Hash() (uint32, error) { return String(b).Hash() }
 func (b Bytes) Len() int              { return len(b) }
 func (b Bytes) Index(i int) Value     { return b[i : i+1] }
 
-func (b Bytes) Attr(name string) (Value, error) { return builtinAttr(b, name, bytesMethods) }
-func (b Bytes) AttrNames() []string             { return builtinAttrNames(bytesMethods) }
+func (b Bytes) Attr(name string) (Value, error)    { return builtinAttr(b, name) }
+func (b Bytes) BuiltinMethod(name string) *Builtin { return bytesMethods[name] }
+func (b Bytes) AttrNames() []string                { return builtinAttrNames(bytesMethods) }
 
 func (b Bytes) Slice(start, end, step int) Value {
 	if step == 1 {

--- a/starlarkstruct/module.go
+++ b/starlarkstruct/module.go
@@ -29,9 +29,9 @@ func (m *Module) Type() string                             { return "module" }
 // MakeModule may be used as the implementation of a Starlark built-in
 // function, module(name, **kwargs). It returns a new module with the
 // specified name and members.
-func MakeModule(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func MakeModule(thread *starlark.Thread, fnname string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var name string
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, nil, 1, &name); err != nil {
+	if err := starlark.UnpackPositionalArgs(fnname, args, nil, 1, &name); err != nil {
 		return nil, err
 	}
 	members := make(starlark.StringDict, len(kwargs))

--- a/starlarkstruct/struct.go
+++ b/starlarkstruct/struct.go
@@ -36,9 +36,9 @@ import (
 // An application can add 'struct' to the Starlark environment like so:
 //
 //	globals := starlark.StringDict{
-//		"struct":  starlark.NewBuiltin("struct", starlarkstruct.Make),
+//		"struct":  starlark.NewBuiltinMethod("struct", starlarkstruct.Make),
 //	}
-func Make(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func Make(_ *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) > 0 {
 		return nil, fmt.Errorf("struct: unexpected positional arguments")
 	}

--- a/starlarkstruct/struct_test.go
+++ b/starlarkstruct/struct_test.go
@@ -20,8 +20,8 @@ func Test(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 	filename := filepath.Join(testdata, "testdata/struct.star")
 	predeclared := starlark.StringDict{
-		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
-		"gensym": starlark.NewBuiltin("gensym", gensym),
+		"struct": starlark.NewBuiltinMethod("struct", starlarkstruct.Make),
+		"gensym": starlark.NewBuiltinMethod("gensym", gensym),
 	}
 	if _, err := starlark.ExecFile(thread, filename, nil, predeclared); err != nil {
 		if err, ok := err.(*starlark.EvalError); ok {
@@ -40,7 +40,7 @@ func load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 }
 
 // gensym is a built-in function that generates a unique symbol.
-func gensym(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func gensym(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var name string
 	if err := starlark.UnpackArgs("gensym", args, kwargs, "name", &name); err != nil {
 		return nil, err

--- a/starlarktest/starlarktest.go
+++ b/starlarktest/starlarktest.go
@@ -64,12 +64,12 @@ var (
 func LoadAssertModule() (starlark.StringDict, error) {
 	once.Do(func() {
 		predeclared := starlark.StringDict{
-			"error":    starlark.NewBuiltin("error", error_),
-			"catch":    starlark.NewBuiltin("catch", catch),
-			"matches":  starlark.NewBuiltin("matches", matches),
-			"module":   starlark.NewBuiltin("module", starlarkstruct.MakeModule),
-			"_freeze":  starlark.NewBuiltin("freeze", freeze),
-			"_floateq": starlark.NewBuiltin("floateq", floateq),
+			"error":    starlark.NewBuiltinMethod("error", error_),
+			"catch":    starlark.NewBuiltinMethod("catch", catch),
+			"matches":  starlark.NewBuiltinMethod("matches", matches),
+			"module":   starlark.NewBuiltinMethod("module", starlarkstruct.MakeModule),
+			"_freeze":  starlark.NewBuiltinMethod("freeze", freeze),
+			"_floateq": starlark.NewBuiltinMethod("floateq", floateq),
 		}
 		thread := new(starlark.Thread)
 		assert, assertErr = starlark.ExecFile(thread, "assert.star", assertFileSrc, predeclared)
@@ -79,7 +79,7 @@ func LoadAssertModule() (starlark.StringDict, error) {
 
 // catch(f) evaluates f() and returns its evaluation error message
 // if it failed or None if it succeeded.
-func catch(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func catch(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var fn starlark.Callable
 	if err := starlark.UnpackArgs("catch", args, kwargs, "fn", &fn); err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func catch(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kw
 }
 
 // matches(pattern, str) reports whether string str matches the regular expression pattern.
-func matches(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func matches(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var pattern, str string
 	if err := starlark.UnpackArgs("matches", args, kwargs, "pattern", &pattern, "str", &str); err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func matches(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, 
 }
 
 // error(x) reports an error to the Go test framework.
-func error_(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func error_(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("error: got %d arguments, want 1", len(args))
 	}
@@ -122,7 +122,7 @@ func error_(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, k
 }
 
 // freeze(x) freezes its operand.
-func freeze(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func freeze(thread *starlark.Thread, _ string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("freeze does not accept keyword arguments")
 	}
@@ -134,9 +134,9 @@ func freeze(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, k
 }
 
 // floateq(x, y) reports whether two floats are within 1 ULP of each other.
-func floateq(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func floateq(thread *starlark.Thread, name string, _ starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var xf, yf starlark.Float
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 2, &xf, &yf); err != nil {
+	if err := starlark.UnpackPositionalArgs(name, args, kwargs, 2, &xf, &yf); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR is a sketch of an alternative approach to supporting faster dispatch of calls to built-in methods by avoiding the allocation ordinarily performed by Builtin.BindReceiver when a method is accessed and then immediately called as in x.f().

The bound Builtin is still created for g=x.f; g(), or for values of x that do not implement the new HasBuiltinMethods interface.

Details:
- Adds HasBuiltinMethods interface implemented by all the interpreter's built-in types.

- Builtin now has two constructors: the legacy NewBuiltin, and a new one (NewBuiltinMethod) that takes a function of this form

    func(thread *Thread, name string, recv Value, args Tuple, kwargs []Tuple) (Value, error)
                         -----------------------
  avoiding the need to allocate a Builtin with BindReceiver. The legacy one wraps the newone, possibly at an unacceptable allocation cost since it calls BindReceiver on every legacy call. The recv argument is nil for non-method calls.

- x.f(...) is compiled to recv, callable = ATTR_METHOD(x, "f") res = CALL(recv, callable, ...) with a special CALL flag indicating that a receiver is provided because we used ATTR_METHOD. If callable is an unbound Builtin, the recv operand is used; otherwise the Builtin supplies the receiver.

WORK IN PROGRESS.  Some parts are slop.