### PR TITLE
Make Message & RepeatedField comparable

### DIFF
--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -84,8 +84,7 @@
 package proto
 
 // TODO(adonovan): Go and Starlark API improvements:
-// - Make Message and RepeatedField comparable.
-//   (NOTE: proto.Equal works only with generated message types.)
+// - Make RepeatedField comparable.
 // - Support oneof, any. But not messageset if we can avoid it.
 // - Support "well-known types".
 // - Defend against cycles in object graph.
@@ -94,9 +93,9 @@ package proto
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
-	"unsafe"
 	_ "unsafe" // for linkname hack
 
 	"google.golang.org/protobuf/encoding/prototext"
@@ -671,7 +670,8 @@ func toStarlark1(typ protoreflect.FieldDescriptor, x protoreflect.Value, frozen 
 
 // A Message is a Starlark value that wraps a protocol message.
 //
-// Two Messages are equivalent if and only if they are identical.
+// Two Messages are equivalent if and only if they wrap the same mutable
+// protobuf message object.
 //
 // When a Message value becomes frozen, a Starlark program may
 // not modify the underlying protocol message, nor any Message
@@ -686,7 +686,10 @@ func (m *Message) Message() protoreflect.ProtoMessage { return m.msg.Interface()
 
 func (m *Message) desc() protoreflect.MessageDescriptor { return m.msg.Descriptor() }
 
-var _ starlark.HasSetField = (*Message)(nil)
+var (
+	_ starlark.HasSetField = (*Message)(nil)
+	_ starlark.Comparable  = (*Message)(nil)
+)
 
 // Unmarshal parses the data as a binary protocol message of the specified type,
 // and returns it as a new Starlark message value.
@@ -762,10 +765,41 @@ func (m *Message) String() string {
 	return buf.String()
 }
 
-func (m *Message) Type() string                { return "proto.Message" }
-func (m *Message) Truth() starlark.Bool        { return true }
-func (m *Message) Freeze()                     { *m.frozen = true }
-func (m *Message) Hash() (h uint32, err error) { return uint32(uintptr(unsafe.Pointer(m))), nil } // identity hash
+func (m *Message) Type() string         { return "proto.Message" }
+func (m *Message) Truth() starlark.Bool { return true }
+func (m *Message) Freeze()              { *m.frozen = true }
+
+// messageIdentity identifies the mutable protobuf object wrapped by m.
+// Generated and dynamic protobuf messages are pointer-backed. For unusual
+// non-pointer implementations, fall back to the identity of the wrapper.
+func (m *Message) messageIdentity() (reflect.Type, uintptr) {
+	v := reflect.ValueOf(m.msg.Interface())
+	if v.IsValid() && v.Kind() == reflect.Pointer && !v.IsNil() {
+		return v.Type(), v.Pointer()
+	}
+	v = reflect.ValueOf(m)
+	return v.Type(), v.Pointer()
+}
+
+func (m *Message) Hash() (h uint32, err error) {
+	_, ptr := m.messageIdentity()
+	return uint32(ptr), nil
+}
+
+func (m *Message) CompareSameType(op syntax.Token, y_ starlark.Value, _ int) (bool, error) {
+	y := y_.(*Message)
+	xType, xPtr := m.messageIdentity()
+	yType, yPtr := y.messageIdentity()
+	equal := xType == yType && xPtr == yPtr
+	switch op {
+	case syntax.EQL:
+		return equal, nil
+	case syntax.NEQ:
+		return !equal, nil
+	default:
+		return false, fmt.Errorf("%s %s %s not implemented", m.Type(), op, y.Type())
+	}
+}
 
 // Attr returns the value of this message's field of the specified name.
 // Extension fields are not accessible this way as their names are not unique.
@@ -940,6 +974,7 @@ type RepeatedField struct {
 
 var (
 	_ starlark.Iterable    = (*RepeatedField)(nil)
+	_ starlark.Container   = (*RepeatedField)(nil)
 	_ starlark.HasSetIndex = (*RepeatedField)(nil)
 	_ starlark.HasAttrs    = (*RepeatedField)(nil)
 )
@@ -1012,6 +1047,20 @@ func (rf *RepeatedField) Freeze()               { *rf.frozen = true }
 func (rf *RepeatedField) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", rf.Type()) }
 func (rf *RepeatedField) Index(i int) starlark.Value {
 	return toStarlark1(rf.typ, rf.list.Get(i), rf.frozen)
+}
+
+// Has reports whether y is equal to an element of the repeated field.
+func (rf *RepeatedField) Has(y starlark.Value) (bool, error) {
+	for i := 0; i < rf.Len(); i++ {
+		equal, err := starlark.Equal(rf.Index(i), y)
+		if err != nil {
+			return false, err
+		}
+		if equal {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 func (rf *RepeatedField) Iterate() starlark.Iterator {
 	if !*rf.frozen {

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -84,7 +84,6 @@
 package proto
 
 // TODO(adonovan): Go and Starlark API improvements:
-// - Make RepeatedField comparable.
 // - Support oneof, any. But not messageset if we can avoid it.
 // - Support "well-known types".
 // - Defend against cycles in object graph.
@@ -963,8 +962,9 @@ func typeString(fdesc protoreflect.FieldDescriptor) string {
 // type using conversions similar to those done when calling a
 // MessageDescriptor to construct a message.
 //
-// TODO(adonovan): make RepeatedField implement starlark.Comparable.
-// Should the comparison include type, or be defined on the elements alone?
+// Two RepeatedFields compare equal if they have the same protobuf element
+// type and their elements compare equal. RepeatedFields of the same type
+// support lexicographic ordered comparison, like Starlark lists.
 type RepeatedField struct {
 	typ       protoreflect.FieldDescriptor // only for type information, not field name
 	list      protoreflect.List
@@ -975,6 +975,7 @@ type RepeatedField struct {
 var (
 	_ starlark.Iterable    = (*RepeatedField)(nil)
 	_ starlark.Container   = (*RepeatedField)(nil)
+	_ starlark.Comparable  = (*RepeatedField)(nil)
 	_ starlark.HasSetIndex = (*RepeatedField)(nil)
 	_ starlark.HasAttrs    = (*RepeatedField)(nil)
 )
@@ -1062,6 +1063,61 @@ func (rf *RepeatedField) Has(y starlark.Value) (bool, error) {
 	}
 	return false, nil
 }
+
+func (x *RepeatedField) CompareSameType(op syntax.Token, y_ starlark.Value, depth int) (bool, error) {
+	y := y_.(*RepeatedField)
+	if x.Type() != y.Type() {
+		switch op {
+		case syntax.EQL:
+			return false, nil
+		case syntax.NEQ:
+			return true, nil
+		default:
+			return false, fmt.Errorf("%s %s %s not implemented", x.Type(), op, y.Type())
+		}
+	}
+
+	if x.Len() != y.Len() && (op == syntax.EQL || op == syntax.NEQ) {
+		return op == syntax.NEQ, nil
+	}
+
+	// Compare lexicographically, like list
+	for i := 0; i < x.Len() && i < y.Len(); i++ {
+		xelem, yelem := x.Index(i), y.Index(i)
+		equal, err := starlark.EqualDepth(xelem, yelem, depth-1)
+		if err != nil {
+			return false, err
+		}
+		if !equal {
+			switch op {
+			case syntax.EQL:
+				return false, nil
+			case syntax.NEQ:
+				return true, nil
+			default:
+				return starlark.CompareDepth(op, xelem, yelem, depth-1)
+			}
+		}
+	}
+
+	switch op {
+	case syntax.EQL:
+		return x.Len() == y.Len(), nil
+	case syntax.NEQ:
+		return x.Len() != y.Len(), nil
+	case syntax.LT:
+		return x.Len() < y.Len(), nil
+	case syntax.LE:
+		return x.Len() <= y.Len(), nil
+	case syntax.GT:
+		return x.Len() > y.Len(), nil
+	case syntax.GE:
+		return x.Len() >= y.Len(), nil
+	default:
+		return false, fmt.Errorf("%s %s %s not implemented", x.Type(), op, y.Type())
+	}
+}
+
 func (rf *RepeatedField) Iterate() starlark.Iterator {
 	if !*rf.frozen {
 		rf.itercount++

--- a/lib/proto/proto_test.go
+++ b/lib/proto/proto_test.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -55,5 +56,107 @@ test_membership()
 
 	if _, err := starlark.ExecFile(&starlark.Thread{Name: t.Name()}, "membership.star", src, predeclared); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRepeatedFieldComparison(t *testing.T) {
+	predeclared := starlark.StringDict{
+		"FileDescriptorProto": MessageDescriptor{Desc: (&descriptorpb.FileDescriptorProto{}).ProtoReflect().Descriptor()},
+		"FileDescriptorSet":   MessageDescriptor{Desc: (&descriptorpb.FileDescriptorSet{}).ProtoReflect().Descriptor()},
+	}
+	const src = `
+strings_a = FileDescriptorProto(
+    dependency = ["alpha", "beta"],
+    public_dependency = [3, 8],
+    weak_dependency = [3, 8],
+)
+strings_b = FileDescriptorProto(dependency = ["alpha", "beta"])
+strings_c = FileDescriptorProto(dependency = ["alpha", "gamma"])
+strings_prefix = FileDescriptorProto(dependency = ["alpha"])
+empty = FileDescriptorProto()
+
+def test_scalar_comparison():
+    if strings_a.dependency != strings_b.dependency:
+        fail("equal repeated strings compare unequal")
+    if strings_a.dependency == strings_c.dependency:
+        fail("unequal repeated strings compare equal")
+    if not strings_a.dependency < strings_c.dependency:
+        fail("lexicographic < failed")
+    if not strings_a.dependency <= strings_c.dependency:
+        fail("lexicographic <= failed")
+    if not strings_c.dependency > strings_a.dependency:
+        fail("lexicographic > failed")
+    if not strings_c.dependency >= strings_a.dependency:
+        fail("lexicographic >= failed")
+    if not strings_a.dependency <= strings_b.dependency:
+        fail("equal fields do not satisfy <=")
+    if not strings_a.dependency >= strings_b.dependency:
+        fail("equal fields do not satisfy >=")
+    if not strings_prefix.dependency < strings_a.dependency:
+        fail("prefix ordering failed")
+    if not strings_a.dependency > strings_prefix.dependency:
+        fail("reverse prefix ordering failed")
+    if empty.dependency != FileDescriptorProto().dependency:
+        fail("empty repeated fields compare unequal")
+    if strings_a.public_dependency != strings_a.weak_dependency:
+        fail("same element type from different fields compares unequal")
+    if empty.dependency == empty.public_dependency:
+        fail("different repeated types compare equal")
+    if strings_a.dependency == ["alpha", "beta"]:
+        fail("repeated field compares equal to list")
+
+shared = FileDescriptorProto(name = "shared.proto")
+messages_a = FileDescriptorSet(file = [shared])
+messages_b = FileDescriptorSet(file = [shared])
+messages_copy = FileDescriptorSet(file = [FileDescriptorProto(name = "shared.proto")])
+
+def test_message_comparison():
+    if messages_a.file != messages_b.file:
+        fail("fields containing the same message compare unequal")
+    if messages_a.file == messages_copy.file:
+        fail("fields containing distinct messages compare equal")
+    if not messages_a.file <= messages_b.file:
+        fail("equal message fields do not satisfy <=")
+    if not messages_a.file >= messages_b.file:
+        fail("equal message fields do not satisfy >=")
+
+test_scalar_comparison()
+test_message_comparison()
+`
+
+	thread := &starlark.Thread{Name: t.Name()}
+	globals, err := starlark.ExecFile(thread, "comparison.star", src, predeclared)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			name: "order different repeated types",
+			expr: "empty.dependency < empty.public_dependency",
+			want: "not implemented",
+		},
+		{
+			name: "order distinct messages",
+			expr: "messages_a.file < messages_copy.file",
+			want: "proto.Message < proto.Message not implemented",
+		},
+		{
+			name: "unhashable",
+			expr: "{strings_a.dependency: None}",
+			want: "unhashable: proto.repeated<string>",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := starlark.Eval(thread, "comparison.star", test.expr, globals); err == nil {
+				t.Fatalf("%s succeeded, want error containing %q", test.expr, test.want)
+			} else if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("%s: got error %q, want error containing %q", test.expr, err, test.want)
+			}
+		})
 	}
 }

--- a/lib/proto/proto_test.go
+++ b/lib/proto/proto_test.go
@@ -1,0 +1,59 @@
+package proto
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"go.starlark.net/starlark"
+)
+
+func TestRepeatedFieldMembership(t *testing.T) {
+	predeclared := starlark.StringDict{
+		"FileDescriptorProto": MessageDescriptor{Desc: (&descriptorpb.FileDescriptorProto{}).ProtoReflect().Descriptor()},
+		"FileDescriptorSet":   MessageDescriptor{Desc: (&descriptorpb.FileDescriptorSet{}).ProtoReflect().Descriptor()},
+	}
+	const src = `
+def test_membership():
+    msg = FileDescriptorProto(
+        dependency = ["alpha", "beta"],
+        public_dependency = [3, 8],
+    )
+
+    if "alpha" not in msg.dependency:
+        fail("present string is missing")
+    if "missing" in msg.dependency:
+        fail("absent string is present")
+    if "anything" in FileDescriptorProto().dependency:
+        fail("empty repeated field contains a value")
+    if 8 not in msg.public_dependency:
+        fail("present integer is missing")
+    if 5 in msg.public_dependency:
+        fail("absent integer is present")
+
+    messages = FileDescriptorSet(file = [msg])
+    item = messages.file[0]
+    if item != messages.file[0]:
+        fail("wrappers of the same message do not compare equal")
+    if item not in messages.file:
+        fail("repeated field does not contain its message")
+    by_message = {item: "found"}
+    if by_message[messages.file[0]] != "found":
+        fail("wrappers of the same message have inconsistent hashes")
+
+    copy = FileDescriptorProto(
+        dependency = ["alpha", "beta"],
+        public_dependency = [3, 8],
+    )
+    if copy == item:
+        fail("separately constructed messages compare equal")
+    if copy in messages.file:
+        fail("repeated field contains a distinct message")
+
+test_membership()
+`
+
+	if _, err := starlark.ExecFile(&starlark.Thread{Name: t.Name()}, "membership.star", src, predeclared); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Hey, I drafted Comparable implementation for Message & RepeatedField, so they could be used with `in` Starlark operator. What do you think?