### PR TITLE
add exact per-thread call profiler

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -50,6 +50,14 @@ type Thread struct {
 	// The default behavior is to call thread.Cancel("too many steps").
 	OnMaxSteps func(thread *Thread)
 
+	// Profile records the exact wall time of Starlark calls on this thread.
+	// A nil Profile disables this profiling. See [ExecProfile].
+	//
+	// Like Print and Load, set or clear Profile only from the goroutine that
+	// runs this thread. Read it only after execution returns to the calling
+	// Go code.
+	Profile *ExecProfile
+
 	// Steps a count of abstract computation steps executed
 	// by this thread. It is incremented by the interpreter. It may be used
 	// as a measure of the approximate cost of Starlark execution, by
@@ -67,6 +75,8 @@ type Thread struct {
 
 	// proftime holds the accumulated execution time since the last profile event.
 	proftime time.Duration
+
+	execProfileSpan profileSpan
 }
 
 // ExecutionSteps returns the current value of Steps.
@@ -186,10 +196,13 @@ func (d StringDict) Has(key string) bool { _, ok := d[key]; return ok }
 // A frame records a call to a Starlark function (including module toplevel)
 // or a built-in function or method.
 type frame struct {
-	callable  Callable // current function (or toplevel) or built-in
-	pc        uint32   // program counter (Starlark frames only)
-	locals    []Value  // local variables (Starlark frames only)
-	spanStart int64    // start time of current profiler span
+	callable                 Callable       // current function (or toplevel) or built-in
+	pc                       uint32         // program counter (Starlark frames only)
+	callerProfileSpanWasOpen bool           // whether the caller's ExecProfile span was open
+	locals                   []Value        // local variables (Starlark frames only)
+	spanStart                int64          // start time of current profiler span
+	execProfileRecord        *profileRecord // ExecProfile record for this call, or nil
+	execProfileCallStart     int64          // time when this ExecProfile call started
 }
 
 // Position returns the source position of the current point of execution in this frame.
@@ -1224,16 +1237,27 @@ func Call(thread *Thread, fn Value, args Tuple, kwargs []Tuple) (Value, error) {
 	// Use defer to ensure that panics from built-ins
 	// pass through the interpreter without leaving
 	// it in a bad state.
+	//
+	// Set up this cleanup before recordCallPush. That function calls the
+	// callable's Name and Position methods. A custom Callable can panic in
+	// those methods, so the cleanup must already be in place.
 	defer func() {
 		thread.endProfSpan()
+		thread.recordCallPop(fr)
 
 		// clear out any references
 		// TODO(adonovan): opt: zero fr.Locals and
 		// reuse it if it is large enough.
+		//
+		// Frames are reused. Always clear execProfileRecord. recordCallPop
+		// uses it to tell whether a call was recorded. An old value could
+		// count a later call twice.
 		*fr = frame{}
 
 		thread.stack = thread.stack[:len(thread.stack)-1] // pop
 	}()
+
+	thread.recordCallPush(fr)
 
 	result, err := c.CallInternal(thread, args, kwargs)
 

--- a/starlark/execprofile.go
+++ b/starlark/execprofile.go
@@ -1,0 +1,430 @@
+package starlark
+
+// ExecProfile measures Starlark calls on one thread at a time. It does not
+// profile all threads at once. Use StartProfile to profile all threads.
+//
+// ExecProfile measures time at four points in the interpreter:
+//
+//	recordCallPush  a call frame was added (Call)
+//	recordCallPop   a call frame will be removed (Call cleanup)
+//	recordPause     the top frame will wait for another call or a load
+//	recordResume    the top frame is running again (CALL and LOAD)
+//
+// A span is a period when one frame is the innermost frame running Starlark
+// code. A thread can have only one open span. Spans do not overlap, so their
+// total time cannot be longer than the full execution time. A frame's spans
+// add up to its Self time.
+//
+// Push and pop must also end spans. Go code in a built-in can call Starlark
+// without a CALL opcode. Push stops the built-in's span, so the called
+// function's time is not part of the built-in's Self. Pop starts the
+// built-in's span again because no opcode will do it. The frame records
+// whether a span was open before push. This keeps loads and normal calls
+// paused when needed.
+//
+// Each point first checks whether profiling is active and returns immediately
+// when it is not.
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+	"unsafe"
+
+	"go.starlark.net/syntax"
+)
+
+// An ExecProfile records the exact wall time of Starlark calls on one thread.
+// Assign one to [Thread.Profile] before execution:
+//
+//	var p starlark.ExecProfile
+//	thread.Profile = &p
+//	_, err := starlark.ExecFile(thread, filename, src, nil)
+//	p.WriteText(os.Stderr)
+//
+// The zero value is ready to use. It keeps data from each execution until it
+// is replaced or cleared. There is no reset method. Use a new ExecProfile to
+// start with no data. Do not copy an ExecProfile value after its first use;
+// the same pointer may be reused as described below.
+//
+// # Identity
+//
+// Each row represents one function. ExecProfile identifies the function by
+// its address, name, and definition position. More than one row can have the
+// same name. For example, every module's top-level code is named
+// "<toplevel>". Use both Name and Position when looking for a row. A callable
+// with no definition position, such as a built-in, uses "<builtin>". Built-ins
+// with different names or implementations use separate rows.
+//
+// Two calls use the same row only when all three values match. This groups
+// repeated calls to one function. It also groups calls to the same compiled
+// [Program] when [ExecProfile.Merge] combines profiles from several threads.
+// A later execution of a file can also use the same row if Go freed the old
+// compiled code and reused its address. Other functions from separate
+// compilations use separate rows. ExecProfile does not keep a Callable in
+// memory. It copies only the address, name, and position.
+//
+// # Threads
+//
+// ExecProfile follows the same goroutine rules as [Thread.Print] and
+// [Thread.Load]. Set or clear it only from the goroutine that runs the thread.
+// Read it only after execution has returned to the calling Go code.
+//
+// You can attach the same *ExecProfile to several threads if their executions
+// do not overlap. For example, a Load function can create a child thread while
+// its parent thread waits. Do not attach the same *ExecProfile to threads that
+// run at the same time. This can produce wrong profile data and may stop the
+// process with "fatal error: concurrent map writes". For parallel executions,
+// use one ExecProfile per thread. Combine them later with [ExecProfile.Merge].
+//
+// # Attaching during execution
+//
+// You can attach, remove, or replace an ExecProfile while code is running.
+// A profile records a call only if it was attached when the call started.
+// A profile attached later does not count a call that is already running.
+// That call has no Calls, Cum, or Max. It keeps only the Self time recorded
+// while the profile was attached.
+//
+// Changing the field cannot end the open span at that exact time. When the
+// span ends, its time is added to the old profile.
+//
+// # Cost
+//
+// Profiling adds clock reads and a map lookup to each call. After a function's
+// first call, later calls do not allocate.
+//
+// A thread with no ExecProfile does a few field checks for each call. It does
+// not make extra function calls. No background work continues after the last
+// reference to an ExecProfile is removed.
+//
+// See also [StartProfile]. It samples all threads and writes a profile in
+// pprof format. The two profilers can run at the same time. Their results
+// differ when a built-in calls Starlark. Only ExecProfile leaves the called
+// Starlark function's time out of the built-in's Self.
+type ExecProfile struct {
+	records map[profileKey]*profileRecord
+}
+
+// A profile key needs the address, name, and definition position. The address
+// alone is not enough. Two Builtins can use the same implementation but have
+// different names. Also, callables with no available address all use zero.
+//
+// The address and name are still not enough. Go can free compiled code and
+// reuse its funcode address. Without the position, functions with the same
+// name from separate compilations could use one row. The key copies a filename
+// and two numbers from the callable. It does not keep the callable in memory.
+//
+// Store the parts of the position instead of a syntax.Position. A
+// syntax.Position stores its filename through a pointer, so equal filenames
+// could compare as different pointers.
+type profileKey struct {
+	address  uintptr
+	name     string
+	filename string
+	line     int32
+	column   int32
+}
+
+type profileRecord struct {
+	owner          *ExecProfile
+	key            profileKey
+	position       syntax.Position
+	completedCalls int64
+	selfTime       time.Duration
+	cumulativeTime time.Duration
+	maxTime        time.Duration
+	activeCalls    int
+}
+
+type profileSpan struct {
+	record    *profileRecord
+	startedAt int64 // zero when closed
+}
+
+func (s *profileSpan) isOpen() bool { return s.startedAt != 0 }
+
+func (s *profileSpan) close(now int64) {
+	if !s.isOpen() {
+		return
+	}
+	s.record.selfTime += time.Duration(now - s.startedAt)
+	s.record = nil
+	s.startedAt = 0
+}
+
+func (s *profileSpan) open(record *profileRecord, now int64) {
+	s.record = record
+	s.startedAt = now
+}
+
+// Do not store c. It could keep a lambda's free variables in memory as long as
+// the profile remains in memory.
+func (p *ExecProfile) recordForCallable(c Callable) *profileRecord {
+	address, position := profileIdentity(c)
+	key := profileKey{
+		address:  address,
+		name:     c.Name(),
+		filename: position.Filename(),
+		line:     position.Line,
+		column:   position.Col,
+	}
+	if rec, ok := p.records[key]; ok {
+		return rec
+	}
+	if p.records == nil {
+		p.records = make(map[profileKey]*profileRecord)
+	}
+	rec := &profileRecord{owner: p, key: key, position: position}
+	p.records[key] = rec
+	return rec
+}
+
+// A zero address means that the callable's address is not available. Common
+// callable types skip reflection because this code runs for every call.
+func profileIdentity(c Callable) (uintptr, syntax.Position) {
+	switch c := c.(type) {
+	case *Function:
+		return uintptr(unsafe.Pointer(c.funcode)), c.funcode.Pos
+	case *Builtin:
+		return reflect.ValueOf(c.fn).Pointer(), builtinPosition
+	}
+	var address uintptr
+	if v := reflect.ValueOf(c); v.Type().Kind() == reflect.Pointer {
+		address = v.Pointer()
+	}
+	return address, callablePosition(c)
+}
+
+func callablePosition(c Callable) syntax.Position {
+	if c, ok := c.(callableWithPosition); ok {
+		return c.Position()
+	}
+	return builtinPosition
+}
+
+var builtinPosition = syntax.MakePosition(&builtinFilename, 0, 0)
+
+func (thread *Thread) recordCallPush(fr *frame) {
+	// Close any span left open by a removed profile.
+	if thread.Profile == nil && !thread.execProfileSpan.isOpen() {
+		return
+	}
+	thread.recordCallPushImpl(fr)
+}
+
+func (thread *Thread) recordCallPushImpl(fr *frame) {
+	now := nanotime()
+	callerSpanWasOpen := thread.execProfileSpan.isOpen()
+	thread.execProfileSpan.close(now)
+	p := thread.Profile
+	if p == nil {
+		return
+	}
+
+	record := p.recordForCallable(fr.callable)
+	record.activeCalls++
+	fr.execProfileRecord = record
+	fr.execProfileCallStart = now
+	fr.callerProfileSpanWasOpen = callerSpanWasOpen
+	thread.execProfileSpan.open(record, now)
+}
+
+func (thread *Thread) recordCallPop(fr *frame) {
+	// The frame keeps this state after profile removal or a panic. In both
+	// cases, activeCalls must still go down.
+	if fr.execProfileRecord == nil {
+		return
+	}
+	thread.recordCallPopImpl(fr)
+}
+
+func (thread *Thread) recordCallPopImpl(fr *frame) {
+	now := nanotime()
+	thread.execProfileSpan.close(now)
+
+	record := fr.execProfileRecord
+	record.activeCalls--
+	if thread.Profile == record.owner {
+		elapsed := time.Duration(now - fr.execProfileCallStart)
+		record.completedCalls++
+		if elapsed > record.maxTime {
+			record.maxTime = elapsed
+		}
+		if record.activeCalls == 0 {
+			record.cumulativeTime += elapsed
+		}
+	}
+
+	// When Load runs Starlark again on the same thread, its caller must stay
+	// paused. If the profile changed, do not resume a caller from the old one.
+	if fr.callerProfileSpanWasOpen && len(thread.stack) > 1 {
+		if caller := thread.frameAt(1); caller.execProfileRecord.owner == thread.Profile {
+			thread.execProfileSpan.open(caller.execProfileRecord, now)
+		}
+	}
+}
+
+func (thread *Thread) recordPause() {
+	if !thread.execProfileSpan.isOpen() {
+		return
+	}
+	thread.recordPauseImpl()
+}
+
+func (thread *Thread) recordPauseImpl() {
+	thread.execProfileSpan.close(nanotime())
+}
+
+func (thread *Thread) recordResume() {
+	if thread.Profile == nil || thread.execProfileSpan.isOpen() {
+		return
+	}
+	thread.recordResumeImpl()
+}
+
+func (thread *Thread) recordResumeImpl() {
+	if fr := thread.frameAt(0); fr.execProfileRecord != nil && fr.execProfileRecord.owner == thread.Profile {
+		thread.execProfileSpan.open(fr.execProfileRecord, nanotime())
+	}
+}
+
+// An ExecProfileRecord reports the execution of one function.
+type ExecProfileRecord struct {
+	// Name is the function's Callable.Name. It is "<toplevel>" for a module's
+	// top-level code.
+	Name string
+
+	// Position is where the function is defined. A function with no definition
+	// position uses the special filename "<builtin>".
+	Position syntax.Position
+
+	// Calls is the number of calls that ended. This includes a normal return,
+	// an error, or a panic.
+	Calls int64
+
+	// Self is the time when this function was the innermost function running
+	// Starlark code. It does not include time in functions it calls or time
+	// waiting for Load. It includes time in Print and OnMaxSteps because those
+	// callbacks do not create frames.
+	Self time.Duration
+
+	// Cum is the total time from the start to the end of each outermost call to
+	// this function. For recursive calls, it counts the full outer call once.
+	// It includes time in called functions and time waiting for Load. The
+	// top-level function's Cum is close to the full execution time.
+	Cum time.Duration
+
+	// Max is the longest time from the start to the end of one completed call.
+	Max time.Duration
+}
+
+// Records returns one record for each function, sorted by decreasing Self.
+func (p *ExecProfile) Records() []ExecProfileRecord {
+	// Two built-ins can have the same Self, Name, and Position. Use their
+	// addresses as the final sort value so map iteration order does not change
+	// the result.
+	sorted := make([]*profileRecord, 0, len(p.records))
+	for _, rec := range p.records {
+		sorted = append(sorted, rec)
+	}
+	slices.SortFunc(sorted, func(x, y *profileRecord) int {
+		return cmp.Or(
+			cmp.Compare(y.selfTime, x.selfTime),
+			cmp.Compare(x.key.name, y.key.name),
+			comparePosition(x.position, y.position),
+			cmp.Compare(x.key.address, y.key.address),
+		)
+	})
+
+	records := make([]ExecProfileRecord, len(sorted))
+	for i, rec := range sorted {
+		records[i] = ExecProfileRecord{
+			Name:     rec.key.name,
+			Position: rec.position,
+			Calls:    rec.completedCalls,
+			Self:     rec.selfTime,
+			Cum:      rec.cumulativeTime,
+			Max:      rec.maxTime,
+		}
+	}
+	return records
+}
+
+// A syntax.Position stores a filename through a pointer. Compare the filename
+// text so equal filenames are treated as equal.
+func comparePosition(p, q syntax.Position) int {
+	if pf, qf := p.Filename(), q.Filename(); pf != qf {
+		return strings.Compare(pf, qf)
+	}
+	if p.Line != q.Line {
+		return int(p.Line - q.Line)
+	}
+	return int(p.Col - q.Col)
+}
+
+// Merge combines q's records into p. Neither profile may be attached to a
+// running thread.
+func (p *ExecProfile) Merge(q *ExecProfile) {
+	if q == nil || q == p {
+		return
+	}
+	for key, qrec := range q.records {
+		prec, ok := p.records[key]
+		if !ok {
+			if p.records == nil {
+				p.records = make(map[profileKey]*profileRecord)
+			}
+			prec = &profileRecord{owner: p, key: key, position: qrec.position}
+			p.records[key] = prec
+		}
+		prec.completedCalls += qrec.completedCalls
+		prec.selfTime += qrec.selfTime
+		prec.cumulativeTime += qrec.cumulativeTime
+		if qrec.maxTime > prec.maxTime {
+			prec.maxTime = qrec.maxTime
+		}
+	}
+}
+
+// WriteText writes a plain-text table to w. It writes a header, followed by
+// one line for each record in the order returned by [ExecProfile.Records]:
+//
+//	calls       self        cum        max  function
+//	 1042    41.52ms    41.52ms     2.10ms  sha256 (hash.star:12:1)
+//	    3    12.08ms    93.11ms    40.07ms  build (build.star:7:1)
+//	    1   830.00µs   140.20ms   140.20ms  <toplevel> (main.star:1:1)
+//
+// WriteText has no options. To change the columns, units, order, or filters,
+// call [ExecProfile.Records] and format the records in the calling code.
+func (p *ExecProfile) WriteText(w io.Writer) error {
+	// Build the full table before making one write to w.
+	buf := new(strings.Builder)
+	fmt.Fprintf(buf, "%8s %10s %10s %10s  %s\n", "calls", "self", "cum", "max", "function")
+	for _, rec := range p.Records() {
+		fmt.Fprintf(buf, "%8d %10s %10s %10s  %s (%s)\n",
+			rec.Calls,
+			profileDuration(rec.Self),
+			profileDuration(rec.Cum),
+			profileDuration(rec.Max),
+			rec.Name,
+			rec.Position)
+	}
+	_, err := io.WriteString(w, buf.String())
+	return err
+}
+
+func profileDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.2fµs", float64(d)/float64(time.Microsecond))
+	case d < time.Second:
+		return fmt.Sprintf("%.2fms", float64(d)/float64(time.Millisecond))
+	}
+	return fmt.Sprintf("%.2fs", d.Seconds())
+}

