### PR TITLE
add a CallTracer hook for function calls

### DIFF
--- a/starlark/bench_test.go
+++ b/starlark/bench_test.go
@@ -168,3 +168,35 @@ func BenchmarkProgram(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkCallTracer(b *testing.B) {
+	globals, err := starlark.ExecFile(new(starlark.Thread), "call_tracer.star", "def nop(): pass", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		fn   starlark.Callable
+	}{
+		{"builtin", nopBuiltin("nop")},
+		{"function", globals["nop"].(*starlark.Function)},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			for _, tracerCount := range []int{0, 1, 3} {
+				b.Run(fmt.Sprintf("tracers=%d", tracerCount), func(b *testing.B) {
+					thread := new(starlark.Thread)
+					for range tracerCount {
+						thread.AddCallTracer(callTracerFuncs{})
+					}
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						if _, err := starlark.Call(thread, test.fn, nil, nil); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/big"
 	"math/bits"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -49,6 +50,8 @@ type Thread struct {
 	// OnMaxSteps is called when the thread reaches the limit set by SetMaxExecutionSteps.
 	// The default behavior is to call thread.Cancel("too many steps").
 	OnMaxSteps func(thread *Thread)
+
+	callTracers []*callTracerRegistration
 
 	// Steps a count of abstract computation steps executed
 	// by this thread. It is incremented by the interpreter. It may be used
@@ -119,8 +122,32 @@ func (thread *Thread) Local(key string) any {
 	return thread.locals[key]
 }
 
+// A CallTracer observes calls on a Thread.
+type CallTracer interface {
+	// TraceCall runs before fn.
+	TraceCall(thread *Thread, fn Callable, args Tuple, kwargs []Tuple)
+
+	// TraceReturn runs after fn.
+	TraceReturn(thread *Thread, fn Callable, result Value, err error)
+}
+
+type callTracerRegistration struct{ tracer CallTracer }
+
+// AddCallTracer adds tracer to the Thread until the returned function removes it.
+func (thread *Thread) AddCallTracer(tracer CallTracer) (remove func()) {
+	// A running call keeps this slice, so update a copy.
+	registration := &callTracerRegistration{tracer}
+	thread.callTracers = append(slices.Clone(thread.callTracers), registration)
+
+	return func() {
+		if i := slices.Index(thread.callTracers, registration); i >= 0 {
+			thread.callTracers = slices.Delete(slices.Clone(thread.callTracers), i, i+1)
+		}
+	}
+}
+
 // CallFrame returns a copy of the specified frame of the callstack.
-// It should only be used in built-ins called from Starlark code.
+// Use it only in a built-in called from Starlark code or in a CallTracer.
 // Depth 0 means the frame of the built-in itself, 1 is its caller, and so on.
 //
 // It is equivalent to CallStack().At(depth), but more efficient.
@@ -1191,6 +1218,7 @@ func stringRepeat(s String, n Int) (String, error) {
 }
 
 // Call calls the function fn with the specified positional and keyword arguments.
+// Tracers added to thread observe the call. See [Thread.AddCallTracer].
 func Call(thread *Thread, fn Value, args Tuple, kwargs []Tuple) (Value, error) {
 	c, ok := fn.(Callable)
 	if !ok {
@@ -1235,7 +1263,22 @@ func Call(thread *Thread, fn Value, args Tuple, kwargs []Tuple) (Value, error) {
 		thread.stack = thread.stack[:len(thread.stack)-1] // pop
 	}()
 
-	result, err := c.CallInternal(thread, args, kwargs)
+	var result Value
+	var err error
+	if len(thread.callTracers) > 0 {
+		tracersForCall := thread.callTracers
+		for _, registration := range tracersForCall {
+			registration.tracer.TraceCall(thread, c, args, kwargs)
+		}
+		// Keep fn's frame on the call stack until TraceReturn finishes.
+		defer func() {
+			for i := len(tracersForCall) - 1; i >= 0; i-- {
+				tracersForCall[i].tracer.TraceReturn(thread, c, result, err)
+			}
+		}()
+	}
+
+	result, err = c.CallInternal(thread, args, kwargs)
 
 	// Sanity check: nil is not a valid Starlark value.
 	if result == nil && err == nil {

--- a/starlark/tracer_test.go
+++ b/starlark/tracer_test.go
@@ -1,0 +1,249 @@
+package starlark_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+type callTracerFuncs struct {
+	onCall   func(thread *starlark.Thread, fn starlark.Callable, args starlark.Tuple, kwargs []starlark.Tuple)
+	onReturn func(thread *starlark.Thread, fn starlark.Callable, result starlark.Value, err error)
+}
+
+func (t callTracerFuncs) TraceCall(thread *starlark.Thread, fn starlark.Callable, args starlark.Tuple, kwargs []starlark.Tuple) {
+	if t.onCall != nil {
+		t.onCall(thread, fn, args, kwargs)
+	}
+}
+
+func (t callTracerFuncs) TraceReturn(thread *starlark.Thread, fn starlark.Callable, result starlark.Value, err error) {
+	if t.onReturn != nil {
+		t.onReturn(thread, fn, result, err)
+	}
+}
+
+func loggingTracer(events *[]string, name string) callTracerFuncs {
+	return callTracerFuncs{
+		onCall: func(thread *starlark.Thread, fn starlark.Callable, args starlark.Tuple, kwargs []starlark.Tuple) {
+			*events = append(*events, name+" call "+fn.Name())
+		},
+		onReturn: func(thread *starlark.Thread, fn starlark.Callable, result starlark.Value, err error) {
+			*events = append(*events, name+" return "+fn.Name())
+		},
+	}
+}
+
+func nopBuiltin(name string) *starlark.Builtin {
+	return starlark.NewBuiltin(name, func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		return starlark.None, nil
+	})
+}
+
+func TestCallTracer(t *testing.T) {
+	const src = `
+def add(x, y = 0): return x + y
+def run():
+    add(1, y = 2)
+    return add(3)
+value = run()
+length = len("abc")
+`
+	var events []string
+	var addFunction starlark.Callable
+	var firstCallArgs, copiedFirstCallArgs starlark.Tuple
+	var firstCallArgsSeenLater string
+	var errorSeenByTracer error
+	thread := new(starlark.Thread)
+	thread.AddCallTracer(callTracerFuncs{
+		onCall: func(thread *starlark.Thread, fn starlark.Callable, args starlark.Tuple, kwargs []starlark.Tuple) {
+			if got := thread.CallFrame(0).Name; got != fn.Name() {
+				t.Errorf("TraceCall frame = %q, want %q", got, fn.Name())
+			}
+			events = append(events, fmt.Sprintf("call %s args=%v kwargs=%v", fn.Name(), args, kwargs))
+			if fn.Name() == "add" {
+				if addFunction == nil {
+					addFunction = fn
+					firstCallArgs = args
+					copiedFirstCallArgs = slices.Clone(args)
+				} else {
+					firstCallArgsSeenLater = fmt.Sprint(firstCallArgs)
+				}
+			}
+		},
+		onReturn: func(thread *starlark.Thread, fn starlark.Callable, result starlark.Value, err error) {
+			if got := thread.CallFrame(0).Name; got != fn.Name() {
+				t.Errorf("TraceReturn frame = %q, want %q", got, fn.Name())
+			}
+			if err != nil {
+				events = append(events, "return "+fn.Name()+" error")
+				errorSeenByTracer = err
+			} else {
+				events = append(events, fmt.Sprintf("return %s = %v", fn.Name(), result))
+			}
+		},
+	})
+	globals, err := starlark.ExecFile(thread, "trace.star", src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addFunction != globals["add"] {
+		t.Errorf("TraceCall function = %v, want %v", addFunction, globals["add"])
+	}
+	if got := fmt.Sprint(globals["value"]); got != "3" {
+		t.Errorf("value = %s, want 3", got)
+	}
+	if got := fmt.Sprint(globals["length"]); got != "3" {
+		t.Errorf("length = %s, want 3", got)
+	}
+	if firstCallArgsSeenLater != "(3,)" {
+		t.Errorf("first call args during second call = %s, want (3,)", firstCallArgsSeenLater)
+	}
+	if got := fmt.Sprint(copiedFirstCallArgs); got != "(1,)" {
+		t.Errorf("copied first call args = %s, want (1,)", got)
+	}
+
+	fail := starlark.NewBuiltin("fail", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		return nil, errors.New("failed")
+	})
+	_, callError := starlark.Call(thread, fail, nil, nil)
+	if callError == nil {
+		t.Fatal("Call returned no error")
+	}
+	if errorSeenByTracer != callError {
+		t.Errorf("TraceReturn error = %v, want caller error %v", errorSeenByTracer, callError)
+	}
+	if _, ok := callError.(*starlark.EvalError); !ok {
+		t.Errorf("Call error has type %T, want *starlark.EvalError", callError)
+	}
+
+	want := []string{
+		"call <toplevel> args=() kwargs=[]",
+		"call run args=() kwargs=[]",
+		`call add args=(1,) kwargs=[("y", 2)]`,
+		"return add = 3",
+		"call add args=(3,) kwargs=[]",
+		"return add = 3",
+		"return run = 3",
+		`call len args=("abc",) kwargs=[]`,
+		"return len = 3",
+		"return <toplevel> = None",
+		"call fail args=() kwargs=[]",
+		"return fail error",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Errorf("events = %q, want %q", events, want)
+	}
+}
+
+func TestCallTracerAddAndRemove(t *testing.T) {
+	var events []string
+	nop := starlark.NewBuiltin("nop", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		events = append(events, "nop")
+		return starlark.None, nil
+	})
+
+	thread := new(starlark.Thread)
+	checkCallEvents := func(want []string) {
+		t.Helper()
+		events = nil
+		if _, err := starlark.Call(thread, nop, nil, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("events = %q, want %q", events, want)
+		}
+	}
+
+	a := loggingTracer(&events, "A")
+	b := loggingTracer(&events, "B")
+	removeA := thread.AddCallTracer(a)
+	removeB1 := thread.AddCallTracer(b)
+	removeB2 := thread.AddCallTracer(b)
+	checkCallEvents([]string{
+		"A call nop", "B call nop", "B call nop", "nop",
+		"B return nop", "B return nop", "A return nop",
+	})
+
+	removeB1()
+	removeB1()
+	checkCallEvents([]string{"A call nop", "B call nop", "nop", "B return nop", "A return nop"})
+
+	removeA()
+	removeB2()
+	checkCallEvents([]string{"nop"})
+}
+
+func TestCallTracerChangesDuringCall(t *testing.T) {
+	var events []string
+	thread := new(starlark.Thread)
+	added := loggingTracer(&events, "added")
+	var removeInitial func()
+	initial := loggingTracer(&events, "initial")
+	recordCall := initial.onCall
+	initial.onCall = func(thread *starlark.Thread, fn starlark.Callable, args starlark.Tuple, kwargs []starlark.Tuple) {
+		recordCall(thread, fn, args, kwargs)
+		if fn.Name() == "f" {
+			thread.AddCallTracer(added)
+			removeInitial()
+		}
+	}
+	removeInitial = thread.AddCallTracer(initial)
+
+	if _, err := starlark.ExecFile(thread, "tracer_changes.star", `
+def g(): return 1
+def f(): return g()
+f()
+`, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"initial call <toplevel>",
+		"initial call f",
+		"added call g",
+		"added return g",
+		"initial return f",
+		"initial return <toplevel>",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Errorf("events = %q, want %q", events, want)
+	}
+}
+
+func TestCallTracerPanic(t *testing.T) {
+	mustPanic := func(want string, f func()) {
+		defer func() {
+			if got := fmt.Sprint(recover()); got != want {
+				t.Errorf("recover() = %v, want %v", got, want)
+			}
+		}()
+		f()
+		t.Error("function returned without a panic")
+	}
+
+	var traceReturnRan bool
+	thread := new(starlark.Thread)
+	thread.AddCallTracer(callTracerFuncs{onReturn: func(thread *starlark.Thread, fn starlark.Callable, result starlark.Value, err error) {
+		traceReturnRan = true
+		if result != nil || err != nil {
+			t.Errorf("TraceReturn(%s) = (%v, %v), want (<nil>, <nil>)", fn.Name(), result, err)
+		}
+	}})
+	panicBuiltin := starlark.NewBuiltin("panic", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		panic(args[0])
+	})
+	mustPanic("1", func() {
+		starlark.Call(thread, panicBuiltin, starlark.Tuple{starlark.MakeInt(1)}, nil)
+	})
+	if !traceReturnRan {
+		t.Error("TraceReturn did not run")
+	}
+	if got := thread.CallStackDepth(); got != 0 {
+		t.Errorf("CallStackDepth = %d after panic, want 0", got)
+	}
+}


### PR DESCRIPTION
Adds call tracing to Starlark threads through the new `CallTracer` interface and `Thread.AddCallTracer`.

Includes tests for call order, errors, panics, tracer removal, and changes during calls, plus benchmarks for tracing overhead.