### PR TITLE
starlark: implement bytes + bytes to fix spec violation

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -774,6 +774,10 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			if y, ok := y.(String); ok {
 				return x + y, nil
 			}
+		case Bytes:
+			if y, ok := y.(Bytes); ok {
+				return x + y, nil
+			}
 		case Int:
 			switch y := y.(type) {
 			case Int:

--- a/starlark/testdata/bytes.star
+++ b/starlark/testdata/bytes.star
@@ -111,6 +111,34 @@ assert.eq(ord(b"a"), 97)
 assert.fails(lambda: ord(b"ab"), "ord: bytes has length 2, want 1")
 assert.fails(lambda: ord(b""), "ord: bytes has length 0, want 1")
 
+# concatenation (bytes + bytes)
+# The compiler folds sums of adjacent bytes literals, so each case below keeps at
+# least one operand dynamic to exercise the interpreter instead.
+def concat(x, y):
+    return x + y
+
+assert.eq(concat(b"abc", b"def"), b"abc" + b"def")  # both paths must agree
+assert.eq(goodbye + b"!", b"goodbye!")
+assert.eq(b"good" + goodbye[4:], goodbye)
+assert.eq(b"[" + goodbye + b"]", b"[goodbye]")
+assert.eq(goodbye + empty, goodbye)
+assert.eq(empty + goodbye, goodbye)
+
+# Concatenation joins bytes, not text: no UTF-8 validation or U+FFFD replacement.
+assert.eq(concat(b"\xed\xb0", b"\x80"), b"\xed\xb0\x80")
+assert.eq(concat(hello[:-1], hello[-1:]), hello)  # split mid-code-point
+
+def inplace():
+    x = goodbye
+    x += b"!"
+    return x
+
+assert.eq(inplace(), b"goodbye!")
+
+# Text and binary strings do not mix.
+assert.fails(lambda: goodbye + "!", "unknown binary op: bytes \\+ string")
+assert.fails(lambda: "!" + goodbye, "unknown binary op: string \\+ bytes")
+
 # repeat (bytes * int)
 assert.eq(goodbye * 3, b"goodbyegoodbyegoodbye")
 assert.eq(3 * goodbye, b"goodbyegoodbyegoodbye")


### PR DESCRIPTION
The canonical Starlark specification requires that two bytes values may be concatenated with the `+` operator:

> [Two bytes values may be concatenated with the `+` operator.](https://github.com/bazelbuild/starlark/blob/c0af0ea03dc90d3bbc021394b693e6957cc15030/spec.md#L851)

and [lists it in the summary of arithmetic operations](https://github.com/bazelbuild/starlark/blob/c0af0ea03dc90d3bbc021394b693e6957cc15030/spec.md#L2239-L2243) alongside the other concatenations:

```
Concatenation
   string + string
    bytes + bytes
     list + list
    tuple + tuple
```

(Links are pinned to bazelbuild/starlark@c0af0ea. The text has been there since [bazelbuild/starlark#161](https://github.com/bazelbuild/starlark/pull/161), merged 2021-02-11, so this is a conformance gap rather than a language proposal.)

But `Binary`'s `PLUS` case has no `Bytes` arm, so the operation fails at run time with:

```
unknown binary op: bytes + bytes
```

The compiler's constant folder already treats `bytes + bytes` as valid: `addable` reports `'b'` for `BYTES` literals and `add` concatenates them. So the two paths disagree, and the same expression succeeds or fails depending on whether its operands are adjacent literals:

```python
b"abc" + b"def"                        # b"abcdef"
(lambda a, b: a + b)(b"abc", b"def")   # unknown binary op: bytes + bytes
```

Both the folder and `Binary`'s `Bytes` arms for `*` and `in` were added when the type was introduced in ebe61bd7; only `+` was left out. It went unnoticed because `testdata/bytes.star` has no concatenation assertions at all.

Since `INPLACE_ADD` falls through to `Binary` for non-list operands, this also fixes `bytes += bytes`.

`Bytes` is defined as `type Bytes string`, so `x + y` needs no conversion. Falling through when `y` is not `Bytes` preserves the existing (and correct) `bytes + string` and `string + bytes` errors.

The new tests keep at least one operand dynamic in every case, since constant folding would otherwise satisfy them without exercising the interpreter, and they assert that the folded and evaluated paths agree. Each of the nine new assertions was checked to fail before the fix and pass after.