--- a/starlark/execprofile_bench_test.go
+++ b/starlark/execprofile_bench_test.go
@@ -1,0 +1,98 @@
+package starlark_test
+
+// This file measures allocations and call overhead with execution
+// profiling both disabled and enabled.
+
+import (
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func prepareWarmedCallBenchmark(tb testing.TB, profile *starlark.ExecProfile) (*starlark.Thread, starlark.Value) {
+	tb.Helper()
+	_, prog, err := starlark.SourceProgram("bench.star", "def f():\n\tpass\n", func(string) bool { return false })
+	if err != nil {
+		tb.Fatal(err)
+	}
+	thread := new(starlark.Thread)
+	globals, err := prog.Init(thread, nil)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	f := globals["f"]
+	thread.Profile = profile
+	if _, err := starlark.Call(thread, f, nil, nil); err != nil {
+		tb.Fatal(err)
+	}
+	return thread, f
+}
+
+func TestProfileNoAlloc(t *testing.T) {
+	allocs := func(profile *starlark.ExecProfile) float64 {
+		thread, f := prepareWarmedCallBenchmark(t, profile)
+		return testing.AllocsPerRun(1000, func() {
+			if _, err := starlark.Call(thread, f, nil, nil); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	off := allocs(nil)
+	on := allocs(new(starlark.ExecProfile))
+
+	if on > off {
+		t.Errorf("%v allocs/call with a profile attached, %v without: the profiler must not allocate per call", on, off)
+	}
+}
+
+func benchmarkCall(b *testing.B, profile *starlark.ExecProfile) {
+	thread, f := prepareWarmedCallBenchmark(b, profile)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := starlark.Call(thread, f, nil, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProfileOff(b *testing.B) { benchmarkCall(b, nil) }
+
+func BenchmarkProfileOn(b *testing.B) { benchmarkCall(b, new(starlark.ExecProfile)) }
+
+func benchmarkScriptCalls(b *testing.B, profile *starlark.ExecProfile) {
+	const calls = 1000
+	_, prog, err := starlark.SourceProgram("bench.star",
+		"def f():\n\tpass\n\ndef loop(r):\n\tfor _ in r:\n\t\tf()\n", func(string) bool { return false })
+	if err != nil {
+		b.Fatal(err)
+	}
+	thread := new(starlark.Thread)
+	globals, err := prog.Init(thread, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := make(starlark.Tuple, calls)
+	for i := range r {
+		r[i] = starlark.MakeInt(i)
+	}
+	loop := globals["loop"]
+	args := starlark.Tuple{r}
+	thread.Profile = profile
+	if _, err := starlark.Call(thread, loop, args, nil); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := starlark.Call(thread, loop, args, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*calls), "ns/call")
+}
+
+func BenchmarkProfileScriptOff(b *testing.B) { benchmarkScriptCalls(b, nil) }
+func BenchmarkProfileScriptOn(b *testing.B) {
+	benchmarkScriptCalls(b, new(starlark.ExecProfile))
+}

--- a/starlark/execprofile_internal_test.go
+++ b/starlark/execprofile_internal_test.go
@@ -1,0 +1,42 @@
+package starlark
+
+// This file checks profiler details that the exported API does not show. For
+// example, it checks that rows with equal sort values always use the same
+// order.
+
+import (
+	"testing"
+
+	"go.starlark.net/syntax"
+)
+
+func TestProfileRecordsTotalOrder(t *testing.T) {
+	firstFilename, secondFilename := "dup.star", "dup.star"
+	positions := []syntax.Position{
+		callablePosition(NewBuiltin("dup", nil)),
+		syntax.MakePosition(&firstFilename, 1, 1),
+		syntax.MakePosition(&secondFilename, 1, 1),
+	}
+
+	var p ExecProfile
+	p.records = make(map[profileKey]*profileRecord)
+	for i, address := range []uintptr{0x30, 0x10, 0x20} {
+		key := profileKey{address: address, name: "dup"}
+		p.records[key] = &profileRecord{
+			owner:          &p,
+			key:            key,
+			position:       positions[i],
+			completedCalls: int64(i + 1),
+		}
+	}
+
+	first := p.Records()
+	for i := range 50 {
+		got := p.Records()
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("render %d record %d = %+v, first render had %+v", i, j, got[j], first[j])
+			}
+		}
+	}
+}

--- a/starlark/execprofile_lifecycle_test.go
+++ b/starlark/execprofile_lifecycle_test.go
@@ -1,0 +1,341 @@
+package starlark_test
+
+// This file checks what happens when calls end because of errors or panics. It
+// also checks Load, profile changes while code is running, and panics from
+// custom Callables.
+
+import (
+	"testing"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+func TestProfileUnwinding(t *testing.T) {
+	boom := starlark.NewBuiltin("boom", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		panic("boom")
+	})
+	spin := starlark.NewBuiltin("spin", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		thread.Cancel("test")
+		return starlark.None, nil
+	})
+
+	for _, test := range []struct {
+		name              string
+		src               string
+		unwindingFunction string
+	}{
+		{"error", "def f():\n\tfail('nope')\n\nf()\n", "fail"},
+		{"cancel", "def f():\n\tspin()\n\tspin()\n\nf()\n", "spin"},
+		{"panic", "def f():\n\tboom()\n\nf()\n", "boom"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			predeclared := starlark.StringDict{"boom": boom, "spin": spin}
+			var p starlark.ExecProfile
+			thread := &starlark.Thread{Profile: &p}
+
+			start := time.Now()
+			func() {
+				defer func() { recover() }()
+				if _, err := starlark.ExecFile(thread, "unwind.star", test.src, predeclared); err == nil {
+					t.Error("execution succeeded, want failure")
+				}
+			}()
+			wall := time.Since(start)
+
+			recs := uniqueRecordsByName(t, &p)
+			for _, name := range []string{"<toplevel>", "f", test.unwindingFunction} {
+				if _, ok := recs[name]; !ok {
+					t.Errorf("no record for %s; got %v", name, p.Records())
+				}
+			}
+			if got := recs["<toplevel>"].Calls; got != 1 {
+				t.Errorf("<toplevel>.Calls = %d, want 1 (all frames must be removed after failure)", got)
+			}
+			if got := recs["f"].Calls; got != 1 {
+				t.Errorf("f.Calls = %d, want 1", got)
+			}
+			checkFullyRecordedProfileInvariants(t, &p, wall)
+
+			thread.Uncancel()
+			if _, err := starlark.ExecFile(thread, "after.star", "def f():\n\tpass\n\nf()\n", nil); err != nil {
+				t.Fatalf("thread could not run code after failure: %v", err)
+			}
+			if got := totalCallsByName(&p, "<toplevel>"); got != 2 {
+				t.Errorf("<toplevel>.Calls = %d after second execution, want 2", got)
+			}
+		})
+	}
+}
+
+func TestProfileLoad(t *testing.T) {
+	const nap = 20 * time.Millisecond
+	const module = `
+def helper():
+	nap()
+
+helper()
+x = 1
+`
+	predeclared := starlark.StringDict{"nap": sleepingBuiltin("nap", nap)}
+
+	var p starlark.ExecProfile
+	parent := &starlark.Thread{Profile: &p}
+	parent.Load = func(thread *starlark.Thread, name string) (starlark.StringDict, error) {
+		child := &starlark.Thread{Load: thread.Load, Profile: thread.Profile}
+		return starlark.ExecFile(child, name, module, predeclared)
+	}
+
+	start := time.Now()
+	if _, err := starlark.ExecFile(parent, "main.star", `load("mod.star", "x")`, predeclared); err != nil {
+		t.Fatal(err)
+	}
+	wall := time.Since(start)
+
+	if _, ok := findRecordByNameAndFile(&p, "helper", "mod.star"); !ok {
+		t.Errorf("no record for the loaded module's helper:\n%v", p.Records())
+	}
+	if _, ok := findRecordByNameAndFile(&p, "<toplevel>", "mod.star"); !ok {
+		t.Errorf("no record for the loaded module's toplevel:\n%v", p.Records())
+	}
+	main, ok := findRecordByNameAndFile(&p, "<toplevel>", "main.star")
+	if !ok {
+		t.Fatalf("no record for the main toplevel:\n%v", p.Records())
+	}
+	if main.Cum < nap {
+		t.Errorf("main toplevel Cum = %v, want >= %v (Cum includes the load)", main.Cum, nap)
+	}
+	if main.Self >= nap {
+		t.Errorf("main toplevel Self = %v, want < %v (Self excludes the load)", main.Self, nap)
+	}
+	checkFullyRecordedProfileInvariants(t, &p, wall)
+}
+
+func TestProfileAttachMidRun(t *testing.T) {
+	var p starlark.ExecProfile
+	attach := starlark.NewBuiltin("attach", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		thread.Profile = &p
+		return starlark.None, nil
+	})
+
+	const src = `
+def before():
+	pass
+
+def after():
+	pass
+
+before()
+attach()
+after()
+after()
+`
+	thread := new(starlark.Thread)
+	if _, err := starlark.ExecFile(thread, "attach.star", src, starlark.StringDict{"attach": attach}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := totalCallsByName(&p, "after"); got != 2 {
+		t.Errorf("after.Calls = %d, want 2 (calls that start after the profile is attached are recorded)", got)
+	}
+	for _, name := range []string{"before", "attach", "<toplevel>"} {
+		if got := totalCallsByName(&p, name); got != 0 {
+			t.Errorf("%s.Calls = %d, want 0 (the call started before the profile was attached)", name, got)
+		}
+	}
+}
+
+func TestProfileDetachMidRun(t *testing.T) {
+	detach := starlark.NewBuiltin("detach", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		thread.Profile = nil
+		return starlark.None, nil
+	})
+
+	const src = `
+def before():
+	pass
+
+def after():
+	pass
+
+before()
+detach()
+after()
+`
+	p := executeProfiledFile(t, "detach.star", src, starlark.StringDict{"detach": detach})
+
+	if got := totalCallsByName(p, "before"); got != 1 {
+		t.Errorf("before.Calls = %d, want 1", got)
+	}
+	if got := totalCallsByName(p, "after"); got != 0 {
+		t.Errorf("after.Calls = %d, want 0 (calls after the profile is removed are not recorded)", got)
+	}
+	// The top-level call started before the profile was removed and ended after
+	// it. The call is not counted. Self still includes span parts that ended
+	// while the profile was attached.
+	top, ok := findRecordByNameAndFile(p, "<toplevel>", "detach.star")
+	if !ok {
+		t.Fatalf("no record for the toplevel:\n%v", p.Records())
+	}
+	if top.Calls != 0 {
+		t.Errorf("<toplevel>.Calls = %d, want 0 (the call ended after the profile was removed)", top.Calls)
+	}
+	if top.Self <= 0 {
+		t.Errorf("<toplevel>.Self = %v, want > 0 (spans closed while attached are kept)", top.Self)
+	}
+}
+
+func TestProfileLoadOnSameThread(t *testing.T) {
+	const embedderWorkDuration = 40 * time.Millisecond
+	const module = `
+def helper():
+	pass
+
+helper()
+x = 1
+`
+	var p starlark.ExecProfile
+	thread := &starlark.Thread{Profile: &p}
+	thread.Load = func(th *starlark.Thread, name string) (starlark.StringDict, error) {
+		globals, err := starlark.ExecFile(th, name, module, nil)
+		time.Sleep(embedderWorkDuration)
+		return globals, err
+	}
+
+	start := time.Now()
+	if _, err := starlark.ExecFile(thread, "main.star", `load("mod.star", "x")`, nil); err != nil {
+		t.Fatal(err)
+	}
+	wall := time.Since(start)
+
+	if _, ok := findRecordByNameAndFile(&p, "helper", "mod.star"); !ok {
+		t.Errorf("the module run by Load was not recorded:\n%v", p.Records())
+	}
+	main, ok := findRecordByNameAndFile(&p, "<toplevel>", "main.star")
+	if !ok {
+		t.Fatalf("no record for the main toplevel:\n%v", p.Records())
+	}
+	if main.Self >= embedderWorkDuration {
+		t.Errorf("main toplevel Self = %v, want < %v: Self excludes time blocked in Load", main.Self, embedderWorkDuration)
+	}
+	if main.Cum < embedderWorkDuration {
+		t.Errorf("main toplevel Cum = %v, want >= %v", main.Cum, embedderWorkDuration)
+	}
+	checkFullyRecordedProfileInvariants(t, &p, wall)
+}
+
+func TestProfileDetachStopsCharging(t *testing.T) {
+	var start time.Time
+	var detachedAt time.Duration
+	detach := starlark.NewBuiltin("detach", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		thread.Profile = nil
+		detachedAt = time.Since(start)
+		return starlark.None, nil
+	})
+
+	// The code after detach() must not make calls. It runs in f's frame, so only
+	// f's span could include its time. A call would end the span and hide the
+	// bug that this test checks.
+	const src = `
+def f():
+	detach()
+	x = "y" * 10000000
+	x = "y" * 10000000
+	x = "y" * 10000000
+	x = "y" * 10000000
+	x = "y" * 10000000
+	return x
+
+f()
+`
+	var p starlark.ExecProfile
+	thread := &starlark.Thread{Profile: &p}
+
+	start = time.Now()
+	if _, err := starlark.ExecFile(thread, "detach.star", src, starlark.StringDict{"detach": detach}); err != nil {
+		t.Fatal(err)
+	}
+	wall := time.Since(start)
+
+	postDetachWork := wall - detachedAt
+	if postDetachWork < time.Millisecond {
+		t.Fatalf("only %v of work ran after detach; the test needs more work to check this case", postDetachWork)
+	}
+	if got, limit := totalProfileSelf(&p), detachedAt+postDetachWork/2; got > limit {
+		t.Errorf("recorded Self totals %v, want <= %v: Self must not include work after detach at %v",
+			got, limit, detachedAt)
+	}
+}
+
+func TestProfileSwapMidRun(t *testing.T) {
+	const nap = 30 * time.Millisecond
+	var q starlark.ExecProfile
+	swap := starlark.NewBuiltin("swap", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		thread.Profile = &q
+		return starlark.None, nil
+	})
+
+	const src = `
+def after():
+	nap()
+
+swap()
+after()
+a = "y" * 10000000
+b = "y" * 10000000
+c = "y" * 10000000
+d = "y" * 10000000
+e = "y" * 10000000
+`
+	predeclared := starlark.StringDict{"swap": swap, "nap": sleepingBuiltin("nap", nap)}
+	p := executeProfiledFile(t, "swap.star", src, predeclared)
+
+	if got := totalCallsByName(&q, "after"); got != 1 {
+		t.Errorf("q recorded after.Calls = %d, want 1", got)
+	}
+	if got := totalCallsByName(p, "after"); got != 0 {
+		t.Errorf("p recorded after.Calls = %d, want 0 (p had been removed)", got)
+	}
+	if got, limit := totalProfileSelf(p), 5*time.Millisecond; got > limit {
+		t.Errorf("p recorded %v of Self, want <= %v: p was removed at swap()", got, limit)
+	}
+	if got := totalProfileSelf(&q); got < nap {
+		t.Errorf("q recorded %v of Self, want >= %v", got, nap)
+	}
+}
+
+type panickingNameCallable struct{}
+
+func (panickingNameCallable) Name() string          { panic("panickingNameCallable.Name") }
+func (panickingNameCallable) String() string        { return "panickingNameCallable" }
+func (panickingNameCallable) Type() string          { return "panickingNameCallable" }
+func (panickingNameCallable) Freeze()               {}
+func (panickingNameCallable) Truth() starlark.Bool  { return true }
+func (panickingNameCallable) Hash() (uint32, error) { return 0, nil }
+func (panickingNameCallable) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, nil
+}
+
+func TestProfilePanicInCallableMethod(t *testing.T) {
+	var p starlark.ExecProfile
+	thread := &starlark.Thread{Profile: &p}
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("no panic from callable with a panicking Name method")
+			}
+		}()
+		starlark.Call(thread, panickingNameCallable{}, nil, nil)
+	}()
+
+	if got := thread.CallStackDepth(); got != 0 {
+		t.Errorf("CallStackDepth = %d after the panic, want 0: the frame must be removed while handling the panic", got)
+	}
+	if _, err := starlark.ExecFile(thread, "after.star", "def f():\n\tpass\n\nf()\n", nil); err != nil {
+		t.Fatalf("thread unusable after the panic: %v", err)
+	}
+	if got := totalCallsByName(&p, "f"); got != 1 {
+		t.Errorf("f.Calls = %d, want 1", got)
+	}
+}

--- a/starlark/execprofile_reporting_test.go
+++ b/starlark/execprofile_reporting_test.go
@@ -1,0 +1,257 @@
+package starlark_test
+
+// This file checks text reports, merged profiles, parallel runs, and use with
+// the pprof profiler.
+
+import (
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+func TestProfileWriteText(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var p starlark.ExecProfile
+		report := renderProfile(t, &p)
+		lines := strings.Split(strings.TrimSuffix(report, "\n"), "\n")
+		if len(lines) != 1 {
+			t.Fatalf("empty profile wrote %d lines, want 1 (header only):\n%s", len(lines), report)
+		}
+		for _, col := range []string{"calls", "self", "cum", "max", "function"} {
+			if !strings.Contains(lines[0], col) {
+				t.Errorf("header %q does not include column %q", lines[0], col)
+			}
+		}
+	})
+
+	const src = `def outer():
+	return inner()
+
+def inner():
+	return 1
+
+outer()
+`
+	p := executeProfiledFile(t, "report.star", src, nil)
+	got := renderProfile(t, p)
+
+	t.Run("rows", func(t *testing.T) {
+		lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+		if want := len(p.Records()) + 1; len(lines) != want {
+			t.Fatalf("wrote %d lines, want %d (one header + one per record):\n%s", len(lines), want, got)
+		}
+		for _, want := range []string{"outer (report.star:1:1)", "inner (report.star:4:1)", "<toplevel> (report.star:1:1)"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("report does not include %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("order", func(t *testing.T) {
+		recs := p.Records()
+		for i := 1; i < len(recs); i++ {
+			x, y := recs[i-1], recs[i]
+			if x.Self < y.Self {
+				t.Errorf("record %d (%v) sorts before %d (%v); want highest Self first", i-1, x.Self, i, y.Self)
+			}
+			if x.Self == y.Self && x.Name > y.Name {
+				t.Errorf("equal Self: %q sorts before %q; want Name in increasing order", x.Name, y.Name)
+			}
+		}
+		var offsets []int
+		for _, rec := range recs {
+			i := strings.Index(got, rec.Name+" (")
+			if i < 0 {
+				t.Fatalf("report does not include a row for %s:\n%s", rec.Name, got)
+			}
+			offsets = append(offsets, i)
+		}
+		for i := 1; i < len(offsets); i++ {
+			if offsets[i-1] > offsets[i] {
+				t.Errorf("report row %d appears after row %d; want Records order:\n%s", i-1, i, got)
+			}
+		}
+	})
+
+	t.Run("stable", func(t *testing.T) {
+		for i := range 20 {
+			if report := renderProfile(t, p); report != got {
+				t.Fatalf("render %d differs from the first:\n%s\nwant:\n%s", i, report, got)
+			}
+		}
+	})
+
+	t.Run("writeError", func(t *testing.T) {
+		want := errors.New("disk full")
+		if err := p.WriteText(failingWriter{want}); !errors.Is(err, want) {
+			t.Errorf("WriteText to a failing writer = %v, want %v", err, want)
+		}
+		if renderProfile(t, p) != got {
+			t.Error("profile changed after a failed write")
+		}
+	})
+}
+
+type failingWriter struct{ err error }
+
+func (w failingWriter) Write(p []byte) (int, error) { return 0, w.err }
+
+func renderProfile(t *testing.T, p *starlark.ExecProfile) string {
+	t.Helper()
+	var buf strings.Builder
+	if err := p.WriteText(&buf); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func TestProfileMerge(t *testing.T) {
+	_, shared, err := starlark.SourceProgram("shared.star", "def f():\n\tpass\n\nf()\nf()\n", func(string) bool { return false })
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, only, err := starlark.SourceProgram("only.star", "def g():\n\tpass\n\ng()\n", func(string) bool { return false })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(p *starlark.ExecProfile, prog *starlark.Program) {
+		t.Helper()
+		thread := &starlark.Thread{Profile: p}
+		if _, err := prog.Init(thread, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var a, b starlark.ExecProfile
+	run(&a, shared)
+	run(&b, shared)
+	run(&b, only)
+
+	before, ok := findRecordByNameAndFile(&b, "f", "shared.star")
+	if !ok {
+		t.Fatal("b has no record for f")
+	}
+	aBefore, ok := findRecordByNameAndFile(&a, "f", "shared.star")
+	if !ok {
+		t.Fatal("a has no record for f")
+	}
+
+	a.Merge(&b)
+
+	merged, ok := findRecordByNameAndFile(&a, "f", "shared.star")
+	if !ok {
+		t.Fatal("merged profile has no record for f")
+	}
+	if want := aBefore.Calls + before.Calls; merged.Calls != want {
+		t.Errorf("merged f.Calls = %d, want %d", merged.Calls, want)
+	}
+	if want := aBefore.Self + before.Self; merged.Self != want {
+		t.Errorf("merged f.Self = %v, want %v", merged.Self, want)
+	}
+	if want := aBefore.Cum + before.Cum; merged.Cum != want {
+		t.Errorf("merged f.Cum = %v, want %v", merged.Cum, want)
+	}
+	if want := max(aBefore.Max, before.Max); merged.Max != want {
+		t.Errorf("merged f.Max = %v, want %v (the larger, not the sum)", merged.Max, want)
+	}
+	if _, ok := findRecordByNameAndFile(&a, "g", "only.star"); !ok {
+		t.Errorf("merge did not keep the record for g:\n%v", a.Records())
+	}
+
+	after, _ := findRecordByNameAndFile(&b, "f", "shared.star")
+	if after != before {
+		t.Errorf("Merge modified its argument: %+v, was %+v", after, before)
+	}
+
+	beforeDegenerate := a.Records()
+	a.Merge(&a)
+	if got := a.Records(); !slices.Equal(got, beforeDegenerate) {
+		t.Errorf("Merge(self) changed the profile:\n got %v\nwant %v", got, beforeDegenerate)
+	}
+	a.Merge(nil)
+	if got := a.Records(); !slices.Equal(got, beforeDegenerate) {
+		t.Errorf("Merge(nil) changed the profile:\n got %v\nwant %v", got, beforeDegenerate)
+	}
+}
+
+func TestProfileParallel(t *testing.T) {
+	_, prog, err := starlark.SourceProgram("par.star", "def f():\n\tpass\n\n[f() for _ in range(20)]\n", func(string) bool { return false })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const threads = 8
+	profiles := make([]starlark.ExecProfile, threads)
+	var wg sync.WaitGroup
+	for i := range profiles {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			thread := &starlark.Thread{Profile: &profiles[i]}
+			if _, err := prog.Init(thread, nil); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	var total starlark.ExecProfile
+	for i := range profiles {
+		total.Merge(&profiles[i])
+	}
+	if got, want := totalCallsByName(&total, "f"), int64(threads*20); got != want {
+		t.Errorf("merged f.Calls = %d, want %d", got, want)
+	}
+}
+
+func TestProfileWithPprof(t *testing.T) {
+	pprof, err := os.CreateTemp(t.TempDir(), "profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pprof.Close()
+	if err := starlark.StartProfile(pprof); err != nil {
+		t.Fatal(err)
+	}
+
+	const src = `
+def f(n):
+	x, y = 1, 1
+	for i in range(n):
+		x, y = y, x + y
+	return y
+
+f(200000)
+`
+	var p starlark.ExecProfile
+	thread := &starlark.Thread{Profile: &p}
+
+	start := time.Now()
+	_, execErr := starlark.ExecFile(thread, "both.star", src, nil)
+	wall := time.Since(start)
+
+	if err := starlark.StopProfile(); err != nil {
+		t.Fatal(err)
+	}
+	if execErr != nil {
+		t.Fatal(execErr)
+	}
+
+	if got := totalCallsByName(&p, "f"); got != 1 {
+		t.Errorf("f.Calls = %d, want 1", got)
+	}
+	checkFullyRecordedProfileInvariants(t, &p, wall)
+
+	if fi, err := pprof.Stat(); err != nil {
+		t.Fatal(err)
+	} else if fi.Size() == 0 {
+		t.Error("the pprof profiler wrote nothing")
+	}
+}

--- a/starlark/execprofile_test.go
+++ b/starlark/execprofile_test.go
@@ -1,0 +1,354 @@
+package starlark_test
+
+// This file checks the main profiling behavior. It covers callable identity,
+// call counts, Self and Cum time, recursive calls, calls back into Starlark,
+// and profiles used for more than one execution.
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func TestProfileCounts(t *testing.T) {
+	const src = `
+def f(n):
+	return n + 1
+
+sq = lambda x: x * x
+
+def g():
+	total = 0
+	for i in range(3):
+		total += f(sq(i))
+	return "n".upper() + str(bump(total))
+
+g()
+`
+	predeclared := starlark.StringDict{"bump": new(incrementingCallable)}
+	p := executeProfiledFile(t, "prof.star", src, predeclared)
+	want := map[string]int64{
+		"<toplevel>": 1,
+		"g":          1,
+		"f":          3,
+		"lambda":     3,
+		"range":      1,
+		"str":        1,
+		"upper":      1,
+		"bump":       1,
+	}
+	got := make(map[string]int64)
+	for _, r := range p.Records() {
+		got[r.Name] = r.Calls
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("call counts (-want +got):\n%s", diff)
+	}
+}
+
+type incrementingCallable struct{ calls int }
+
+func (b *incrementingCallable) Name() string          { return "bump" }
+func (b *incrementingCallable) String() string        { return "bump" }
+func (b *incrementingCallable) Type() string          { return "incrementingCallable" }
+func (b *incrementingCallable) Freeze()               {}
+func (b *incrementingCallable) Truth() starlark.Bool  { return true }
+func (b *incrementingCallable) Hash() (uint32, error) { return 0, nil }
+func (b *incrementingCallable) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	b.calls++
+	n, err := starlark.AsInt32(args[0])
+	if err != nil {
+		return nil, err
+	}
+	return starlark.MakeInt(n + 1), nil
+}
+
+func executeProfiledFile(t *testing.T, filename, src string, predeclared starlark.StringDict) *starlark.ExecProfile {
+	t.Helper()
+	p := new(starlark.ExecProfile)
+	thread := &starlark.Thread{Profile: p}
+	if _, err := starlark.ExecFile(thread, filename, src, predeclared); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func uniqueRecordsByName(t *testing.T, p *starlark.ExecProfile) map[string]starlark.ExecProfileRecord {
+	t.Helper()
+	byName := make(map[string]starlark.ExecProfileRecord)
+	for _, rec := range p.Records() {
+		if _, dup := byName[rec.Name]; dup {
+			t.Fatalf("two records named %s; test needs distinct names", rec.Name)
+		}
+		byName[rec.Name] = rec
+	}
+	return byName
+}
+
+func totalCallsByName(p *starlark.ExecProfile, name string) int64 {
+	var calls int64
+	for _, rec := range p.Records() {
+		if rec.Name == name {
+			calls += rec.Calls
+		}
+	}
+	return calls
+}
+
+func checkFullyRecordedProfileInvariants(t *testing.T, p *starlark.ExecProfile, wall time.Duration) {
+	t.Helper()
+	var totalSelf time.Duration
+	for _, rec := range p.Records() {
+		if rec.Self < 0 || rec.Cum < 0 || rec.Max < 0 || rec.Calls < 0 {
+			t.Errorf("%s: negative field in %+v", rec.Name, rec)
+		}
+		if rec.Self > rec.Cum {
+			t.Errorf("%s: Self (%v) > Cum (%v)", rec.Name, rec.Self, rec.Cum)
+		}
+		if rec.Max > rec.Cum {
+			t.Errorf("%s: Max (%v) > Cum (%v)", rec.Name, rec.Max, rec.Cum)
+		}
+		if rec.Cum > wall {
+			t.Errorf("%s: Cum (%v) > wall (%v)", rec.Name, rec.Cum, wall)
+		}
+		totalSelf += rec.Self
+	}
+	if totalSelf > wall {
+		t.Errorf("sum of Self (%v) exceeds wall time (%v)", totalSelf, wall)
+	}
+}
+
+func sleepingBuiltin(name string, d time.Duration) *starlark.Builtin {
+	return starlark.NewBuiltin(name, func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		time.Sleep(d)
+		return starlark.None, nil
+	})
+}
+
+func TestProfileReentry(t *testing.T) {
+	const nap = 20 * time.Millisecond
+
+	var builtinWork, callbackWork time.Duration
+	work := starlark.NewBuiltin("work", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		ownStart := time.Now()
+		time.Sleep(nap)
+		builtinWork = time.Since(ownStart)
+
+		callbackStart := time.Now()
+		for range 2 {
+			if _, err := starlark.Call(thread, args[0], nil, nil); err != nil {
+				return nil, err
+			}
+		}
+		callbackWork = time.Since(callbackStart)
+		return starlark.None, nil
+	})
+
+	const src = `
+def slow():
+	nap()
+
+work(slow)
+`
+	predeclared := starlark.StringDict{"work": work, "nap": sleepingBuiltin("nap", nap)}
+
+	start := time.Now()
+	p := executeProfiledFile(t, "reentry.star", src, predeclared)
+	wall := time.Since(start)
+
+	recs := uniqueRecordsByName(t, p)
+	if got := recs["slow"].Calls; got != 2 {
+		t.Errorf("slow.Calls = %d, want 2", got)
+	}
+	if got := recs["nap"].Self; got < 2*nap {
+		t.Errorf("nap.Self = %v, want >= %v", got, 2*nap)
+	}
+	if got := recs["work"].Self; got < builtinWork {
+		t.Errorf("work.Self = %v, want >= the %v spent in the built-in", got, builtinWork)
+	}
+	if got, limit := recs["work"].Self, builtinWork+callbackWork/2; got >= limit {
+		t.Errorf("work.Self = %v, want < %v: it slept %v and spent %v in callbacks",
+			got, limit, builtinWork, callbackWork)
+	}
+	if got, want := recs["work"].Cum, builtinWork+callbackWork; got < want {
+		t.Errorf("work.Cum = %v, want >= %v", got, want)
+	}
+	checkFullyRecordedProfileInvariants(t, p, wall)
+}
+
+func TestProfileRecursion(t *testing.T) {
+	const nap = 10 * time.Millisecond
+	recursive := &syntax.FileOptions{Recursion: true}
+
+	t.Run("direct", func(t *testing.T) {
+		const src = `
+def countdown(n):
+	nap()
+	if n > 0:
+		countdown(n - 1)
+
+countdown(3)
+`
+		predeclared := starlark.StringDict{"nap": sleepingBuiltin("nap", nap)}
+		var p starlark.ExecProfile
+		thread := &starlark.Thread{Profile: &p}
+
+		start := time.Now()
+		if _, err := starlark.ExecFileOptions(recursive, thread, "recursion.star", src, predeclared); err != nil {
+			t.Fatal(err)
+		}
+		wall := time.Since(start)
+
+		recs := uniqueRecordsByName(t, &p)
+		if got := recs["countdown"].Calls; got != 4 {
+			t.Errorf("countdown.Calls = %d, want 4", got)
+		}
+		if got := recs["countdown"].Cum; got > wall {
+			t.Errorf("countdown.Cum = %v, want <= wall %v", got, wall)
+		}
+		if got := recs["countdown"].Cum; got < 4*nap {
+			t.Errorf("countdown.Cum = %v, want >= %v", got, 4*nap)
+		}
+		if got, cum := recs["countdown"].Max, recs["countdown"].Cum; got != cum {
+			t.Errorf("countdown.Max = %v, want %v (the full time of the outermost call)", got, cum)
+		}
+		checkFullyRecordedProfileInvariants(t, &p, wall)
+	})
+
+	t.Run("mutual", func(t *testing.T) {
+		const src = `
+def even(n):
+	nap()
+	return True if n == 0 else odd(n - 1)
+
+def odd(n):
+	nap()
+	return False if n == 0 else even(n - 1)
+
+even(3)
+`
+		predeclared := starlark.StringDict{"nap": sleepingBuiltin("nap", nap)}
+		var p starlark.ExecProfile
+		thread := &starlark.Thread{Profile: &p}
+
+		start := time.Now()
+		if _, err := starlark.ExecFileOptions(recursive, thread, "mutual.star", src, predeclared); err != nil {
+			t.Fatal(err)
+		}
+		wall := time.Since(start)
+
+		recs := uniqueRecordsByName(t, &p)
+		if got := recs["even"].Calls; got != 2 {
+			t.Errorf("even.Calls = %d, want 2", got)
+		}
+		if got := recs["odd"].Calls; got != 2 {
+			t.Errorf("odd.Calls = %d, want 2", got)
+		}
+		checkFullyRecordedProfileInvariants(t, &p, wall)
+	})
+}
+
+func findRecordByNameAndFile(p *starlark.ExecProfile, name, filename string) (starlark.ExecProfileRecord, bool) {
+	for _, rec := range p.Records() {
+		if rec.Name == name && rec.Position.Filename() == filename {
+			return rec, true
+		}
+	}
+	return starlark.ExecProfileRecord{}, false
+}
+
+func TestProfileAccumulates(t *testing.T) {
+	const src = `
+def f():
+	pass
+
+f()
+f()
+`
+	var p starlark.ExecProfile
+	thread := &starlark.Thread{Profile: &p}
+	for range 3 {
+		if _, err := starlark.ExecFile(thread, "accum.star", src, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := totalCallsByName(&p, "f"); got != 6 {
+		t.Errorf("f.Calls = %d after 3 executions, want 6", got)
+	}
+	if got := totalCallsByName(&p, "<toplevel>"); got != 3 {
+		t.Errorf("<toplevel>.Calls = %d after 3 executions, want 3", got)
+	}
+}
+
+type addresslessCallable string
+
+func (c addresslessCallable) Name() string          { return string(c) }
+func (c addresslessCallable) String() string        { return string(c) }
+func (c addresslessCallable) Type() string          { return "addresslessCallable" }
+func (c addresslessCallable) Freeze()               {}
+func (c addresslessCallable) Truth() starlark.Bool  { return true }
+func (c addresslessCallable) Hash() (uint32, error) { return 0, nil }
+func (c addresslessCallable) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, nil
+}
+
+func TestProfileAddresslessCallable(t *testing.T) {
+	predeclared := starlark.StringDict{"one": addresslessCallable("one"), "two": addresslessCallable("two")}
+	p := executeProfiledFile(t, "tags.star", "one()\none()\ntwo()\n", predeclared)
+
+	if got := totalCallsByName(p, "one"); got != 2 {
+		t.Errorf("one.Calls = %d, want 2", got)
+	}
+	if got := totalCallsByName(p, "two"); got != 1 {
+		t.Errorf("two.Calls = %d, want 1 (the same address must still use separate rows for each name)", got)
+	}
+	rec, ok := findRecordByNameAndFile(p, "one", "<builtin>")
+	if !ok {
+		t.Fatalf("one has no record positioned in <builtin>:\n%v", p.Records())
+	}
+	if rec.Position.Line != 0 {
+		t.Errorf("one.Position = %v, want line 0 in <builtin>", rec.Position)
+	}
+}
+
+func totalProfileSelf(p *starlark.ExecProfile) time.Duration {
+	var total time.Duration
+	for _, rec := range p.Records() {
+		total += rec.Self
+	}
+	return total
+}
+
+func TestProfileIdentityAcrossCompilations(t *testing.T) {
+	const files = 200
+	var p starlark.ExecProfile
+	for i := range files {
+		src := strings.Repeat("\n", i) + "def f():\n\tpass\n\nf()\n"
+		thread := &starlark.Thread{Profile: &p}
+		if _, err := starlark.ExecFile(thread, "gen.star", src, nil); err != nil {
+			t.Fatal(err)
+		}
+		// Run garbage collection after each execution. This frees its funcode
+		// addresses so the next compilation can reuse them.
+		runtime.GC()
+	}
+
+	var rows int
+	for _, rec := range p.Records() {
+		if rec.Name == "f" {
+			rows++
+		}
+	}
+	if rows != files {
+		t.Errorf("%d rows for f after %d separately compiled files, want %d: "+
+			"distinct functions must not share a row", rows, files, files)
+	}
+	if got := totalCallsByName(&p, "f"); got != files {
+		t.Errorf("total f.Calls = %d, want %d", got, files)
+	}
+}

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -373,8 +373,10 @@ loop:
 			}
 
 			thread.endProfSpan()
+			thread.recordPause()
 			z, err2 := Call(thread, function, positional, kvpairs)
 			thread.beginProfSpan()
+			thread.recordResume()
 			if err2 != nil {
 				err = err2
 				break loop
@@ -571,8 +573,10 @@ loop:
 			}
 
 			thread.endProfSpan()
+			thread.recordPause()
 			dict, err2 := thread.Load(thread, module)
 			thread.beginProfSpan()
+			thread.recordResume()
 			if err2 != nil {
 				err = wrappedError{
 					msg:   fmt.Sprintf("cannot load %s: %v", module, err2),

--- a/starlark/profile.go
+++ b/starlark/profile.go
@@ -82,6 +82,11 @@ import (
 // StartProfile returns an error if profiling was already enabled.
 //
 // StartProfile must not be called concurrently with Starlark execution.
+//
+// See also [Thread.Profile]. It records every call on one thread. It does not
+// sample calls or write an output file. The two profilers can run at the same
+// time. Their results differ when a built-in calls Starlark. This profiler
+// includes the called Starlark function's time in the built-in's own time.
 func StartProfile(w io.Writer) error {
 	if !profiler.on.CompareAndSwap(false, true) {
 		return fmt.Errorf("profiler already running")


### PR DESCRIPTION
## Summary
This adds opt-in execution profiling through `Thread.Profile`.
It records exact call times and returns the results directly to Go code.
It complements the existing `StartProfile` sampling profiler.

```go
var p starlark.ExecProfile
thread.Profile = &p
_, err := starlark.ExecFile(thread, filename, src, nil)
p.WriteText(os.Stderr)
```

The new profiler:

- records short runs that may not produce a `StartProfile` sample;
- reports calls, self time, cumulative time, and maximum call time;
- makes results available as structured records or a text table;
- can merge results from separate threads; and
- avoids counting time twice during Go-to-Starlark re-entry.

Profiling is off by default. It starts when an `ExecProfile` is assigned to Thread.Profile`. No other setup is needed.

## Timing model

Each row groups calls to one function. 
`Self` is time spent in the function itself. It excludes called functions and time waiting for `Load`. 
`Cum` is the full call time, including both. For recursion, `Cum` counts only the outermost call so the same time is not counted more than once.

Only one function adds to `Self` at a time. The profiler pauses the caller while another function or `Load` runs. This prevents double counting, including when a Go callable calls back into Starlark.

## Performance

When profiling was off, the combined benchmark result was 0.26% slower. 
Most benchmarks did not show a clear change. A few call-heavy results were 1.5% to 2.6% slower, but only `bench_bigint` repeated that result in a second run. The likely cause is that each interpreter frame grew from 56 to 72 bytes to hold profile state.

With profiling enabled, an empty call was about 2.4 to 2.6 times slower. 

## Tests

Tests cover timing and call counts, recursion, Go-to-Starlark re-entry, errors, panics, `Load`, profile changes during a run, merging, parallel threads, and use with `StartProfile`. They also check that total self time does not exceed wall time.
